### PR TITLE
Store and display river flow direction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,8 +28,8 @@ endif()
 
 # Version
 set(CPACK_PACKAGE_VERSION_MAJOR "2")
-set(CPACK_PACKAGE_VERSION_MINOR "3")
-set(CPACK_PACKAGE_VERSION_PATCH "7")
+set(CPACK_PACKAGE_VERSION_MINOR "4")
+set(CPACK_PACKAGE_VERSION_PATCH "0")
 set(VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}")
 add_definitions(-DMMAPPER_VERSION="${VERSION}" -DWITH_SPLASH)
 message(STATUS "MMapper version ${VERSION} (${CMAKE_BUILD_TYPE} distribution)")
@@ -63,7 +63,7 @@ if (UNIX AND NOT APPLE)
         CACHE PATH "Base directory for files which go to share/"
     )
 
-    SET(CMAKE_CXX_FLAGS_DEBUG 
+    SET(CMAKE_CXX_FLAGS_DEBUG
       "-g -Wall -g3 -ggdb -gdwarf-2 -Wunused-variable -Wno-long-long -Wno-unknown-pragmas -Wno-system-headers"
       CACHE STRING "Debug builds CMAKE CXX flags " FORCE )
 endif (UNIX AND NOT APPLE)

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,5 +1,4 @@
 ================================
-<<<<<<< HEAD
 MMapper 2.4.0 (Not released)
 ================================
 
@@ -52,7 +51,7 @@ MMapper 2.3.2 (January 17, 2015)
 
 Changes:
  - Fixed critical bug that disallowed Mac and Linux users to connect to MMapper (nschimme)
- 
+
 ================================
 MMapper 2.3.1 (January 17, 2015)
 ================================

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,4 +1,5 @@
 ================================
+<<<<<<< HEAD
 MMapper 2.4.0 (Not released)
 ================================
 
@@ -6,7 +7,6 @@ Note:
   - The .mm2 file format changed. Old files can be read, but files saved
     with this version can't be used with MMapper 2.3.x or older.
 Changes:
-  - Added extra door flags (teoli)
   - Added support for classes of info marks, with different colors and font decorations (teoli)
   - Added ability to rotate info marks (teoli)
   - Fixed wall color when a special exit was present (was white instead of black) (teoli)
@@ -18,26 +18,26 @@ MMapper 2.3.6 (December 9, 2015)
 Changes:
   - High DPI displays are now supported such as Retina displays (nschimme)
 
-=============================
-MMapper 2.3.5 July 29, 2015)
-=============================
+=================================
+MMapper 2.3.5 (July 29, 2015)
+=================================
 
 Changes:
   - Fixed bug that prevented connections from having TCP KeepAlive (nschimme)
   - Updated base map to include new zones; thanks Ortansia! (nschimme)
 
-=============================
+================================
 MMapper 2.3.4 (May 1, 2015)
-=============================
+================================
 
 Changes:
   - All connections now utilize TCP KeepAlive to help with dropped connections (nschimme)
   - Prompts are now correctly identified and remembered for internal commands (nschimme)
   - Cleaned up vote and Windows build code (nschimme)
 
-=============================
+================================
 MMapper 2.3.3 (January 18, 2015)
-=============================
+================================
 
 Changes:
   - [GroupManager] Player's hp, mana, and moves are now correctly updated (nschimme)
@@ -46,25 +46,25 @@ Changes:
   - Prompts should not be displayed after an internal command like _help is run (nschimme)
   - Added new _vote command and menu action to vote for MUME on TMC (nschimme)
 
-=============================
+================================
 MMapper 2.3.2 (January 17, 2015)
-=============================
+================================
 
 Changes:
  - Fixed critical bug that disallowed Mac and Linux users to connect to MMapper (nschimme)
-
-=============================
+ 
+================================
 MMapper 2.3.1 (January 17, 2015)
-=============================
+================================
 
 Changes:
  - Telnet characters now parsed correctly (nschimme)
  - Info marks load correctly (nschimme)
  - Updated base map with the new zones (nschimme)
 
-=============================
+================================
 MMapper 2.3.0 (January 17, 2015)
-=============================
+================================
 
 Changes:
  - Build now requires Qt5.2 and CMake 2.8.11 (nschimme)
@@ -74,18 +74,18 @@ Changes:
  - Prompt detection fixes (kalev)
  - New note search feature (Arfang)
 
-=============================
+================================
 MMapper 2.2.1 (July 14, 2013)
-=============================
+================================
 
 Changes:
  - Build fixes
  - Fix issues with XML mode in the account menu
  - Make _name and _noride commands work (thanks Waba!)
 
-=============================
+================================
 MMapper 2.2.0 (July 13, 2013)
-=============================
+================================
 
 Changes:
  - Compatibility fixes with latest MUME server

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -9,6 +9,7 @@ Changes:
   - Added support for classes of info marks, with different colors and font decorations (teoli)
   - Added ability to rotate info marks (teoli)
   - Fixed wall color when a special exit was present (was white instead of black) (teoli)
+  - Added ability to store direction of river flows and display it on the map (telling)
 
 ================================
 MMapper 2.3.6 (December 9, 2015)

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -9,7 +9,7 @@ Changes:
   - Added support for classes of info marks, with different colors and font decorations (teoli)
   - Added ability to rotate info marks (teoli)
   - Fixed wall color when a special exit was present (was white instead of black) (teoli)
-  - Added ability to store direction of river flows and display it on the map (telling)
+  - Added ability to store direction of river flows and display it on the map (teoli)
 
 ================================
 MMapper 2.3.6 (December 9, 2015)

--- a/src/display/mapcanvas.cpp
+++ b/src/display/mapcanvas.cpp
@@ -1653,6 +1653,58 @@ void MapCanvas::drawRoomDoorName(const Room *sourceRoom, uint sourceDir, const R
     glPopMatrix();
 }
 
+void MapCanvas::drawFlow(const Room* room, const std::vector<Room *> & rooms, ExitDirection exitDirection)
+{
+  // Start drawing
+  glPushMatrix();
+
+  // Prepare pen
+  qglColor(QColor(76,216,255));
+  glEnable(GL_BLEND);
+  glPointSize (devicePixelRatio() * 4.0);
+  glLineWidth (devicePixelRatio() * 1.0);
+
+  // Draw part in this room
+  if (room->getPosition().z == m_currentLayer)
+  {
+    glCallList(m_flow_begin_gllist[exitDirection]);
+  }
+
+  // Draw part in adjacent room
+  uint targetDir = opposite(exitDirection);
+  uint targetId;
+  const Room *targetRoom;
+  const ExitsList & exitslist = room->getExitsList();
+  int rx;
+  int ry;
+  const Exit & sourceExit = exitslist[exitDirection];
+
+  //For each outgoing connections
+  std::set<uint>::const_iterator itOut = sourceExit.outBegin();
+  while (itOut != sourceExit.outEnd()) {
+      targetId = *itOut;
+      targetRoom = rooms[targetId];
+      rx = targetRoom->getPosition().x;
+      ry = targetRoom->getPosition().y;
+      if (targetRoom->getPosition().z == m_currentLayer)
+      {
+        glLoadIdentity();
+        glTranslated(rx, ry, 0.0);
+        glCallList(m_flow_end_gllist[targetDir]);
+      }
+      ++itOut;
+  }
+
+  // Finish pen
+  glLineWidth (devicePixelRatio() * 2.0);
+  glPointSize (devicePixelRatio() * 2.0);
+  glDisable(GL_BLEND);
+
+  // Termite drawing
+  qglColor(Qt::black);
+  glPopMatrix();
+}
+
 void MapCanvas::drawRoom(const Room *room, const std::vector<Room *> & rooms, const std::vector<std::set<RoomRecipient *> > & locks)
 {
     if (!room) return;
@@ -1906,6 +1958,10 @@ void MapCanvas::drawRoom(const Room *room, const std::vector<Room *> & rooms, co
             qglColor(Qt::black);
             glDisable(GL_LINE_STIPPLE);
         }
+        if ( ISSET(getFlags(room->exit(ED_NORTH)), EF_FLOW))
+        {
+            drawFlow(room, rooms, ED_NORTH);
+        }
     }
     //wall n
     if (ISNOTSET(ef_north, EF_EXIT) || ISSET(ef_north, EF_DOOR))
@@ -1960,6 +2016,10 @@ void MapCanvas::drawRoom(const Room *room, const std::vector<Room *> & rooms, co
             glCallList(m_wall_south_gllist);
             qglColor(Qt::black);
             glDisable(GL_LINE_STIPPLE);
+        }
+        if ( ISSET(getFlags(room->exit(ED_SOUTH)), EF_FLOW))
+        {
+            drawFlow(room, rooms, ED_SOUTH);
         }
     }
     //wall s
@@ -2017,6 +2077,10 @@ void MapCanvas::drawRoom(const Room *room, const std::vector<Room *> & rooms, co
             qglColor(Qt::black);
             glDisable(GL_LINE_STIPPLE);
         }
+        if ( ISSET(getFlags(room->exit(ED_EAST)), EF_FLOW))
+        {
+            drawFlow(room, rooms, ED_EAST);
+        }
     }
     //wall e
     if (ISNOTSET(ef_east, EF_EXIT) || ISSET(ef_east, EF_DOOR))
@@ -2073,6 +2137,10 @@ void MapCanvas::drawRoom(const Room *room, const std::vector<Room *> & rooms, co
             qglColor(Qt::black);
             glDisable(GL_LINE_STIPPLE);
         }
+        if ( ISSET(getFlags(room->exit(ED_WEST)), EF_FLOW))
+        {
+            drawFlow(room, rooms, ED_WEST);
+        }
     }
     //wall w
     if (ISNOTSET(ef_west, EF_EXIT) || ISSET(ef_west, EF_DOOR))
@@ -2126,6 +2194,11 @@ void MapCanvas::drawRoom(const Room *room, const std::vector<Room *> & rooms, co
 
             if (ISSET(ef_up, EF_DOOR))
                 glCallList(m_door_up_gllist);
+
+            if ( ISSET(getFlags(room->exit(ED_UP)), EF_FLOW))
+            {
+                drawFlow(room, rooms, ED_UP);
+            }
         }
     }
 
@@ -2159,6 +2232,11 @@ void MapCanvas::drawRoom(const Room *room, const std::vector<Room *> & rooms, co
 
             if (ISSET(ef_down, EF_DOOR))
                 glCallList(m_door_down_gllist);
+
+            if ( ISSET(getFlags(room->exit(ED_DOWN)), EF_FLOW))
+            {
+                drawFlow(room, rooms, ED_DOWN);
+            }
         }
     }
 
@@ -2864,6 +2942,132 @@ void MapCanvas::makeGlLists()
     glVertex3d(-0.2, 1.2, 0.0);
     glVertex3d(1.2, 1.2, 0.0);
     glVertex3d(1.2, -0.2, 0.0);
+    glEnd();
+    glEndList();
+
+    m_flow_begin_gllist[ED_NORTH] = glGenLists(1);
+    glNewList(m_flow_begin_gllist[ED_NORTH], GL_COMPILE);
+    glBegin(GL_LINE_STRIP);
+    glVertex3d(0.5, 0.5, 0.1);
+    glVertex3d(0.5, 0.0, 0.1);
+    glEnd();
+    glBegin(GL_TRIANGLES);
+    glVertex3d(0.44, +0.20, 0.1);
+    glVertex3d(0.50, +0.00, 0.1);
+    glVertex3d(0.56, +0.20, 0.1);
+    glEnd();
+    glEndList();
+
+    m_flow_begin_gllist[ED_SOUTH] = glGenLists(1);
+    glNewList(m_flow_begin_gllist[ED_SOUTH], GL_COMPILE);
+    glBegin(GL_LINE_STRIP);
+    glVertex3d(0.5, 0.5, 0.1);
+    glVertex3d(0.5, 1.0, 0.1);
+    glEnd();
+    glBegin(GL_TRIANGLES);
+    glVertex3d(0.44, +0.80, 0.1);
+    glVertex3d(0.50, +1.00, 0.1);
+    glVertex3d(0.56, +0.80, 0.1);
+    glEnd();
+    glEndList();
+
+    m_flow_begin_gllist[ED_EAST] = glGenLists(1);
+    glNewList(m_flow_begin_gllist[ED_EAST], GL_COMPILE);
+    glBegin(GL_LINE_STRIP);
+    glVertex3d(0.5, 0.5, 0.1);
+    glVertex3d(1.0, 0.5, 0.1);
+    glEnd();
+    glBegin(GL_TRIANGLES);
+    glVertex3d(0.80, +0.44, 0.1);
+    glVertex3d(1.00, +0.50, 0.1);
+    glVertex3d(0.80, +0.56, 0.1);
+    glEnd();
+    glEndList();
+
+    m_flow_begin_gllist[ED_WEST] = glGenLists(1);
+    glNewList(m_flow_begin_gllist[ED_WEST], GL_COMPILE);
+    glBegin(GL_LINE_STRIP);
+    glVertex3d(0.5, 0.5, 0.1);
+    glVertex3d(0.0, 0.5, 0.1);
+    glEnd();
+    glBegin(GL_TRIANGLES);
+    glVertex3d(0.20, +0.44, 0.1);
+    glVertex3d(0.00, +0.50, 0.1);
+    glVertex3d(0.20, +0.56, 0.1);
+    glEnd();
+    glEndList();
+
+    m_flow_begin_gllist[ED_UP] = glGenLists(1);
+    glNewList(m_flow_begin_gllist[ED_UP], GL_COMPILE);
+    glBegin(GL_LINE_STRIP);
+    glVertex3d(0.5, 0.5, 0.1);
+    glVertex3d(0.75, 0.25, 0.1);
+    glEnd();
+    glBegin(GL_TRIANGLES);
+    glVertex3d(0.51, 0.42, 0.1);
+    glVertex3d(0.64, 0.37, 0.1);
+    glVertex3d(0.60, 0.48, 0.1);
+    glEnd();
+    glEndList();
+
+    m_flow_begin_gllist[ED_DOWN] = glGenLists(1);
+    glNewList(m_flow_begin_gllist[ED_DOWN], GL_COMPILE);
+    glBegin(GL_LINE_STRIP);
+    glVertex3d(0.5, 0.5, 0.1);
+    glVertex3d(0.25, 0.75, 0.1);
+    glEnd();
+    glBegin(GL_TRIANGLES);
+    glVertex3d(0.36, 0.57, 0.1);
+    glVertex3d(0.33, 0.67, 0.1);
+    glVertex3d(0.44, 0.63, 0.1);
+    glEnd();
+    glEndList();
+
+    m_flow_end_gllist[ED_SOUTH] = glGenLists(1);
+    glNewList(m_flow_end_gllist[ED_SOUTH], GL_COMPILE);
+    glBegin(GL_LINE_STRIP);
+    glVertex3d(0.0, 0.0, 0.1);
+    glVertex3d(0.0,  0.5, 0.1);
+    glEnd();
+    glEndList();
+
+    m_flow_end_gllist[ED_NORTH] = glGenLists(1);
+    glNewList(m_flow_end_gllist[ED_NORTH], GL_COMPILE);
+    glBegin(GL_LINE_STRIP);
+    glVertex3d(0.0, -0.5, 0.1);
+    glVertex3d(0.0, 0.0, 0.1);
+    glEnd();
+    glEndList();
+
+    m_flow_end_gllist[ED_WEST] = glGenLists(1);
+    glNewList(m_flow_end_gllist[ED_WEST], GL_COMPILE);
+    glBegin(GL_LINE_STRIP);
+    glVertex3d(-0.5, 0.0, 0.1);
+    glVertex3d( 0.0, 0.0, 0.1);
+    glEnd();
+    glEndList();
+
+    m_flow_end_gllist[ED_EAST] = glGenLists(1);
+    glNewList(m_flow_end_gllist[ED_EAST], GL_COMPILE);
+    glBegin(GL_LINE_STRIP);
+    glVertex3d(0.5, 0.0, 0.1);
+    glVertex3d(0.0, 0.0, 0.1);
+    glEnd();
+    glEndList();
+
+    m_flow_end_gllist[ED_DOWN] = glGenLists(1);
+    glNewList(m_flow_end_gllist[ED_DOWN], GL_COMPILE);
+    glBegin(GL_LINE_STRIP);
+    glVertex3d(-0.25, 0.25, 0.1);
+    glVertex3d(0.0, 0.0, 0.1);
+    glEnd();
+    glEndList();
+
+    m_flow_end_gllist[ED_UP] = glGenLists(1);
+    glNewList(m_flow_end_gllist[ED_UP], GL_COMPILE);
+    glBegin(GL_LINE_STRIP);
+    glVertex3d(0.25, -0.25, 0.1);
+    glVertex3d(0.0, 0.0, 0.1);
     glEnd();
     glEndList();
 

--- a/src/display/mapcanvas.cpp
+++ b/src/display/mapcanvas.cpp
@@ -1530,6 +1530,50 @@ void MapCanvas::drawRoomDoorName(const Room *sourceRoom, uint sourceDir, const R
     qint32 dX = srcX - tarX;
     qint32 dY = srcY - tarY;
 
+    // Look at door flags to code postfixes
+    DoorFlags sourceDoorFlags = getDoorFlags(sourceRoom->exit(sourceDir));
+    QString sourcePostFix;
+    if (ISSET(sourceDoorFlags, DF_HIDDEN))
+    {
+      sourcePostFix = "h";
+    }
+    if (ISSET(sourceDoorFlags, DF_NEEDKEY))
+    {
+      sourcePostFix += "L";
+    }
+    if (ISSET(sourceDoorFlags, DF_NOPICK))
+    {
+      sourcePostFix += "/NP";
+    }
+    if (ISSET(sourceDoorFlags, DF_DELAYED))
+    {
+      sourcePostFix += "d";
+    }
+    if (sourcePostFix.length() > 0) {
+      sourcePostFix = " [" + sourcePostFix + "]";
+    }
+    DoorFlags targetDoorFlags = getDoorFlags(targetRoom->exit(targetDir));
+    QString targetPostFix;
+    if (ISSET(targetDoorFlags, DF_HIDDEN))
+    {
+      targetPostFix = "h";
+    }
+    if (ISSET(targetDoorFlags, DF_NEEDKEY))
+    {
+      targetPostFix += "L";
+    }
+    if (ISSET(targetDoorFlags, DF_NOPICK))
+    {
+      targetPostFix += "/NP";
+    }
+    if (ISSET(targetDoorFlags, DF_DELAYED))
+    {
+      targetPostFix += "d";
+    }
+    if (targetPostFix.length() > 0) {
+      targetPostFix = " [" + targetPostFix + "]";
+    }
+
     QString name;
     bool together = false;
 
@@ -1544,8 +1588,8 @@ void MapCanvas::drawRoomDoorName(const Room *sourceRoom, uint sourceDir, const R
         together = true;
 
         // no need for duplicating names (its spammy)
-        const QString &sourceName = getDoorName(sourceRoom->exit(sourceDir));
-        const QString &targetName = getDoorName(targetRoom->exit(targetDir));
+        const QString &sourceName = getDoorName(sourceRoom->exit(sourceDir)) + sourcePostFix;
+        const QString &targetName = getDoorName(targetRoom->exit(targetDir)) + targetPostFix;
         if (sourceName != targetName)
             name =  sourceName + "/" + targetName;
         else
@@ -1633,10 +1677,10 @@ void MapCanvas::drawRoom(const Room *room, const std::vector<Room *> & rooms, co
     if (layer > 0)
     {
         if (Config().m_drawUpperLayersTextured)
-            glEnable (GL_POLYGON_STIPPLE);
+            glEnable(GL_POLYGON_STIPPLE);
         else
         {
-            glDisable (GL_POLYGON_STIPPLE);
+            glDisable(GL_POLYGON_STIPPLE);
             glColor4d(0.3, 0.3, 0.3, 0.6-0.2*layer);
             glEnable(GL_BLEND);
         }

--- a/src/display/mapcanvas.h
+++ b/src/display/mapcanvas.h
@@ -137,6 +137,7 @@ class MapCanvas : public QOpenGLWidget, protected QOpenGLFunctions
     void drawPathStart(const Coordinate&);
     bool drawPath(const Coordinate& sc, const Coordinate& dc, double &dx, double &dy, double &dz);
     void drawPathEnd(double dx, double dy, double dz);
+    void drawFlow( const Room *room, const std::vector<Room *> & rooms, ExitDirection exitDirection);
 
     // QGLWidget backwards compatability
     void qglColor(QColor color);
@@ -219,6 +220,9 @@ class MapCanvas : public QOpenGLWidget, protected QOpenGLFunctions
     GLuint m_room_gllist;
     GLuint m_room_selection_gllist;
     GLuint m_room_selection_inner_gllist;
+
+    GLuint m_flow_begin_gllist[6];
+    GLuint m_flow_end_gllist[6];
 
     QFont *m_glFont;
     QFontMetrics *m_glFontMetrics;

--- a/src/mainwindow/infomarkseditdlg.h
+++ b/src/mainwindow/infomarkseditdlg.h
@@ -38,32 +38,32 @@ class InfoMarksEditDlg : public QDialog, private Ui::InfoMarksEditDlg
     Q_OBJECT
 
 signals:
-	void mapChanged();
-	void closeEventReceived();
+    void mapChanged();
+    void closeEventReceived();
 
 public slots:
-	void objectListCurrentIndexChanged(const QString&);
-	void objectTypeCurrentIndexChanged(const QString&);
-  void objectClassCurrentIndexChanged(const QString&);
+    void objectListCurrentIndexChanged(const QString&);
+    void objectTypeCurrentIndexChanged(const QString&);
+    void objectClassCurrentIndexChanged(const QString&);
 
-	void objectNameTextChanged(QString);
-	void objectTextChanged(QString);
-	void x1ValueChanged(double);
-	void y1ValueChanged(double);
-	void x2ValueChanged(double);
-	void y2ValueChanged(double);
-  void rotValueChanged(double);
-	void layerValueChanged(int);
-	void createClicked();
-	void modifyClicked();
-	void deleteClicked();
-	void onMoveNorthClicked();
-	void onMoveSouthClicked();
-	void onMoveEastClicked();
-	void onMoveWestClicked();
-	void onMoveUpClicked();
-	void onMoveDownClicked();
-	void onDeleteAllClicked();
+    void objectNameTextChanged(QString);
+    void objectTextChanged(QString);
+    void x1ValueChanged(double);
+    void y1ValueChanged(double);
+    void x2ValueChanged(double);
+    void y2ValueChanged(double);
+    void rotValueChanged(double);
+    void layerValueChanged(int);
+    void createClicked();
+    void modifyClicked();
+    void deleteClicked();
+    void onMoveNorthClicked();
+    void onMoveSouthClicked();
+    void onMoveEastClicked();
+    void onMoveWestClicked();
+    void onMoveUpClicked();
+    void onMoveDownClicked();
+    void onDeleteAllClicked();
 
 
 public:
@@ -73,30 +73,30 @@ public:
     void setPoints(double x1, double y1, double x2, double y2, int layer);
 
     void readSettings();
-	void writeSettings();
+    void writeSettings();
 
 protected:
-	void closeEvent(QCloseEvent*);
+    void closeEvent(QCloseEvent*);
 
 
 private:
 
-	MapData* m_mapData;
+    MapData* m_mapData;
 
-	double m_selX1, m_selY1, m_selX2, m_selY2;
-	int m_selLayer;
+    double m_selX1, m_selY1, m_selX2, m_selY2;
+    int m_selLayer;
 
-	void connectAll();
-	void disconnectAll();
+    void connectAll();
+    void disconnectAll();
 
-	InfoMarkType getType();
-  InfoMarkClass getClass();
-	InfoMark* getInfoMark(QString name);
-	InfoMark* getCurrentInfoMark();
-	void setCurrentInfoMark(InfoMark* m);
+    InfoMarkType getType();
+    InfoMarkClass getClass();
+    InfoMark* getInfoMark(QString name);
+    InfoMark* getCurrentInfoMark();
+    void setCurrentInfoMark(InfoMark* m);
 
-	void updateMarkers();
-	void updateDialog();
+    void updateMarkers();
+    void updateDialog();
 };
 
 

--- a/src/mainwindow/roomeditattrdlg.cpp
+++ b/src/mainwindow/roomeditattrdlg.cpp
@@ -100,10 +100,11 @@ RoomEditAttrDlg::RoomEditAttrDlg(QWidget *parent)
 	exitListItems[4] = (QListWidgetItem*) new QListWidgetItem("Random");
 	exitListItems[5] = (QListWidgetItem*) new QListWidgetItem("Special");
 	exitListItems[6] = (QListWidgetItem*) new QListWidgetItem("No match");
-	exitListItems[7] = NULL;
+	exitListItems[7] = (QListWidgetItem*) new QListWidgetItem("Flow dir"); // Added in schema 040
+  exitListItems[8] = NULL; // Don't add an item here: file schema doesn't support value > 7
 
 	exitFlagsListWidget->clear();
-	for (int i=0; i<7; i++)
+	for (int i=0; i<8; i++)
 	{
 		exitListItems[i]->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled);
 		exitFlagsListWidget->addItem(exitListItems[i]);
@@ -491,6 +492,11 @@ void RoomEditAttrDlg::updateDialog(const Room *r)
 			exitListItems[6]->setCheckState(Qt::Checked);
 		else
 			exitListItems[6]->setCheckState(Qt::Unchecked);
+
+    if (ISSET(ef, EF_FLOW))
+			exitListItems[7]->setCheckState(Qt::Checked);
+		else
+			exitListItems[7]->setCheckState(Qt::Unchecked);
 
 		roomNoteTextEdit->clear();
 		roomNoteTextEdit->setEnabled(false);

--- a/src/mainwindow/roomeditattrdlg.cpp
+++ b/src/mainwindow/roomeditattrdlg.cpp
@@ -4,7 +4,7 @@
 **            Marek Krejza <krejza@gmail.com> (Caligor),
 **            Nils Schimmelmann <nschimme@gmail.com> (Jahara)
 **
-** This file is part of the MMapper project. 
+** This file is part of the MMapper project.
 ** Maintained by Nils Schimmelmann <nschimme@gmail.com>
 **
 ** This program is free software; you can redistribute it and/or
@@ -43,7 +43,7 @@ RoomEditAttrDlg::RoomEditAttrDlg(QWidget *parent)
 {
     setupUi(this);
 	roomDescriptionTextEdit->setLineWrapMode(QTextEdit::NoWrap);
-		
+
 	mobListItems[0] = (QListWidgetItem*) new QListWidgetItem("Rent place");
 	mobListItems[1] = (QListWidgetItem*) new QListWidgetItem("Generic shop");
 	mobListItems[2] = (QListWidgetItem*) new QListWidgetItem("Weapon shop");
@@ -58,12 +58,12 @@ RoomEditAttrDlg::RoomEditAttrDlg(QWidget *parent)
 	mobListItems[11] = (QListWidgetItem*) new QListWidgetItem("Ranger guild");
 	mobListItems[12] = (QListWidgetItem*) new QListWidgetItem("SMOB");
 	mobListItems[13] = (QListWidgetItem*) new QListWidgetItem("Quest mob");
-	mobListItems[14] = (QListWidgetItem*) new QListWidgetItem("Any mob"); 
+	mobListItems[14] = (QListWidgetItem*) new QListWidgetItem("Any mob");
 	mobListItems[15] = NULL;
 
 	mobFlagsListWidget->clear();
 	for (int i=0; i<15; i++)
-	{	
+	{
 		mobListItems[i]->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled | Qt::ItemIsTristate);
 		mobFlagsListWidget->addItem(mobListItems[i]);
 	}
@@ -80,12 +80,12 @@ RoomEditAttrDlg::RoomEditAttrDlg(QWidget *parent)
 	loadListItems[9] = (QListWidgetItem*) new QListWidgetItem("Pack horse");
 	loadListItems[10] = (QListWidgetItem*) new QListWidgetItem("Trained horse");
 	loadListItems[11] = (QListWidgetItem*) new QListWidgetItem("Rohirrim");
-	loadListItems[12] = (QListWidgetItem*) new QListWidgetItem("Warg"); 
-	loadListItems[13] = (QListWidgetItem*) new QListWidgetItem("Boat"); 
+	loadListItems[12] = (QListWidgetItem*) new QListWidgetItem("Warg");
+	loadListItems[13] = (QListWidgetItem*) new QListWidgetItem("Boat");
 	loadListItems[14] = (QListWidgetItem*) new QListWidgetItem("Attention");
-	loadListItems[15] = (QListWidgetItem*) new QListWidgetItem("Tower"); 
+	loadListItems[15] = (QListWidgetItem*) new QListWidgetItem("Tower");
 	loadListItems[16] = NULL;
-		
+
 	loadFlagsListWidget->clear();
 	for (int i=0; i<16; i++)
 	{
@@ -104,21 +104,30 @@ RoomEditAttrDlg::RoomEditAttrDlg(QWidget *parent)
 
 	exitFlagsListWidget->clear();
 	for (int i=0; i<7; i++)
-	{	
+	{
 		exitListItems[i]->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled);
 		exitFlagsListWidget->addItem(exitListItems[i]);
 	}
-	
+
 	doorListItems[0] = (QListWidgetItem*) new QListWidgetItem("Hidden");
 	doorListItems[1] = (QListWidgetItem*) new QListWidgetItem("Need key");
 	doorListItems[2] = (QListWidgetItem*) new QListWidgetItem("No block");
 	doorListItems[3] = (QListWidgetItem*) new QListWidgetItem("No break");
 	doorListItems[4] = (QListWidgetItem*) new QListWidgetItem("No pick");
 	doorListItems[5] = (QListWidgetItem*) new QListWidgetItem("Delayed");
-	doorListItems[6] = NULL;
+	doorListItems[6] = (QListWidgetItem*) new QListWidgetItem("Callable"); // Added in schema 040
+  doorListItems[7] = (QListWidgetItem*) new QListWidgetItem("Knockable"); // Added in schema 040
+  doorListItems[8] = (QListWidgetItem*) new QListWidgetItem("Magic"); // Added in schema 040
+  doorListItems[9] = (QListWidgetItem*) new QListWidgetItem("Action-controlled"); // Added in schema 040
+  doorListItems[10] = NULL;
+  doorListItems[11] = NULL;
+  doorListItems[12] = NULL;
+  doorListItems[13] = NULL;
+  doorListItems[14] = NULL;
+  doorListItems[15] = NULL;
 
 	doorFlagsListWidget->clear();
-	for (int i=0; i<6; i++)
+	for (int i=0; i<10; i++)
 	{
 		doorListItems[i]->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled);
 		doorFlagsListWidget->addItem(doorListItems[i]);
@@ -127,8 +136,8 @@ RoomEditAttrDlg::RoomEditAttrDlg(QWidget *parent)
   m_hiddenShortcut = new QShortcut( QKeySequence( tr( "Ctrl+H", "Room edit > hidden flag" ) ), this );
 
 	updatedLabel->setText("Room has not been online updated yet!!!");
-		
-	readSettings();	
+
+	readSettings();
 }
 
 RoomEditAttrDlg::~RoomEditAttrDlg()
@@ -155,32 +164,32 @@ void RoomEditAttrDlg::writeSettings()
 
 void RoomEditAttrDlg::connectAll()
 {
-    connect(neutralRadioButton, SIGNAL(toggled(bool)), this, SLOT(neutralRadioButtonToggled(bool)));	
-    connect(goodRadioButton, SIGNAL(toggled(bool)), this, SLOT(goodRadioButtonToggled(bool)));	
-    connect(evilRadioButton, SIGNAL(toggled(bool)), this, SLOT(evilRadioButtonToggled(bool)));	
-    connect(alignUndefRadioButton, SIGNAL(toggled(bool)), this, SLOT(alignUndefRadioButtonToggled(bool)));	
+    connect(neutralRadioButton, SIGNAL(toggled(bool)), this, SLOT(neutralRadioButtonToggled(bool)));
+    connect(goodRadioButton, SIGNAL(toggled(bool)), this, SLOT(goodRadioButtonToggled(bool)));
+    connect(evilRadioButton, SIGNAL(toggled(bool)), this, SLOT(evilRadioButtonToggled(bool)));
+    connect(alignUndefRadioButton, SIGNAL(toggled(bool)), this, SLOT(alignUndefRadioButtonToggled(bool)));
 
-    connect(noPortRadioButton, SIGNAL(toggled(bool)), this, SLOT(noPortRadioButtonToggled(bool)));	
-    connect(portableRadioButton, SIGNAL(toggled(bool)), this, SLOT(portableRadioButtonToggled(bool)));	
-    connect(portUndefRadioButton, SIGNAL(toggled(bool)), this, SLOT(portUndefRadioButtonToggled(bool)));	
-	
-    connect(noRideRadioButton, SIGNAL(toggled(bool)), this, SLOT(noRideRadioButtonToggled(bool)));	
-    connect(ridableRadioButton, SIGNAL(toggled(bool)), this, SLOT(ridableRadioButtonToggled(bool)));	
-    connect(rideUndefRadioButton, SIGNAL(toggled(bool)), this, SLOT(rideUndefRadioButtonToggled(bool)));	
+    connect(noPortRadioButton, SIGNAL(toggled(bool)), this, SLOT(noPortRadioButtonToggled(bool)));
+    connect(portableRadioButton, SIGNAL(toggled(bool)), this, SLOT(portableRadioButtonToggled(bool)));
+    connect(portUndefRadioButton, SIGNAL(toggled(bool)), this, SLOT(portUndefRadioButtonToggled(bool)));
 
-    connect(litRadioButton, SIGNAL(toggled(bool)), this, SLOT(litRadioButtonToggled(bool)));	
-    connect(darkRadioButton, SIGNAL(toggled(bool)), this, SLOT(darkRadioButtonToggled(bool)));	
-    connect(lightUndefRadioButton, SIGNAL(toggled(bool)), this, SLOT(lightUndefRadioButtonToggled(bool)));	
-	
+    connect(noRideRadioButton, SIGNAL(toggled(bool)), this, SLOT(noRideRadioButtonToggled(bool)));
+    connect(ridableRadioButton, SIGNAL(toggled(bool)), this, SLOT(ridableRadioButtonToggled(bool)));
+    connect(rideUndefRadioButton, SIGNAL(toggled(bool)), this, SLOT(rideUndefRadioButtonToggled(bool)));
+
+    connect(litRadioButton, SIGNAL(toggled(bool)), this, SLOT(litRadioButtonToggled(bool)));
+    connect(darkRadioButton, SIGNAL(toggled(bool)), this, SLOT(darkRadioButtonToggled(bool)));
+    connect(lightUndefRadioButton, SIGNAL(toggled(bool)), this, SLOT(lightUndefRadioButtonToggled(bool)));
+
 	connect(mobFlagsListWidget, SIGNAL(itemChanged(QListWidgetItem*)), this, SLOT(mobFlagsListItemChanged(QListWidgetItem*)));
 	connect(loadFlagsListWidget, SIGNAL(itemChanged(QListWidgetItem*)), this, SLOT(loadFlagsListItemChanged(QListWidgetItem*)));
 
-    connect(exitNButton, SIGNAL(toggled(bool)), this, SLOT(exitButtonToggled(bool)));	
-    connect(exitSButton, SIGNAL(toggled(bool)), this, SLOT(exitButtonToggled(bool)));	
-    connect(exitEButton, SIGNAL(toggled(bool)), this, SLOT(exitButtonToggled(bool)));	
-    connect(exitWButton, SIGNAL(toggled(bool)), this, SLOT(exitButtonToggled(bool)));	
-    connect(exitUButton, SIGNAL(toggled(bool)), this, SLOT(exitButtonToggled(bool)));	
-    connect(exitDButton, SIGNAL(toggled(bool)), this, SLOT(exitButtonToggled(bool)));	
+    connect(exitNButton, SIGNAL(toggled(bool)), this, SLOT(exitButtonToggled(bool)));
+    connect(exitSButton, SIGNAL(toggled(bool)), this, SLOT(exitButtonToggled(bool)));
+    connect(exitEButton, SIGNAL(toggled(bool)), this, SLOT(exitButtonToggled(bool)));
+    connect(exitWButton, SIGNAL(toggled(bool)), this, SLOT(exitButtonToggled(bool)));
+    connect(exitUButton, SIGNAL(toggled(bool)), this, SLOT(exitButtonToggled(bool)));
+    connect(exitDButton, SIGNAL(toggled(bool)), this, SLOT(exitButtonToggled(bool)));
 
 	connect(exitFlagsListWidget, SIGNAL(itemChanged(QListWidgetItem*)), this, SLOT(exitFlagsListItemChanged(QListWidgetItem*)));
 	connect(doorFlagsListWidget, SIGNAL(itemChanged(QListWidgetItem*)), this, SLOT(doorFlagsListItemChanged(QListWidgetItem*)));
@@ -211,32 +220,32 @@ void RoomEditAttrDlg::connectAll()
 
 void RoomEditAttrDlg::disconnectAll()
 {
-    disconnect(neutralRadioButton, SIGNAL(toggled(bool)), this, SLOT(neutralRadioButtonToggled(bool)));	
-    disconnect(goodRadioButton, SIGNAL(toggled(bool)), this, SLOT(goodRadioButtonToggled(bool)));	
-    disconnect(evilRadioButton, SIGNAL(toggled(bool)), this, SLOT(evilRadioButtonToggled(bool)));	
-    disconnect(alignUndefRadioButton, SIGNAL(toggled(bool)), this, SLOT(alignUndefRadioButtonToggled(bool)));	
+    disconnect(neutralRadioButton, SIGNAL(toggled(bool)), this, SLOT(neutralRadioButtonToggled(bool)));
+    disconnect(goodRadioButton, SIGNAL(toggled(bool)), this, SLOT(goodRadioButtonToggled(bool)));
+    disconnect(evilRadioButton, SIGNAL(toggled(bool)), this, SLOT(evilRadioButtonToggled(bool)));
+    disconnect(alignUndefRadioButton, SIGNAL(toggled(bool)), this, SLOT(alignUndefRadioButtonToggled(bool)));
 
-    disconnect(noPortRadioButton, SIGNAL(toggled(bool)), this, SLOT(noPortRadioButtonToggled(bool)));	
-    disconnect(portableRadioButton, SIGNAL(toggled(bool)), this, SLOT(portableRadioButtonToggled(bool)));	
-    disconnect(portUndefRadioButton, SIGNAL(toggled(bool)), this, SLOT(portUndefRadioButtonToggled(bool)));	
-	
-    disconnect(noRideRadioButton, SIGNAL(toggled(bool)), this, SLOT(noRideRadioButtonToggled(bool)));	
-    disconnect(ridableRadioButton, SIGNAL(toggled(bool)), this, SLOT(ridableRadioButtonToggled(bool)));	
-    disconnect(rideUndefRadioButton, SIGNAL(toggled(bool)), this, SLOT(rideUndefRadioButtonToggled(bool)));	
+    disconnect(noPortRadioButton, SIGNAL(toggled(bool)), this, SLOT(noPortRadioButtonToggled(bool)));
+    disconnect(portableRadioButton, SIGNAL(toggled(bool)), this, SLOT(portableRadioButtonToggled(bool)));
+    disconnect(portUndefRadioButton, SIGNAL(toggled(bool)), this, SLOT(portUndefRadioButtonToggled(bool)));
 
-    disconnect(litRadioButton, SIGNAL(toggled(bool)), this, SLOT(litRadioButtonToggled(bool)));	
-    disconnect(darkRadioButton, SIGNAL(toggled(bool)), this, SLOT(darkRadioButtonToggled(bool)));	
-    disconnect(lightUndefRadioButton, SIGNAL(toggled(bool)), this, SLOT(lightUndefRadioButtonToggled(bool)));	
-	
+    disconnect(noRideRadioButton, SIGNAL(toggled(bool)), this, SLOT(noRideRadioButtonToggled(bool)));
+    disconnect(ridableRadioButton, SIGNAL(toggled(bool)), this, SLOT(ridableRadioButtonToggled(bool)));
+    disconnect(rideUndefRadioButton, SIGNAL(toggled(bool)), this, SLOT(rideUndefRadioButtonToggled(bool)));
+
+    disconnect(litRadioButton, SIGNAL(toggled(bool)), this, SLOT(litRadioButtonToggled(bool)));
+    disconnect(darkRadioButton, SIGNAL(toggled(bool)), this, SLOT(darkRadioButtonToggled(bool)));
+    disconnect(lightUndefRadioButton, SIGNAL(toggled(bool)), this, SLOT(lightUndefRadioButtonToggled(bool)));
+
 	disconnect(mobFlagsListWidget, SIGNAL(itemChanged(QListWidgetItem*)), this, SLOT(mobFlagsListItemChanged(QListWidgetItem*)));
 	disconnect(loadFlagsListWidget, SIGNAL(itemChanged(QListWidgetItem*)), this, SLOT(loadFlagsListItemChanged(QListWidgetItem*)));
 
-    disconnect(exitNButton, SIGNAL(toggled(bool)), this, SLOT(exitButtonToggled(bool)));	
-    disconnect(exitSButton, SIGNAL(toggled(bool)), this, SLOT(exitButtonToggled(bool)));	
-    disconnect(exitEButton, SIGNAL(toggled(bool)), this, SLOT(exitButtonToggled(bool)));	
-    disconnect(exitWButton, SIGNAL(toggled(bool)), this, SLOT(exitButtonToggled(bool)));	
-    disconnect(exitUButton, SIGNAL(toggled(bool)), this, SLOT(exitButtonToggled(bool)));	
-    disconnect(exitDButton, SIGNAL(toggled(bool)), this, SLOT(exitButtonToggled(bool)));	
+    disconnect(exitNButton, SIGNAL(toggled(bool)), this, SLOT(exitButtonToggled(bool)));
+    disconnect(exitSButton, SIGNAL(toggled(bool)), this, SLOT(exitButtonToggled(bool)));
+    disconnect(exitEButton, SIGNAL(toggled(bool)), this, SLOT(exitButtonToggled(bool)));
+    disconnect(exitWButton, SIGNAL(toggled(bool)), this, SLOT(exitButtonToggled(bool)));
+    disconnect(exitUButton, SIGNAL(toggled(bool)), this, SLOT(exitButtonToggled(bool)));
+    disconnect(exitDButton, SIGNAL(toggled(bool)), this, SLOT(exitButtonToggled(bool)));
 
 	disconnect(exitFlagsListWidget, SIGNAL(itemChanged(QListWidgetItem*)), this, SLOT(exitFlagsListItemChanged(QListWidgetItem*)));
 	disconnect(doorFlagsListWidget, SIGNAL(itemChanged(QListWidgetItem*)), this, SLOT(doorFlagsListItemChanged(QListWidgetItem*)));
@@ -260,7 +269,7 @@ void RoomEditAttrDlg::disconnectAll()
 	disconnect(toolButton14, SIGNAL(toggled(bool)), this, SLOT(terrainToolButtonToggled(bool)));
 	disconnect(toolButton15, SIGNAL(toggled(bool)), this, SLOT(terrainToolButtonToggled(bool)));
 
-    disconnect(roomNoteTextEdit, SIGNAL(textChanged()), this, SLOT(roomNoteChanged()));	
+    disconnect(roomNoteTextEdit, SIGNAL(textChanged()), this, SLOT(roomNoteChanged()));
 
     disconnect(m_hiddenShortcut, SIGNAL(activated()), this, SLOT(toggleHiddenDoor()));
 }
@@ -268,9 +277,9 @@ void RoomEditAttrDlg::disconnectAll()
 const Room* RoomEditAttrDlg::getSelectedRoom()
 {
 	if ( m_roomSelection->size() == 0 ) return NULL;
-	if ( m_roomSelection->size() == 1 ) 
+	if ( m_roomSelection->size() == 1 )
 		return (m_roomSelection->values().front());
-	else	
+	else
 		return (m_roomSelection->value((roomListComboBox->itemData(roomListComboBox->currentIndex()).toInt())));
 }
 
@@ -298,48 +307,48 @@ void RoomEditAttrDlg::roomListCurrentIndexChanged(int)
 
 void RoomEditAttrDlg::setRoomSelection(const RoomSelection* rs, MapData* md, MapCanvas* mc)
 {
-	m_roomSelection = rs; 
+	m_roomSelection = rs;
 	m_mapData=md;
 	m_mapCanvas=mc;
-	
+
 	roomListComboBox->clear();
-	
-    if (rs->size() > 1) 
+
+    if (rs->size() > 1)
     {
     	tabWidget->setCurrentWidget(selectionTab);
     	roomListComboBox->addItem("All", 0);
-    	updateDialog(NULL);    	    	
-    	
+    	updateDialog(NULL);
+
 		disconnectAll();
 		alignUndefRadioButton->setChecked(true);
 		portUndefRadioButton->setChecked(true);
 		lightUndefRadioButton->setChecked(true);
 		connectAll();
     }
-    else if (rs->size() == 1) 
+    else if (rs->size() == 1)
     {
     	tabWidget->setCurrentWidget(attributesTab);
-    	updateDialog(m_roomSelection->values().front());    	
+    	updateDialog(m_roomSelection->values().front());
     }
-    
-    
+
+
    RoomSelection::const_iterator i = m_roomSelection->constBegin();
     while (i != m_roomSelection->constEnd()) {
     	roomListComboBox->addItem(getName(i.value()), i.value()->getId());
         ++i;
     }
-        
-    connect(roomListComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(roomListCurrentIndexChanged(int)) );	
-    connect(closeButton, SIGNAL(clicked()), this, SLOT(closeClicked()));	
-    connect(this, SIGNAL(mapChanged()), m_mapCanvas, SLOT(update()));	
+
+    connect(roomListComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(roomListCurrentIndexChanged(int)) );
+    connect(closeButton, SIGNAL(clicked()), this, SLOT(closeClicked()));
+    connect(this, SIGNAL(mapChanged()), m_mapCanvas, SLOT(update()));
 }
 
 
 void RoomEditAttrDlg::updateDialog(const Room *r)
 {
 	disconnectAll();
-	
-	if (r == NULL) 
+
+	if (r == NULL)
 	{
 		roomDescriptionTextEdit->clear();
 		roomDescriptionTextEdit->setEnabled(false);
@@ -350,23 +359,23 @@ void RoomEditAttrDlg::updateDialog(const Room *r)
 		roomNoteTextEdit->setEnabled(false);
 
 		terrainLabel->setPixmap(QPixmap(QString(":/pixmaps/terrain%1.png").arg(0)));
-		
-		exitsFrame->setEnabled(false);                                
+
+		exitsFrame->setEnabled(false);
 
 		int index = 0;
 		while(loadListItems[index]!=NULL)
 		{
 			loadListItems[index]->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled | Qt::ItemIsTristate);
 			loadListItems[index]->setCheckState(Qt::PartiallyChecked);
-			index++;		
+			index++;
 		}
-	
+
 		index = 0;
 		while(mobListItems[index]!=NULL)
 		{
 			mobListItems[index]->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled | Qt::ItemIsTristate);
-			mobListItems[index]->setCheckState(Qt::PartiallyChecked);		
-			index++;		
+			mobListItems[index]->setCheckState(Qt::PartiallyChecked);
+			index++;
 		}
 	}
 	else
@@ -374,91 +383,111 @@ void RoomEditAttrDlg::updateDialog(const Room *r)
 		roomDescriptionTextEdit->clear();
 		roomDescriptionTextEdit->setEnabled(true);
 
-		if (r->isUpToDate()) 
+		if (r->isUpToDate())
 			updatedLabel->setText("Room has been online updated.");
-		else	
+		else
 			updatedLabel->setText("Room has not been online updated yet!!!");
 
-		exitsFrame->setEnabled(true);          
-		
+		exitsFrame->setEnabled(true);
+
 		const Exit &e = r->exit(getSelectedExit());
-		ExitFlags ef = getFlags(e);                      
-				
-		if (ISSET(ef, EF_EXIT))	
+		ExitFlags ef = getFlags(e);
+
+		if (ISSET(ef, EF_EXIT))
 			exitListItems[0]->setCheckState(Qt::Checked);
 		else
 			exitListItems[0]->setCheckState(Qt::Unchecked);
-		
+
 		if (ISSET(ef, EF_DOOR))
 		{
 			doorNameLineEdit->setEnabled(true);
-			doorFlagsListWidget->setEnabled(true);	
-						
-			exitListItems[1]->setCheckState(Qt::Checked);			
-			doorNameLineEdit->setText(getDoorName(e));		
-				
+			doorFlagsListWidget->setEnabled(true);
+
+			exitListItems[1]->setCheckState(Qt::Checked);
+			doorNameLineEdit->setText(getDoorName(e));
+
 			DoorFlags df = getDoorFlags(e);
-			
-			if (ISSET(df, DF_HIDDEN))	
+
+			if (ISSET(df, DF_HIDDEN))
 				doorListItems[0]->setCheckState(Qt::Checked);
 			else
 				doorListItems[0]->setCheckState(Qt::Unchecked);
-				
-			if (ISSET(df, DF_NEEDKEY))	
+
+			if (ISSET(df, DF_NEEDKEY))
 				doorListItems[1]->setCheckState(Qt::Checked);
 			else
 				doorListItems[1]->setCheckState(Qt::Unchecked);
-	
-			if (ISSET(df, DF_NOBLOCK))	
+
+			if (ISSET(df, DF_NOBLOCK))
 				doorListItems[2]->setCheckState(Qt::Checked);
 			else
 				doorListItems[2]->setCheckState(Qt::Unchecked);
-	
-			if (ISSET(df, DF_NOBREAK))	
+
+			if (ISSET(df, DF_NOBREAK))
 				doorListItems[3]->setCheckState(Qt::Checked);
 			else
 				doorListItems[3]->setCheckState(Qt::Unchecked);
-	
-			if (ISSET(df, DF_NOPICK))	
+
+			if (ISSET(df, DF_NOPICK))
 				doorListItems[4]->setCheckState(Qt::Checked);
 			else
 				doorListItems[4]->setCheckState(Qt::Unchecked);
-	
-			if (ISSET(df, DF_DELAYED))	
+
+			if (ISSET(df, DF_DELAYED))
 				doorListItems[5]->setCheckState(Qt::Checked);
 			else
 				doorListItems[5]->setCheckState(Qt::Unchecked);
+
+      if (ISSET(df, DF_CALLABLE))
+        doorListItems[6]->setCheckState(Qt::Checked);
+      else
+        doorListItems[6]->setCheckState(Qt::Unchecked);
+
+      if (ISSET(df, DF_KNOCKABLE))
+        doorListItems[7]->setCheckState(Qt::Checked);
+      else
+        doorListItems[7]->setCheckState(Qt::Unchecked);
+
+      if (ISSET(df, DF_MAGIC))
+        doorListItems[8]->setCheckState(Qt::Checked);
+      else
+        doorListItems[8]->setCheckState(Qt::Unchecked);
+
+      if (ISSET(df, DF_ACTION))
+        doorListItems[9]->setCheckState(Qt::Checked);
+      else
+        doorListItems[9]->setCheckState(Qt::Unchecked);
 		}
 		else
 		{
 			doorNameLineEdit->clear();
 			doorNameLineEdit->setEnabled(false);
-			doorFlagsListWidget->setEnabled(false);				
+			doorFlagsListWidget->setEnabled(false);
 
 			exitListItems[1]->setCheckState(Qt::Unchecked);
 		}
 
-		if (ISSET(ef, EF_ROAD))	
+		if (ISSET(ef, EF_ROAD))
 			exitListItems[2]->setCheckState(Qt::Checked);
 		else
 			exitListItems[2]->setCheckState(Qt::Unchecked);
 
-		if (ISSET(ef, EF_CLIMB))	
+		if (ISSET(ef, EF_CLIMB))
 			exitListItems[3]->setCheckState(Qt::Checked);
 		else
 			exitListItems[3]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(ef, EF_RANDOM))	
+
+		if (ISSET(ef, EF_RANDOM))
 			exitListItems[4]->setCheckState(Qt::Checked);
 		else
 			exitListItems[4]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(ef, EF_SPECIAL))	
+
+		if (ISSET(ef, EF_SPECIAL))
 			exitListItems[5]->setCheckState(Qt::Checked);
 		else
 			exitListItems[5]->setCheckState(Qt::Unchecked);
 
-		if (ISSET(ef, EF_NO_MATCH))	
+		if (ISSET(ef, EF_NO_MATCH))
 			exitListItems[6]->setCheckState(Qt::Checked);
 		else
 			exitListItems[6]->setCheckState(Qt::Unchecked);
@@ -471,245 +500,245 @@ void RoomEditAttrDlg::updateDialog(const Room *r)
 		while(loadListItems[index]!=NULL)
 		{
 			loadListItems[index]->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled);
-			index++;		
+			index++;
 		}
-	
+
 		index = 0;
 		while(mobListItems[index]!=NULL)
 		{
 			mobListItems[index]->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled);
-			index++;		
+			index++;
 		}
 
-		
-		if (ISSET(getMobFlags(r),RMF_RENT)) 
+
+		if (ISSET(getMobFlags(r),RMF_RENT))
 			mobListItems[0]->setCheckState(Qt::Checked);
-		else 
+		else
 			mobListItems[0]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(getMobFlags(r),RMF_SHOP))	
+
+		if (ISSET(getMobFlags(r),RMF_SHOP))
 			mobListItems[1]->setCheckState(Qt::Checked);
 		else
 			mobListItems[1]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(getMobFlags(r),RMF_WEAPONSHOP))	
+
+		if (ISSET(getMobFlags(r),RMF_WEAPONSHOP))
 			mobListItems[2]->setCheckState(Qt::Checked);
 		else
 			mobListItems[2]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(getMobFlags(r),RMF_ARMOURSHOP))	
+
+		if (ISSET(getMobFlags(r),RMF_ARMOURSHOP))
 			mobListItems[3]->setCheckState(Qt::Checked);
 		else
 			mobListItems[3]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(getMobFlags(r),RMF_FOODSHOP))	
+
+		if (ISSET(getMobFlags(r),RMF_FOODSHOP))
 			mobListItems[4]->setCheckState(Qt::Checked);
 		else
 			mobListItems[4]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(getMobFlags(r),RMF_PETSHOP))	
+
+		if (ISSET(getMobFlags(r),RMF_PETSHOP))
 			mobListItems[5]->setCheckState(Qt::Checked);
 		else
 			mobListItems[5]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(getMobFlags(r),RMF_GUILD))	
+
+		if (ISSET(getMobFlags(r),RMF_GUILD))
 			mobListItems[6]->setCheckState(Qt::Checked);
 		else
 			mobListItems[6]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(getMobFlags(r),RMF_SCOUTGUILD))	
+
+		if (ISSET(getMobFlags(r),RMF_SCOUTGUILD))
 			mobListItems[7]->setCheckState(Qt::Checked);
 		else
 			mobListItems[7]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(getMobFlags(r),RMF_MAGEGUILD))	
+
+		if (ISSET(getMobFlags(r),RMF_MAGEGUILD))
 			mobListItems[8]->setCheckState(Qt::Checked);
 		else
 			mobListItems[8]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(getMobFlags(r),RMF_CLERICGUILD))	
+
+		if (ISSET(getMobFlags(r),RMF_CLERICGUILD))
 			mobListItems[9]->setCheckState(Qt::Checked);
 		else
 			mobListItems[9]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(getMobFlags(r),RMF_WARRIORGUILD))	
+
+		if (ISSET(getMobFlags(r),RMF_WARRIORGUILD))
 			mobListItems[10]->setCheckState(Qt::Checked);
 		else
 			mobListItems[10]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(getMobFlags(r),RMF_RANGERGUILD))	
+
+		if (ISSET(getMobFlags(r),RMF_RANGERGUILD))
 			mobListItems[11]->setCheckState(Qt::Checked);
 		else
 			mobListItems[11]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(getMobFlags(r),RMF_SMOB))	
+
+		if (ISSET(getMobFlags(r),RMF_SMOB))
 			mobListItems[12]->setCheckState(Qt::Checked);
 		else
 			mobListItems[12]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(getMobFlags(r),RMF_QUEST))	
+
+		if (ISSET(getMobFlags(r),RMF_QUEST))
 			mobListItems[13]->setCheckState(Qt::Checked);
 		else
 			mobListItems[13]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(getMobFlags(r),RMF_ANY))	
+
+		if (ISSET(getMobFlags(r),RMF_ANY))
 			mobListItems[14]->setCheckState(Qt::Checked);
 		else
 			mobListItems[14]->setCheckState(Qt::Unchecked);
-	
-	
-		if (ISSET(getLoadFlags(r),RLF_TREASURE))	
+
+
+		if (ISSET(getLoadFlags(r),RLF_TREASURE))
 			loadListItems[0]->setCheckState(Qt::Checked);
 		else
 			loadListItems[0]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(getLoadFlags(r),RLF_ARMOUR))	
+
+		if (ISSET(getLoadFlags(r),RLF_ARMOUR))
 			loadListItems[1]->setCheckState(Qt::Checked);
 		else
 			loadListItems[1]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(getLoadFlags(r),RLF_WEAPON))	
+
+		if (ISSET(getLoadFlags(r),RLF_WEAPON))
 			loadListItems[2]->setCheckState(Qt::Checked);
 		else
 			loadListItems[2]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(getLoadFlags(r),RLF_WATER))	
+
+		if (ISSET(getLoadFlags(r),RLF_WATER))
 			loadListItems[3]->setCheckState(Qt::Checked);
 		else
 			loadListItems[3]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(getLoadFlags(r),RLF_FOOD))	
+
+		if (ISSET(getLoadFlags(r),RLF_FOOD))
 			loadListItems[4]->setCheckState(Qt::Checked);
 		else
 			loadListItems[4]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(getLoadFlags(r),RLF_HERB))	
+
+		if (ISSET(getLoadFlags(r),RLF_HERB))
 			loadListItems[5]->setCheckState(Qt::Checked);
 		else
 			loadListItems[5]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(getLoadFlags(r),RLF_KEY))	
+
+		if (ISSET(getLoadFlags(r),RLF_KEY))
 			loadListItems[6]->setCheckState(Qt::Checked);
 		else
 			loadListItems[6]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(getLoadFlags(r),RLF_MULE))	
+
+		if (ISSET(getLoadFlags(r),RLF_MULE))
 			loadListItems[7]->setCheckState(Qt::Checked);
 		else
 			loadListItems[7]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(getLoadFlags(r),RLF_HORSE))	
+
+		if (ISSET(getLoadFlags(r),RLF_HORSE))
 			loadListItems[8]->setCheckState(Qt::Checked);
 		else
 			loadListItems[8]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(getLoadFlags(r),RLF_PACKHORSE))	
+
+		if (ISSET(getLoadFlags(r),RLF_PACKHORSE))
 			loadListItems[9]->setCheckState(Qt::Checked);
 		else
 			loadListItems[9]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(getLoadFlags(r),RLF_TRAINEDHORSE))	
+
+		if (ISSET(getLoadFlags(r),RLF_TRAINEDHORSE))
 			loadListItems[10]->setCheckState(Qt::Checked);
 		else
 			loadListItems[10]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(getLoadFlags(r),RLF_ROHIRRIM))	
+
+		if (ISSET(getLoadFlags(r),RLF_ROHIRRIM))
 			loadListItems[11]->setCheckState(Qt::Checked);
 		else
 			loadListItems[11]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(getLoadFlags(r),RLF_WARG))	
+
+		if (ISSET(getLoadFlags(r),RLF_WARG))
 			loadListItems[12]->setCheckState(Qt::Checked);
 		else
 			loadListItems[12]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(getLoadFlags(r),RLF_BOAT))	
+
+		if (ISSET(getLoadFlags(r),RLF_BOAT))
 			loadListItems[13]->setCheckState(Qt::Checked);
 		else
 			loadListItems[13]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(getLoadFlags(r),RLF_ATTENTION))	
+
+		if (ISSET(getLoadFlags(r),RLF_ATTENTION))
 			loadListItems[14]->setCheckState(Qt::Checked);
 		else
 			loadListItems[14]->setCheckState(Qt::Unchecked);
-	
-		if (ISSET(getLoadFlags(r),RLF_TOWER))	
+
+		if (ISSET(getLoadFlags(r),RLF_TOWER))
 			loadListItems[15]->setCheckState(Qt::Checked);
 		else
 			loadListItems[15]->setCheckState(Qt::Unchecked);
-	
-	
+
+
 		roomDescriptionTextEdit->setEnabled(true);
 		roomNoteTextEdit->setEnabled(true);
-				
+
 		roomDescriptionTextEdit->clear();
 		roomDescriptionTextEdit->setFontItalic(false);
 		QString str = getDescription(r);
 		str = str.left(str.length()-1);
-		roomDescriptionTextEdit->append(str);	
-		roomDescriptionTextEdit->setFontItalic(true);			
-		roomDescriptionTextEdit->append(getDynamicDescription(r));	
+		roomDescriptionTextEdit->append(str);
+		roomDescriptionTextEdit->setFontItalic(true);
+		roomDescriptionTextEdit->append(getDynamicDescription(r));
 		roomDescriptionTextEdit->scroll(-100,-100);
-		
+
 		roomNoteTextEdit->clear();
 		roomNoteTextEdit->append(getNote(r));
-		
+
 		terrainLabel->setPixmap(QPixmap(QString(":/pixmaps/terrain%1.png").arg(getTerrainType(r))));
-	
+
 		switch (getAlignType(r))
 		{
-			case RAT_GOOD: 
-				goodRadioButton->setChecked(true); 
+			case RAT_GOOD:
+				goodRadioButton->setChecked(true);
 				break;
-			case RAT_NEUTRAL: 
-				neutralRadioButton->setChecked(true); 
+			case RAT_NEUTRAL:
+				neutralRadioButton->setChecked(true);
 				break;
-			case RAT_EVIL: 
-				evilRadioButton->setChecked(true); 
+			case RAT_EVIL:
+				evilRadioButton->setChecked(true);
 				break;
-			case RAT_UNDEFINED:	
+			case RAT_UNDEFINED:
 				alignUndefRadioButton->setChecked(true);
 				break;
-		}	
-	
+		}
+
 		switch (getPortableType(r))
 		{
-			case RPT_PORTABLE: 
-				portableRadioButton->setChecked(true); 
+			case RPT_PORTABLE:
+				portableRadioButton->setChecked(true);
 				break;
-			case RPT_NOTPORTABLE: 
+			case RPT_NOTPORTABLE:
 				noPortRadioButton->setChecked(true);
 				break;
-			case RPT_UNDEFINED:	
+			case RPT_UNDEFINED:
 				portUndefRadioButton->setChecked(true);
 				break;
-		}	
-	
+		}
+
 		switch (getRidableType(r))
 		{
-			case RRT_RIDABLE: 
-				ridableRadioButton->setChecked(true); 
+			case RRT_RIDABLE:
+				ridableRadioButton->setChecked(true);
 				break;
-			case RRT_NOTRIDABLE: 
+			case RRT_NOTRIDABLE:
 				noRideRadioButton->setChecked(true);
 				break;
-			case RRT_UNDEFINED:	
+			case RRT_UNDEFINED:
 				rideUndefRadioButton->setChecked(true);
 				break;
-		}	
+		}
 
 		switch (getLightType(r))
 		{
-			case RLT_DARK: 
-				darkRadioButton->setChecked(true); 
+			case RLT_DARK:
+				darkRadioButton->setChecked(true);
 				break;
-			case RLT_LIT: 
-				litRadioButton->setChecked(true); 
+			case RLT_LIT:
+				litRadioButton->setChecked(true);
 				break;
-			case RLT_UNDEFINED:	
+			case RLT_UNDEFINED:
 				lightUndefRadioButton->setChecked(true);
 				break;
-		}	
+		}
 	}
 
 	connectAll();
@@ -721,7 +750,7 @@ void RoomEditAttrDlg::updateDialog(const Room *r)
 //attributes page
 void RoomEditAttrDlg::exitButtonToggled(bool)
 {
-	updateDialog( getSelectedRoom() );	
+	updateDialog( getSelectedRoom() );
 }
 
 void RoomEditAttrDlg::neutralRadioButtonToggled(bool val)
@@ -729,14 +758,14 @@ void RoomEditAttrDlg::neutralRadioButtonToggled(bool val)
 	if (val)
 	{
 		const Room* r = getSelectedRoom();
-		if (r)	
+		if (r)
 			m_mapData->execute(new SingleRoomAction(new UpdateRoomField(RAT_NEUTRAL, R_ALIGNTYPE), r->getId()), m_roomSelection);
 		else
-			m_mapData->execute(new GroupAction(new UpdateRoomField(RAT_NEUTRAL, R_ALIGNTYPE), m_roomSelection), m_roomSelection);		
-	
-		emit mapChanged();		
-		updateDialog( getSelectedRoom() );		
-	}  										
+			m_mapData->execute(new GroupAction(new UpdateRoomField(RAT_NEUTRAL, R_ALIGNTYPE), m_roomSelection), m_roomSelection);
+
+		emit mapChanged();
+		updateDialog( getSelectedRoom() );
+	}
 }
 
 void RoomEditAttrDlg::goodRadioButtonToggled(bool val)
@@ -744,14 +773,14 @@ void RoomEditAttrDlg::goodRadioButtonToggled(bool val)
 	if (val)
 	{
 		const Room* r = getSelectedRoom();
-		if (r)	
+		if (r)
 			m_mapData->execute(new SingleRoomAction(new UpdateRoomField(RAT_GOOD, R_ALIGNTYPE), r->getId()), m_roomSelection);
 		else
-			m_mapData->execute(new GroupAction(new UpdateRoomField(RAT_GOOD, R_ALIGNTYPE), m_roomSelection), m_roomSelection);		
-	
-		emit mapChanged();		  										
-		updateDialog( getSelectedRoom() );		
-	}  										
+			m_mapData->execute(new GroupAction(new UpdateRoomField(RAT_GOOD, R_ALIGNTYPE), m_roomSelection), m_roomSelection);
+
+		emit mapChanged();
+		updateDialog( getSelectedRoom() );
+	}
 }
 
 void RoomEditAttrDlg::evilRadioButtonToggled(bool val)
@@ -759,14 +788,14 @@ void RoomEditAttrDlg::evilRadioButtonToggled(bool val)
 	if (val)
 	{
 		const Room* r = getSelectedRoom();
-		if (r)	
+		if (r)
 			m_mapData->execute(new SingleRoomAction(new UpdateRoomField(RAT_EVIL, R_ALIGNTYPE), r->getId()), m_roomSelection);
 		else
-			m_mapData->execute(new GroupAction(new UpdateRoomField(RAT_EVIL, R_ALIGNTYPE), m_roomSelection), m_roomSelection);		
-	
-		emit mapChanged();		  										
-		updateDialog( getSelectedRoom() );		
-	}  										
+			m_mapData->execute(new GroupAction(new UpdateRoomField(RAT_EVIL, R_ALIGNTYPE), m_roomSelection), m_roomSelection);
+
+		emit mapChanged();
+		updateDialog( getSelectedRoom() );
+	}
 }
 
 void RoomEditAttrDlg::alignUndefRadioButtonToggled(bool val)
@@ -774,30 +803,30 @@ void RoomEditAttrDlg::alignUndefRadioButtonToggled(bool val)
 	if (val)
 	{
 		const Room* r = getSelectedRoom();
-		if (r)	
+		if (r)
 			m_mapData->execute(new SingleRoomAction(new UpdateRoomField(RAT_UNDEFINED, R_ALIGNTYPE), r->getId()), m_roomSelection);
 		else
-			m_mapData->execute(new GroupAction(new UpdateRoomField(RAT_UNDEFINED, R_ALIGNTYPE), m_roomSelection), m_roomSelection);		
-	
-		emit mapChanged();		  										
-		updateDialog( getSelectedRoom() );		
-	}  										
+			m_mapData->execute(new GroupAction(new UpdateRoomField(RAT_UNDEFINED, R_ALIGNTYPE), m_roomSelection), m_roomSelection);
+
+		emit mapChanged();
+		updateDialog( getSelectedRoom() );
+	}
 }
 
-	
+
 void RoomEditAttrDlg::noPortRadioButtonToggled(bool val)
 {
 	if (val)
 	{
 		const Room* r = getSelectedRoom();
-		if (r)	
+		if (r)
 			m_mapData->execute(new SingleRoomAction(new UpdateRoomField(RPT_NOTPORTABLE, R_PORTABLETYPE), r->getId()), m_roomSelection);
 		else
-			m_mapData->execute(new GroupAction(new UpdateRoomField(RPT_NOTPORTABLE, R_PORTABLETYPE), m_roomSelection), m_roomSelection);		
-	
-		emit mapChanged();		  										
-		updateDialog( getSelectedRoom() );		
-	}  										
+			m_mapData->execute(new GroupAction(new UpdateRoomField(RPT_NOTPORTABLE, R_PORTABLETYPE), m_roomSelection), m_roomSelection);
+
+		emit mapChanged();
+		updateDialog( getSelectedRoom() );
+	}
 }
 
 void RoomEditAttrDlg::portableRadioButtonToggled(bool val)
@@ -805,14 +834,14 @@ void RoomEditAttrDlg::portableRadioButtonToggled(bool val)
 	if (val)
 	{
 		const Room* r = getSelectedRoom();
-		if (r)	
+		if (r)
 			m_mapData->execute(new SingleRoomAction(new UpdateRoomField(RPT_PORTABLE, R_PORTABLETYPE), r->getId()), m_roomSelection);
 		else
-			m_mapData->execute(new GroupAction(new UpdateRoomField(RPT_PORTABLE, R_PORTABLETYPE), m_roomSelection), m_roomSelection);		
-	
-		emit mapChanged();		  										
-		updateDialog( getSelectedRoom() );		
-	}  										
+			m_mapData->execute(new GroupAction(new UpdateRoomField(RPT_PORTABLE, R_PORTABLETYPE), m_roomSelection), m_roomSelection);
+
+		emit mapChanged();
+		updateDialog( getSelectedRoom() );
+	}
 }
 
 void RoomEditAttrDlg::portUndefRadioButtonToggled(bool val)
@@ -820,14 +849,14 @@ void RoomEditAttrDlg::portUndefRadioButtonToggled(bool val)
 	if (val)
 	{
 		const Room* r = getSelectedRoom();
-		if (r)	
+		if (r)
 			m_mapData->execute(new SingleRoomAction(new UpdateRoomField(RPT_UNDEFINED, R_PORTABLETYPE), r->getId()), m_roomSelection);
 		else
-			m_mapData->execute(new GroupAction(new UpdateRoomField(RPT_UNDEFINED, R_PORTABLETYPE), m_roomSelection), m_roomSelection);		
-	
-		emit mapChanged();		  									
-		updateDialog( getSelectedRoom() );		
-	}  										
+			m_mapData->execute(new GroupAction(new UpdateRoomField(RPT_UNDEFINED, R_PORTABLETYPE), m_roomSelection), m_roomSelection);
+
+		emit mapChanged();
+		updateDialog( getSelectedRoom() );
+	}
 }
 
 void RoomEditAttrDlg::noRideRadioButtonToggled(bool val)
@@ -835,14 +864,14 @@ void RoomEditAttrDlg::noRideRadioButtonToggled(bool val)
 	if (val)
 	{
 		const Room* r = getSelectedRoom();
-		if (r)	
+		if (r)
 			m_mapData->execute(new SingleRoomAction(new UpdateRoomField(RRT_NOTRIDABLE, R_RIDABLETYPE), r->getId()), m_roomSelection);
 		else
-			m_mapData->execute(new GroupAction(new UpdateRoomField(RRT_NOTRIDABLE, R_RIDABLETYPE), m_roomSelection), m_roomSelection);		
-	
-		emit mapChanged();		  										
-		updateDialog( getSelectedRoom() );		
-	}  										
+			m_mapData->execute(new GroupAction(new UpdateRoomField(RRT_NOTRIDABLE, R_RIDABLETYPE), m_roomSelection), m_roomSelection);
+
+		emit mapChanged();
+		updateDialog( getSelectedRoom() );
+	}
 }
 
 void RoomEditAttrDlg::ridableRadioButtonToggled(bool val)
@@ -850,14 +879,14 @@ void RoomEditAttrDlg::ridableRadioButtonToggled(bool val)
 	if (val)
 	{
 		const Room* r = getSelectedRoom();
-		if (r)	
+		if (r)
 			m_mapData->execute(new SingleRoomAction(new UpdateRoomField(RRT_RIDABLE, R_RIDABLETYPE), r->getId()), m_roomSelection);
 		else
-			m_mapData->execute(new GroupAction(new UpdateRoomField(RRT_RIDABLE, R_RIDABLETYPE), m_roomSelection), m_roomSelection);		
-	
-		emit mapChanged();		  										
-		updateDialog( getSelectedRoom() );		
-	}  										
+			m_mapData->execute(new GroupAction(new UpdateRoomField(RRT_RIDABLE, R_RIDABLETYPE), m_roomSelection), m_roomSelection);
+
+		emit mapChanged();
+		updateDialog( getSelectedRoom() );
+	}
 }
 
 void RoomEditAttrDlg::rideUndefRadioButtonToggled(bool val)
@@ -865,29 +894,29 @@ void RoomEditAttrDlg::rideUndefRadioButtonToggled(bool val)
 	if (val)
 	{
 		const Room* r = getSelectedRoom();
-		if (r)	
+		if (r)
 			m_mapData->execute(new SingleRoomAction(new UpdateRoomField(RRT_UNDEFINED, R_RIDABLETYPE), r->getId()), m_roomSelection);
 		else
-			m_mapData->execute(new GroupAction(new UpdateRoomField(RRT_UNDEFINED, R_RIDABLETYPE), m_roomSelection), m_roomSelection);		
-	
-		emit mapChanged();		  									
-		updateDialog( getSelectedRoom() );		
-	}  										
+			m_mapData->execute(new GroupAction(new UpdateRoomField(RRT_UNDEFINED, R_RIDABLETYPE), m_roomSelection), m_roomSelection);
+
+		emit mapChanged();
+		updateDialog( getSelectedRoom() );
+	}
 }
-		
+
 void RoomEditAttrDlg::litRadioButtonToggled(bool val)
 {
 	if (val)
 	{
 		const Room* r = getSelectedRoom();
-		if (r)	
+		if (r)
 			m_mapData->execute(new SingleRoomAction(new UpdateRoomField(RLT_LIT, R_LIGHTTYPE), r->getId()), m_roomSelection);
 		else
-			m_mapData->execute(new GroupAction(new UpdateRoomField(RLT_LIT, R_LIGHTTYPE), m_roomSelection), m_roomSelection);		
-	
-		emit mapChanged();		  								
-		updateDialog( getSelectedRoom() );		
-	}  										
+			m_mapData->execute(new GroupAction(new UpdateRoomField(RLT_LIT, R_LIGHTTYPE), m_roomSelection), m_roomSelection);
+
+		emit mapChanged();
+		updateDialog( getSelectedRoom() );
+	}
 }
 
 void RoomEditAttrDlg::darkRadioButtonToggled(bool val)
@@ -895,14 +924,14 @@ void RoomEditAttrDlg::darkRadioButtonToggled(bool val)
 	if (val)
 	{
 		const Room* r = getSelectedRoom();
-		if (r)	
+		if (r)
 			m_mapData->execute(new SingleRoomAction(new UpdateRoomField(RLT_DARK, R_LIGHTTYPE), r->getId()), m_roomSelection);
 		else
-			m_mapData->execute(new GroupAction(new UpdateRoomField(RLT_DARK, R_LIGHTTYPE), m_roomSelection), m_roomSelection);		
-	
-		emit mapChanged();		  								
-		updateDialog( getSelectedRoom() );		
-	}  										
+			m_mapData->execute(new GroupAction(new UpdateRoomField(RLT_DARK, R_LIGHTTYPE), m_roomSelection), m_roomSelection);
+
+		emit mapChanged();
+		updateDialog( getSelectedRoom() );
+	}
 }
 
 void RoomEditAttrDlg::lightUndefRadioButtonToggled(bool val)
@@ -910,17 +939,17 @@ void RoomEditAttrDlg::lightUndefRadioButtonToggled(bool val)
 	if (val)
 	{
 		const Room* r = getSelectedRoom();
-		if (r)	
+		if (r)
 			m_mapData->execute(new SingleRoomAction(new UpdateRoomField(RLT_UNDEFINED, R_LIGHTTYPE), r->getId()), m_roomSelection);
 		else
-			m_mapData->execute(new GroupAction(new UpdateRoomField(RLT_UNDEFINED, R_LIGHTTYPE), m_roomSelection), m_roomSelection);		
-	
-		emit mapChanged();		  							
-		updateDialog( getSelectedRoom() );		
-	}  										
+			m_mapData->execute(new GroupAction(new UpdateRoomField(RLT_UNDEFINED, R_LIGHTTYPE), m_roomSelection), m_roomSelection);
+
+		emit mapChanged();
+		updateDialog( getSelectedRoom() );
+	}
 }
 
-	
+
 void RoomEditAttrDlg::mobFlagsListItemChanged(QListWidgetItem* item)
 {
 	int index = 0;
@@ -932,22 +961,22 @@ void RoomEditAttrDlg::mobFlagsListItemChanged(QListWidgetItem* item)
 	switch (item->checkState())
 	{
 	case Qt::Unchecked:
-		if (r)	
+		if (r)
 			m_mapData->execute(new SingleRoomAction(new ModifyRoomFlags((uint)pow(2.0, index), R_MOBFLAGS, FMM_UNSET), r->getId()), m_roomSelection);
 		else
 			m_mapData->execute(new GroupAction(new ModifyRoomFlags((uint)pow(2.0, index), R_MOBFLAGS, FMM_UNSET), m_roomSelection), m_roomSelection);
-		break;		
+		break;
 	case Qt::PartiallyChecked:
 		break;
 	case Qt::Checked:
-		if (r)	
+		if (r)
 			m_mapData->execute(new SingleRoomAction(new ModifyRoomFlags((uint)pow(2.0, index), R_MOBFLAGS, FMM_SET), r->getId()), m_roomSelection);
 		else
-			m_mapData->execute(new GroupAction(new ModifyRoomFlags((uint)pow(2.0, index), R_MOBFLAGS, FMM_SET), m_roomSelection), m_roomSelection);		
-		break;		
+			m_mapData->execute(new GroupAction(new ModifyRoomFlags((uint)pow(2.0, index), R_MOBFLAGS, FMM_SET), m_roomSelection), m_roomSelection);
+		break;
 	}
-	
-	emit mapChanged();		  						
+
+	emit mapChanged();
 }
 
 void RoomEditAttrDlg::loadFlagsListItemChanged(QListWidgetItem* item)
@@ -961,22 +990,22 @@ void RoomEditAttrDlg::loadFlagsListItemChanged(QListWidgetItem* item)
 	switch (item->checkState())
 	{
 	case Qt::Unchecked:
-		if (r)	
+		if (r)
 			m_mapData->execute(new SingleRoomAction(new ModifyRoomFlags((uint)pow(2.0, index), R_LOADFLAGS, FMM_UNSET), r->getId()), m_roomSelection);
 		else
 			m_mapData->execute(new GroupAction(new ModifyRoomFlags((uint)pow(2.0, index), R_LOADFLAGS, FMM_UNSET), m_roomSelection), m_roomSelection);
-		break;		
+		break;
 	case Qt::PartiallyChecked:
 		break;
 	case Qt::Checked:
-		if (r)	
+		if (r)
 			m_mapData->execute(new SingleRoomAction(new ModifyRoomFlags((uint)pow(2.0, index), R_LOADFLAGS, FMM_SET), r->getId()), m_roomSelection);
 		else
-			m_mapData->execute(new GroupAction(new ModifyRoomFlags((uint)pow(2.0, index), R_LOADFLAGS, FMM_SET), m_roomSelection), m_roomSelection);		
-		break;		
+			m_mapData->execute(new GroupAction(new ModifyRoomFlags((uint)pow(2.0, index), R_LOADFLAGS, FMM_SET), m_roomSelection), m_roomSelection);
+		break;
 	}
-	
-	emit mapChanged();		  							
+
+	emit mapChanged();
 }
 
 void RoomEditAttrDlg::exitFlagsListItemChanged(QListWidgetItem* item)
@@ -990,32 +1019,32 @@ void RoomEditAttrDlg::exitFlagsListItemChanged(QListWidgetItem* item)
 	switch (item->checkState())
 	{
 	case Qt::Unchecked:
-		if (r)	
+		if (r)
 			m_mapData->execute(new SingleRoomAction(new ModifyExitFlags((uint)pow(2.0, index), getSelectedExit(), E_FLAGS, FMM_UNSET), r->getId()), m_roomSelection);
 		else
 			m_mapData->execute(new GroupAction(new ModifyExitFlags((uint)pow(2.0, index), getSelectedExit(), E_FLAGS, FMM_UNSET), m_roomSelection), m_roomSelection);
-		break;		
+		break;
 	case Qt::PartiallyChecked:
 		break;
 	case Qt::Checked:
-		if (r)	
+		if (r)
 			m_mapData->execute(new SingleRoomAction(new ModifyExitFlags((uint)pow(2.0, index), getSelectedExit(), E_FLAGS, FMM_SET), r->getId()), m_roomSelection);
 		else
-			m_mapData->execute(new GroupAction(new ModifyExitFlags((uint)pow(2.0, index), getSelectedExit(), E_FLAGS, FMM_SET), m_roomSelection), m_roomSelection);		
-		break;		
+			m_mapData->execute(new GroupAction(new ModifyExitFlags((uint)pow(2.0, index), getSelectedExit(), E_FLAGS, FMM_SET), m_roomSelection), m_roomSelection);
+		break;
 	}
-	
-	updateDialog( getSelectedRoom() );		
-	emit mapChanged();		  					
+
+	updateDialog( getSelectedRoom() );
+	emit mapChanged();
 }
 
 
 void RoomEditAttrDlg::doorNameLineEditTextChanged(QString)
 {
 	const Room* r = getSelectedRoom();
-	
+
 	m_mapData->execute(new SingleRoomAction(new UpdateExitField(doorNameLineEdit->text(), getSelectedExit(), E_DOORNAME), r->getId()), m_roomSelection);
-		
+
 }
 
 void RoomEditAttrDlg::doorFlagsListItemChanged(QListWidgetItem* item)
@@ -1030,30 +1059,30 @@ void RoomEditAttrDlg::doorFlagsListItemChanged(QListWidgetItem* item)
 	{
 	case Qt::Unchecked:
 		m_mapData->execute(new SingleRoomAction(new ModifyExitFlags((uint)pow(2.0, index), getSelectedExit(), E_DOORFLAGS, FMM_UNSET), r->getId()), m_roomSelection);
-		break;		
+		break;
 	case Qt::PartiallyChecked:
 		break;
 	case Qt::Checked:
 		m_mapData->execute(new SingleRoomAction(new ModifyExitFlags((uint)pow(2.0, index), getSelectedExit(), E_DOORFLAGS, FMM_SET), r->getId()), m_roomSelection);
-		break;		
+		break;
 	}
-			
-	emit mapChanged();		  				
+
+	emit mapChanged();
 }
 
 void RoomEditAttrDlg::toggleHiddenDoor()
 {
-  if ( doorFlagsListWidget->isEnabled() )  
+  if ( doorFlagsListWidget->isEnabled() )
     doorListItems[0]->setCheckState( doorListItems[0]->checkState() == Qt::Unchecked ? Qt::Checked : Qt::Unchecked );
 }
 
-//terrain tab	
+//terrain tab
 void RoomEditAttrDlg::terrainToolButtonToggled(bool val)
 {
 	if (val)
 	{
 		const Room* r = getSelectedRoom();
-		
+
 		uint index = 0;
 		if (toolButton00->isChecked()) index = 0;
 		if (toolButton01->isChecked()) index = 1;
@@ -1071,35 +1100,34 @@ void RoomEditAttrDlg::terrainToolButtonToggled(bool val)
 		if (toolButton13->isChecked()) index = 13;
 		if (toolButton14->isChecked()) index = 14;
 		if (toolButton15->isChecked()) index = 15;
-		
+
 		terrainLabel->setPixmap(QPixmap(QString(":/pixmaps/terrain%1.png").arg(index)));
-	
-		if (r)	
+
+		if (r)
 			m_mapData->execute(new SingleRoomAction(new UpdateRoomField(index, R_TERRAINTYPE), r->getId()), m_roomSelection);
 		else
 			m_mapData->execute(new GroupAction(new UpdateRoomField(index, R_TERRAINTYPE), m_roomSelection), m_roomSelection);
-	
-		emit mapChanged();		  				
+
+		emit mapChanged();
 	}
 }
-	
+
 //note tab
 void RoomEditAttrDlg::roomNoteChanged()
 {
 	const Room* r = getSelectedRoom();
-	
-	if (r)
-		m_mapData->execute(new SingleRoomAction(new UpdateRoomField( roomNoteTextEdit->document()->toPlainText(), R_NOTE), r->getId()), m_roomSelection);	
-	else
-		m_mapData->execute(new GroupAction(new UpdateRoomField( roomNoteTextEdit->document()->toPlainText(), R_NOTE), m_roomSelection), m_roomSelection);	
 
-	emit mapChanged();		  				
+	if (r)
+		m_mapData->execute(new SingleRoomAction(new UpdateRoomField( roomNoteTextEdit->document()->toPlainText(), R_NOTE), r->getId()), m_roomSelection);
+	else
+		m_mapData->execute(new GroupAction(new UpdateRoomField( roomNoteTextEdit->document()->toPlainText(), R_NOTE), m_roomSelection), m_roomSelection);
+
+	emit mapChanged();
 }
 
-	
+
 //all tabs
 void RoomEditAttrDlg::closeClicked()
 {
-	accept();	
+	accept();
 }
-

--- a/src/mainwindow/roomeditattrdlg.h
+++ b/src/mainwindow/roomeditattrdlg.h
@@ -4,7 +4,7 @@
 **            Marek Krejza <krejza@gmail.com> (Caligor),
 **            Nils Schimmelmann <nschimme@gmail.com> (Jahara)
 **
-** This file is part of the MMapper project. 
+** This file is part of the MMapper project.
 ** Maintained by Nils Schimmelmann <nschimme@gmail.com>
 **
 ** This program is free software; you can redistribute it and/or
@@ -44,9 +44,9 @@ signals:
 	void mapChanged();
 
 public slots:
-    void setRoomSelection(const RoomSelection*, MapData*, MapCanvas*);   
+    void setRoomSelection(const RoomSelection*, MapData*, MapCanvas*);
 
-	//selection page    
+	//selection page
     void roomListCurrentIndexChanged(int);
 
 	//attributes page
@@ -54,7 +54,7 @@ public slots:
 	void goodRadioButtonToggled(bool);
 	void evilRadioButtonToggled(bool);
 	void alignUndefRadioButtonToggled(bool);
-	
+
 	void noPortRadioButtonToggled(bool);
 	void portableRadioButtonToggled(bool);
 	void portUndefRadioButtonToggled(bool);
@@ -62,14 +62,14 @@ public slots:
 	void noRideRadioButtonToggled(bool);
 	void ridableRadioButtonToggled(bool);
 	void rideUndefRadioButtonToggled(bool);
-		
+
 	void litRadioButtonToggled(bool);
 	void darkRadioButtonToggled(bool);
 	void lightUndefRadioButtonToggled(bool);
-	
+
 	void mobFlagsListItemChanged(QListWidgetItem*);
 	void loadFlagsListItemChanged(QListWidgetItem*);
-        
+
 	void exitButtonToggled(bool);
 
 	void exitFlagsListItemChanged(QListWidgetItem*);
@@ -79,42 +79,42 @@ public slots:
 
   void toggleHiddenDoor();
 
-	//terrain tab	
+	//terrain tab
 	void terrainToolButtonToggled(bool);
-	
+
 	//note tab
 	void roomNoteChanged();
-	
+
 	//all tabs
 	void closeClicked();
-	    
+
 public:
     RoomEditAttrDlg(QWidget *parent = 0);
     ~RoomEditAttrDlg();
-    
+
     void readSettings();
 	void writeSettings();
-    
-    
+
+
 private:
 
 	void connectAll();
 	void disconnectAll();
 
-	const Room* getSelectedRoom();	
+	const Room* getSelectedRoom();
 	uint getSelectedExit();
 	void updateDialog(const Room *r);
-	
+
 	QListWidgetItem* loadListItems[20];
 	QListWidgetItem* mobListItems[20];
-	
+
 	QListWidgetItem* exitListItems[20];
 	QListWidgetItem* doorListItems[20];
 
 	const RoomSelection* 	m_roomSelection;
-	MapData* 		m_mapData;
-	MapCanvas* 		m_mapCanvas;
-  QShortcut *m_hiddenShortcut;
+	MapData* 		          m_mapData;
+	MapCanvas* 		        m_mapCanvas;
+  QShortcut*            m_hiddenShortcut;
 };
 
 

--- a/src/mainwindow/roomeditattrdlg.ui
+++ b/src/mainwindow/roomeditattrdlg.ui
@@ -454,6 +454,12 @@
               <height>115</height>
              </size>
             </property>
+            <property name="maximumSize">
+             <size>
+              <width>110</width>
+              <height>115</height>
+             </size>
+            </property>
             <property name="title">
              <string>Select exit:</string>
             </property>

--- a/src/mapdata/mmapper2exit.h
+++ b/src/mapdata/mmapper2exit.h
@@ -56,8 +56,10 @@ typedef class QString DoorName;
 #define DF_NOBREAK    bit4
 #define DF_NOPICK     bit5
 #define DF_DELAYED    bit6
-#define DF_RESERVED1  bit7
-#define DF_RESERVED2  bit8
+#define DF_CALLABLE   bit7
+#define DF_KNOCKABLE  bit8
+#define DF_MAGIC      bit9
+#define DF_ACTION     bit10
 
 enum ExitField {E_DOORNAME = 0, E_FLAGS, E_DOORFLAGS};
 

--- a/src/mapdata/mmapper2exit.h
+++ b/src/mapdata/mmapper2exit.h
@@ -49,6 +49,7 @@ typedef class QString DoorName;
 #define EF_RANDOM     bit5
 #define EF_SPECIAL    bit6
 #define EF_NO_MATCH   bit7
+#define EF_FLOW       bit8
 
 #define DF_HIDDEN     bit1
 #define DF_NEEDKEY    bit2

--- a/src/mapdata/mmapper2exit.h
+++ b/src/mapdata/mmapper2exit.h
@@ -3,7 +3,7 @@
 ** Authors:   Ulf Hermann <ulfonk_mennhar@gmx.de> (Alve),
 **            Marek Krejza <krejza@gmail.com> (Caligor)
 **
-** This file is part of the MMapper project. 
+** This file is part of the MMapper project.
 ** Maintained by Nils Schimmelmann <nschimme@gmail.com>
 **
 ** This program is free software; you can redistribute it and/or
@@ -33,7 +33,7 @@ class Exit;
 
 enum ExitType { ET_NORMAL, ET_LOOP, ET_ONEWAY, ET_UNDEFINED };
 
-enum ExitDirection { ED_NORTH=0, ED_SOUTH, ED_EAST, ED_WEST, ED_UP, 
+enum ExitDirection { ED_NORTH=0, ED_SOUTH, ED_EAST, ED_WEST, ED_UP,
 			   ED_DOWN, ED_UNKNOWN, ED_NONE };
 
 ExitDirection opposite(ExitDirection in);
@@ -62,7 +62,7 @@ typedef class QString DoorName;
 enum ExitField {E_DOORNAME = 0, E_FLAGS, E_DOORFLAGS};
 
 typedef quint8 ExitFlags;
-typedef quint8 DoorFlags;
+typedef quint16 DoorFlags;
 
 ExitFlags getFlags(const Exit & e);
 
@@ -73,11 +73,11 @@ DoorFlags getDoorFlags(const Exit & e);
 void updateExit(Exit & e, ExitFlags flags);
 
 void orExitFlags(Exit & e, ExitFlags flags);
-  
+
 void nandExitFlags(Exit & e, ExitFlags flags);
 
 void orDoorFlags(Exit & e, DoorFlags flags);
-  
+
 void nandDoorFlags(Exit & e, DoorFlags flags);
-  
+
 #endif

--- a/src/mapstorage/mapstorage.cpp
+++ b/src/mapstorage/mapstorage.cpp
@@ -902,7 +902,7 @@ bool MapStorage::saveData( bool baseMapOnly )
 
   // Write a header with a "magic number" and a version
   stream << (quint32)0xFFB2AF01;
-  stream << (qint32)031;
+  stream << (qint32)040;
   stream.setVersion(QDataStream::Qt_4_8);
 
   // QtIOCompressor

--- a/src/mapstorage/mapstorage.cpp
+++ b/src/mapstorage/mapstorage.cpp
@@ -340,21 +340,34 @@ Room * MapStorage::loadRoom(QDataStream & stream, qint32 version)
   return room;
 }
 
-void MapStorage::loadExits(Room * room, QDataStream & stream, qint32 /*version*/)
+void MapStorage::loadExits(Room * room, QDataStream & stream, qint32 version)
 {
+  quint8 vquint8; // To read generic 8-bit value
+
   ExitsList & eList = room->getExitsList();
   for (int i = 0; i < 7; ++i)
   {
     Exit & e = eList[i];
 
+    // Read the exit flags
     ExitFlags flags;
     stream >> flags;
     if (ISSET(flags, EF_DOOR)) SET(flags, EF_EXIT);
     e[E_FLAGS] = flags;
 
     DoorFlags dFlags;
-    stream >> dFlags;
-    e[E_DOORFLAGS] = dFlags;
+    if (version >= 040)
+    {
+      // Door flags are stored with 16 bits in version >= 040
+      stream >> dFlags;
+      e[E_DOORFLAGS] = dFlags;
+    }
+    else
+    {
+      // Door flags were stored with 8 bits in version < 040
+      stream >> vquint8;
+      e[E_DOORFLAGS] = vquint8;
+    }
 
     DoorName dName;
     stream >> dName;
@@ -418,7 +431,7 @@ bool MapStorage::mergeData()
     stream >> magic;
     if ( magic != 0xFFB2AF01 ) return false;
     stream >> version;
-    if ( version != 031 && version != 030 &&
+    if ( version != 040 && version != 031 && version != 030 &&
 	 version != 020 && version != 021 && version != 007 ) return false;
 
     // We currently force serialization to Qt4.8 since Qt5 broke QDateTime serialization

--- a/src/mapstorage/mapstorage.h
+++ b/src/mapstorage/mapstorage.h
@@ -4,7 +4,7 @@
 **            Marek Krejza <krejza@gmail.com> (Caligor),
 **            Nils Schimmelmann <nschimme@gmail.com> (Jahara)
 **
-** This file is part of the MMapper project. 
+** This file is part of the MMapper project.
 ** Maintained by Nils Schimmelmann <nschimme@gmail.com>
 **
 ** This program is free software; you can redistribute it and/or
@@ -40,7 +40,7 @@ public:
     MapStorage(MapData&, const QString&, QFile*);
     MapStorage(MapData&, const QString&);
     bool mergeData();
-    
+
 private:
     virtual bool canLoad() {return TRUE;};
     virtual bool canSave() {return TRUE;};
@@ -59,7 +59,7 @@ private:
     void translateOldConnection(Connection *);
     void saveRoom(const Room * room, QDataStream & stream);
     void saveExits(const Room * room, QDataStream & stream);
-    
+
     uint baseId;
     Coordinate basePosition;
 };

--- a/src/mapstorage/olddoor.h
+++ b/src/mapstorage/olddoor.h
@@ -3,7 +3,7 @@
 ** Authors:   Ulf Hermann <ulfonk_mennhar@gmx.de> (Alve),
 **            Marek Krejza <krejza@gmail.com> (Caligor)
 **
-** This file is part of the MMapper project. 
+** This file is part of the MMapper project.
 ** Maintained by Nils Schimmelmann <nschimme@gmail.com>
 **
 ** This program is free software; you can redistribute it and/or
@@ -37,7 +37,7 @@
 #define DF_RESERVED1  bit7
 #define DF_RESERVED2  bit8
 typedef class QString DoorName;
-typedef quint8 DoorFlags;
+typedef quint16 DoorFlags;
 
 class Door {
 


### PR DESCRIPTION
I extended the exit flag with a 'river flow' that allows to store the direction of the flow of a river.

With this info, I display a path for the river flow, so that this is not a surprise for the player.

Here is how it looks like:
<img width="598" alt="screen shot 2016-12-16 at 22 16 46" src="https://cloud.githubusercontent.com/assets/1466293/21280397/9fa0b684-c3dd-11e6-9a0e-a42df2ab6957.png">

(Screenshot also show use of  colored and rotated info mark ;-) (It is in a previous PR)