### PR TITLE
Command line access to set and print note

### DIFF
--- a/src/mapdata/mapdata.cpp
+++ b/src/mapdata/mapdata.cpp
@@ -110,13 +110,9 @@ void MapData::toggleRoomFlag(const Coordinate & pos, uint flag, uint field)
 
 bool MapData::getRoomFlag(const Coordinate & pos, uint flag, uint field)
 {
-  QMutexLocker locker(&mapLock);
-  Room * room = map.get(pos);
-  if (room && field < ROOMFIELD_LAST )
-  {
-    if (ISSET((*room)[field].toUInt(), flag)) return true;
-  }
-  return false;
+  const QVariant val = getRoomField(pos, field);
+  if (val.isNull()) return false;
+  return ISSET(val.toUInt(), flag);
 }
 
 void MapData::setRoomField(const Coordinate & pos, const QVariant & flag, uint field)

--- a/src/mapdata/mapdata.cpp
+++ b/src/mapdata/mapdata.cpp
@@ -131,15 +131,15 @@ void MapData::setRoomField(const Coordinate & pos, const QVariant & flag, uint f
   }
 }
 
-uint MapData::getRoomField(const Coordinate & pos, uint field)
+QVariant MapData::getRoomField(const Coordinate & pos, uint field)
 {
   QMutexLocker locker(&mapLock);
   Room * room = map.get(pos);
   if (room && field < ROOMFIELD_LAST )
   {
-    return (*room)[field].toUInt();
+    return (*room)[field];
   }
-  return 0;
+  return QVariant();
 }
 
 QList<Coordinate> MapData::getPath(const QList<CommandIdType> dirs)

--- a/src/mapdata/mapdata.cpp
+++ b/src/mapdata/mapdata.cpp
@@ -119,7 +119,7 @@ bool MapData::getRoomFlag(const Coordinate & pos, uint flag, uint field)
   return false;
 }
 
-void MapData::setRoomField(const Coordinate & pos, uint flag, uint field)
+void MapData::setRoomField(const Coordinate & pos, const QVariant & flag, uint field)
 {
   QMutexLocker locker(&mapLock);
   Room * room = map.get(pos);

--- a/src/mapdata/mapdata.h
+++ b/src/mapdata/mapdata.h
@@ -109,7 +109,7 @@ public:
   void setDoorName(const Coordinate & pos, const QString & name, uint dir);
   bool getExitFlag(const Coordinate & pos, uint flag, uint dir, uint field);
   void toggleExitFlag(const Coordinate & pos, uint flag, uint dir, uint field);
-  void setRoomField(const Coordinate & pos, uint field, uint flag);
+  void setRoomField(const Coordinate & pos, const QVariant & field, uint flag);
   uint getRoomField(const Coordinate & pos, uint flag);
   void toggleRoomFlag(const Coordinate & pos, uint flag, uint field);
   bool getRoomFlag(const Coordinate & pos, uint flag, uint field);

--- a/src/mapdata/mapdata.h
+++ b/src/mapdata/mapdata.h
@@ -110,7 +110,7 @@ public:
   bool getExitFlag(const Coordinate & pos, uint flag, uint dir, uint field);
   void toggleExitFlag(const Coordinate & pos, uint flag, uint dir, uint field);
   void setRoomField(const Coordinate & pos, const QVariant & field, uint flag);
-  uint getRoomField(const Coordinate & pos, uint flag);
+  QVariant getRoomField(const Coordinate & pos, uint flag);
   void toggleRoomFlag(const Coordinate & pos, uint flag, uint field);
   bool getRoomFlag(const Coordinate & pos, uint flag, uint field);
 

--- a/src/parser/abstractparser.cpp
+++ b/src/parser/abstractparser.cpp
@@ -837,6 +837,11 @@ bool AbstractParser::parseUserCommands(QString& command)
       toggleRoomFlagCommand(RLF_TOWER, R_LOADFLAGS);
       return false;
     }
+    else if (str.startsWith("_note"))
+    {
+      setRoomFieldCommand(str.section(' ', 1), R_NOTE);
+      return false;
+    }
 
     if (str.startsWith("_open"))   {dooraction = true; daction = DAT_OPEN;}
     else
@@ -974,6 +979,9 @@ bool AbstractParser::parseUserCommands(QString& command)
       emit sendToUser((QByteArray)"  _boat         - toggle a boat in the room\r\n");
       emit sendToUser((QByteArray)"  _attention    - toggle an attention flag in the room\r\n");
       emit sendToUser((QByteArray)"  _watch        - toggle a watchable spot in the room\r\n"); 
+
+      emit sendToUser((QByteArray)"\r\nMiscellaneous commands:\r\n");
+      emit sendToUser((QByteArray)"  _note [note]         - set a note in the room\r\n");
 
       emit sendToUser((QByteArray)"\r\n");
 
@@ -1645,7 +1653,7 @@ void AbstractParser::toggleDoorFlagCommand(uint flag, DirectionType direction)
   sendPromptToUser();
 }
 
-void AbstractParser::setRoomFieldCommand(uint flag, uint field)
+void AbstractParser::setRoomFieldCommand(const QVariant & flag, uint field)
 {
   Coordinate c;
   QList<Coordinate> cl = m_mapData->getPath(queue);

--- a/src/parser/abstractparser.h
+++ b/src/parser/abstractparser.h
@@ -135,7 +135,7 @@ protected:
   void nameDoorCommand(QString doorname, DirectionType direction);
   void toggleDoorFlagCommand(uint flag, DirectionType direction);
   void toggleExitFlagCommand(uint flag, DirectionType direction);
-  void setRoomFieldCommand(uint flag, uint field);
+  void setRoomFieldCommand(const QVariant & flag, uint field);
   void toggleRoomFlagCommand(uint flag, uint field);
 
   //utility functions

--- a/src/parser/abstractparser.h
+++ b/src/parser/abstractparser.h
@@ -138,6 +138,8 @@ protected:
   void setRoomFieldCommand(const QVariant & flag, uint field);
   void toggleRoomFlagCommand(uint flag, uint field);
 
+  void printRoomInfo(uint fieldset);
+
   //utility functions
   QString& removeAnsiMarks(QString& str);
 


### PR DESCRIPTION
This adds two new commands: _note to set a note in the current room, and _pnote to print the current note.

Also makes _pdynamic and _pstatic work; they'd previously bitrotted to print nothing.