### PR TITLE
Shortest path directions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,7 @@ set(mmapper_SRCS
     mainwindow/roomeditattrdlg.cpp
     mapdata/customaction.cpp
     mapdata/roomfilter.cpp
+    mapdata/shortestpath.cpp
     mapdata/mapdata.cpp
     mapdata/mmapper2exit.cpp
     mapdata/mmapper2room.cpp
@@ -95,6 +96,7 @@ set(mmapper_MOC_HDRS
     mainwindow/roomeditattrdlg.h
     mapdata/mapdata.h
     mapdata/roomfilter.h
+    mapdata/shortestpath.h
     mapfrontend/mapfrontend.h
     mapstorage/abstractmapstorage.h
     mapstorage/mapstorage.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ set(mmapper_SRCS
     mainwindow/mainwindow.cpp
     mainwindow/roomeditattrdlg.cpp
     mapdata/customaction.cpp
+    mapdata/roomfilter.cpp
     mapdata/mapdata.cpp
     mapdata/mmapper2exit.cpp
     mapdata/mmapper2room.cpp
@@ -93,6 +94,7 @@ set(mmapper_MOC_HDRS
     mainwindow/mainwindow.h
     mainwindow/roomeditattrdlg.h
     mapdata/mapdata.h
+    mapdata/roomfilter.h
     mapfrontend/mapfrontend.h
     mapstorage/abstractmapstorage.h
     mapstorage/mapstorage.h

--- a/src/mainwindow/findroomsdlg.cpp
+++ b/src/mainwindow/findroomsdlg.cpp
@@ -69,14 +69,16 @@ void FindRoomsDlg::findClicked()
   m_mapData->lookingForRooms(this, createEvent(CID_UNKNOWN, text, nullString, nullString, 0, 0));
   */
 
+  char kind = PAT_UNK;
   if (nameRadioButton->isChecked())
-    m_mapData->searchNames(this, text, cs);
+    kind = PAT_NAME;
   else if (descRadioButton->isChecked())
-    m_mapData->searchDescriptions(this, text, cs);
+    kind = PAT_DESC;
   else if (exitsRadioButton->isChecked())
-    m_mapData->searchDoorNames(this, text, cs);
+    kind = PAT_EXITS;
   else if (notesRadioButton->isChecked())
-    m_mapData->searchNotes(this, text, cs);
+    kind = PAT_NOTE;
+  m_mapData->genericSearch(this, RoomFilter(text, cs, kind));
 }
 
 void FindRoomsDlg::receiveRoom(RoomAdmin * sender, const Room * room)

--- a/src/mapdata/mapdata.cpp
+++ b/src/mapdata/mapdata.cpp
@@ -385,17 +385,14 @@ void MapData::removeDoorNames()
   }
 }
 
-void MapData::searchDescriptions(RoomRecipient * recipient, QString s, Qt::CaseSensitivity cs)
-{
+void MapData::genericSearch(RoomRecipient * recipient, const RoomFilter &f){
   QMutexLocker locker(&mapLock);
   Room * r = 0;
-
   for(vector<Room *>::iterator i = roomIndex.begin(); i != roomIndex.end(); ++i)
   {
     r = *i;
     if (r) {
-      if (QString((*r)[1].toString()).contains(s, cs))
-      {
+      if (f.filter(r)) {
         locks[r->getId()].insert(recipient);
         recipient->receiveRoom(this, r);
       }
@@ -403,64 +400,11 @@ void MapData::searchDescriptions(RoomRecipient * recipient, QString s, Qt::CaseS
   }
 }
 
-void MapData::searchNames(RoomRecipient * recipient, QString s, Qt::CaseSensitivity cs)
-{
+void MapData::genericSearch(const RoomSelection * in, const RoomFilter &f){
   QMutexLocker locker(&mapLock);
-  Room * r = 0;
-
-  for(vector<Room *>::iterator i = roomIndex.begin(); i != roomIndex.end(); ++i)
-  {
-    r = *i;
-    if (r) {
-      if (QString((*r)[0].toString()).contains(s, cs))
-      {
-        locks[r->getId()].insert(recipient);
-        recipient->receiveRoom(this, r);
-      }
-    }
-  }
-}
-
-void MapData::searchDoorNames(RoomRecipient * recipient, QString s, Qt::CaseSensitivity cs)
-{
-  QMutexLocker locker(&mapLock);
-  Room * r = 0;
-
-  for(vector<Room *>::iterator i = roomIndex.begin(); i != roomIndex.end(); ++i)
-  {
-    r = *i;
-    if (r) {
-      ExitsList exits = r->getExitsList();
-      for(ExitsList::const_iterator exitIter = exits.begin(); exitIter != exits.end(); ++exitIter)
-      {
-        const Exit & e = *exitIter;
-        if (QString((e)[0].toString()).contains(s, cs))
-        {
-          locks[r->getId()].insert(recipient);
-          recipient->receiveRoom(this, r);
-          break;
-        }
-      }
-    }
-  }
-}
-
-void MapData::searchNotes(RoomRecipient * recipient, QString s, Qt::CaseSensitivity cs)
-{
-  QMutexLocker locker(&mapLock);
-  Room * r = 0;
-
-  for(vector<Room *>::iterator i = roomIndex.begin(); i != roomIndex.end(); ++i)
-  {
-    r = *i;
-    if (r) {
-      if (QString((*r)[4].toString()).contains(s, cs))
-      {
-        locks[r->getId()].insert(recipient);
-        recipient->receiveRoom(this, r);
-      }
-    }
-  }
+  RoomSelection * selection = selections[in];
+  assert(selection);
+  genericSearch((RoomRecipient *)selection, f);
 }
 
 MapData::~MapData()

--- a/src/mapdata/mapdata.h
+++ b/src/mapdata/mapdata.h
@@ -30,6 +30,7 @@
 #include "mapfrontend.h"
 #include "abstractparser.h"
 #include "roomfilter.h"
+#include "shortestpath.h"
 
 #include <QLinkedList>
 
@@ -101,6 +102,8 @@ public:
   // search for matches
   void genericSearch(RoomRecipient * recipient, const RoomFilter &f);
   void genericSearch(const RoomSelection * in, const RoomFilter &f);
+
+  void shortestPathSearch(const Room *origin, ShortestPathRecipient * recipient, const RoomFilter &f, int max_hits=-1, double max_dist=0);
 
   // Used in Console Commands
   void removeDoorNames();

--- a/src/mapdata/mapdata.h
+++ b/src/mapdata/mapdata.h
@@ -29,6 +29,7 @@
 
 #include "mapfrontend.h"
 #include "abstractparser.h"
+#include "roomfilter.h"
 
 #include <QLinkedList>
 
@@ -98,10 +99,8 @@ public:
   virtual void clear();
 
   // search for matches
-  void searchDescriptions(RoomRecipient * recipient, QString s, Qt::CaseSensitivity cs);
-  void searchNames(RoomRecipient * recipient, QString s, Qt::CaseSensitivity cs);
-  void searchDoorNames(RoomRecipient * recipient, QString s, Qt::CaseSensitivity cs);
-  void searchNotes(RoomRecipient * recipient, QString s, Qt::CaseSensitivity cs);
+  void genericSearch(RoomRecipient * recipient, const RoomFilter &f);
+  void genericSearch(const RoomSelection * in, const RoomFilter &f);
 
   // Used in Console Commands
   void removeDoorNames();

--- a/src/mapdata/mmapper2exit.cpp
+++ b/src/mapdata/mmapper2exit.cpp
@@ -92,3 +92,15 @@ ExitDirection dirForChar(char dir) {
 	}
 }
 
+char charForDir(ExitDirection dir) {
+  switch (dir) {
+  case ED_NORTH: return 'n';
+  case ED_SOUTH: return 's';
+  case ED_EAST: return 'e';
+  case ED_WEST: return 'w';
+  case ED_UP: return 'u';
+  case ED_DOWN: return 'd';
+  default: return '?';
+  }
+}
+

--- a/src/mapdata/mmapper2exit.h
+++ b/src/mapdata/mmapper2exit.h
@@ -39,6 +39,7 @@ enum ExitDirection { ED_NORTH=0, ED_SOUTH, ED_EAST, ED_WEST, ED_UP,
 ExitDirection opposite(ExitDirection in);
 uint opposite(uint in);
 ExitDirection dirForChar(char dir);
+char charForDir(ExitDirection dir);
 
 typedef class QString DoorName;
 

--- a/src/mapdata/roomfilter.cpp
+++ b/src/mapdata/roomfilter.cpp
@@ -2,7 +2,7 @@
 #include <assert.h>
 #include <errno.h>
 
-const char * RoomFilter::parse_help = "Parse error; format is: [-(name|desc|note|exits|all)] text\r\n";
+const char * RoomFilter::parse_help = "Parse error; format is: [-(name|desc|note|exits|all)] pattern\r\n";
 
 
 bool RoomFilter::parseRoomFilter(const QString & line, RoomFilter &output)

--- a/src/mapdata/roomfilter.cpp
+++ b/src/mapdata/roomfilter.cpp
@@ -1,0 +1,54 @@
+#include "roomfilter.h"
+#include <assert.h>
+#include <errno.h>
+
+const char * RoomFilter::parse_help = "Parse error; format is: [-(name|desc|note|exits|all)] text\r\n";
+
+
+bool RoomFilter::parseRoomFilter(const QString & line, RoomFilter &output)
+{
+  QString pattern = line;
+  char kind = PAT_NAME;
+  if (line.size() >= 2 && line[0] == '-')
+  {
+    QString kindstr = line.section(" ", 0, 0);
+    if (kindstr == "-desc" || kindstr == "-d") kind = PAT_DESC;
+    else if (kindstr == "-name") kind = PAT_NAME;
+    else if (kindstr == "-exits" || kindstr == "-e") kind = PAT_EXITS;
+    else if (kindstr == "-note" || kindstr == "-n") kind = PAT_NOTE;
+    else if (kindstr == "-all" || kindstr == "-a") kind = PAT_ALL;
+    else return false;
+
+    pattern = line.section(" ", 1);
+  }
+  output = RoomFilter(pattern, Qt::CaseInsensitive, kind);
+  return true;
+}
+
+const bool RoomFilter::filter(const Room *r) const
+{
+  if (kind == PAT_DESC)
+    return QString((*r)[1].toString()).contains(pattern, cs);
+  else if (kind == PAT_ALL)
+  {
+    for(auto elt: (*r))
+      if(elt.toString().contains(pattern, cs))
+        return 1;
+    return 0;
+  }
+  else if (kind == PAT_NAME)
+    return QString((*r)[0].toString()).contains(pattern, cs);
+  else if (kind == PAT_NOTE)
+    return QString((*r)[4].toString()).contains(pattern, cs);
+  else if (kind == PAT_EXITS)
+  {
+    ExitsList exits = r->getExitsList();
+    for(ExitsList::const_iterator exitIter = exits.begin(); exitIter != exits.end(); ++exitIter)
+    {
+      const Exit & e = *exitIter;
+      if (QString((e)[0].toString()).contains(pattern, cs))
+        return 1;
+    }
+    return 0;
+  }
+}

--- a/src/mapdata/roomfilter.h
+++ b/src/mapdata/roomfilter.h
@@ -1,0 +1,30 @@
+#ifndef ROOMFILTER_H
+#define ROOMFILTER_H
+
+#include "roomadmin.h"
+#include "component.h"
+
+#include "intermediatenode.h"
+#include "map.h"
+
+enum pattern_kinds {PAT_UNK, PAT_DESC, PAT_NAME, PAT_NOTE, PAT_EXITS, PAT_ALL};
+
+class RoomFilter
+{
+public:
+  RoomFilter() {};
+  RoomFilter(const QString &pattern, const Qt::CaseSensitivity &cs, const char kind) : pattern(pattern), cs(cs), kind(kind) { }
+
+  // Return false on parse failure
+  static bool parseRoomFilter(const QString & line, RoomFilter &output);
+  static const char * parse_help;
+
+  const bool filter(const Room * r) const;
+
+protected:
+  QString pattern;
+  Qt::CaseSensitivity cs;
+  char kind;
+};
+
+#endif

--- a/src/mapdata/shortestpath.cpp
+++ b/src/mapdata/shortestpath.cpp
@@ -1,0 +1,97 @@
+#include "shortestpath.h"
+#include "mmapper2exit.h"
+#include "mmapper2room.h"
+#include "mapdata.h"
+#include<queue>
+
+#include<queue>
+
+// Movement costs per terrain type.
+// Same order as the RoomTerrainType enum.
+// Values taken from https://github.com/nstockton/tintin-mume/blob/master/mapperproxy/mapper/constants.py
+const double TERRAIN_COSTS[] = {1, // undef
+                          0.75, // indoors
+                          0.75, // city
+                          1.5, // field
+                          2.15, // forest
+                          2.45, // hills
+                          2.8, // mountains
+                          2.45, // shallowwater
+                          50.0, // water
+                          60.0, // rapids
+                          100.0, // underwater
+                          0.85, // road
+                          1.5, // brush
+                          0.75, // tunnel
+                          0.75, // cavern
+                          1000.0, // Deathtrap
+                          30.0 // random
+                         };
+
+double getLength(const Exit &e, const Room *curr, const Room *nextr)
+{
+  double cost = TERRAIN_COSTS[getTerrainType(nextr)];
+  uint flags = getFlags(e);
+  if(ISSET(flags, EF_DOOR))
+    cost += 1;
+  if(ISSET(flags, EF_CLIMB))
+    cost += 2;
+  if (getRidableType(nextr) == RRT_NOTRIDABLE) {
+    cost += 3;
+    // One non-ridable room means walking two rooms, plus dismount/mount.
+    if (getRidableType(curr) != RRT_NOTRIDABLE)
+      cost += 4;
+  }
+  if(ISSET(flags, EF_ROAD)) // Not sure if this is appropriate.
+    cost -= 0.1;
+  return cost;
+}
+
+void MapData::shortestPathSearch(const Room *origin, ShortestPathRecipient * recipient, const RoomFilter &f, int max_hits, double max_dist)
+{
+  QMutexLocker locker(&mapLock);
+  QVector<SPNode> sp_nodes;
+  QSet<uint> visited;
+  std::priority_queue<std::pair<double, int> > future_paths;
+  int q = 0;
+  sp_nodes.push_back(SPNode(origin, -1, 0, ED_UNKNOWN));
+  future_paths.push(std::make_pair(0, 0));
+  while(future_paths.size())
+  {
+    int spindex = future_paths.top().second;
+    future_paths.pop();
+    SPNode * spnode = &sp_nodes[spindex];
+    int room_id = spnode->r->getId();
+    if (visited.contains(room_id))
+      continue;
+    visited.insert(room_id);
+    if(f.filter(spnode->r))
+    {
+      recipient->receiveShortestPath(this, sp_nodes, spindex);
+      if (--max_hits == 0)
+        return;
+    }
+    if (max_dist && spnode->dist > max_dist)
+      return;
+    ExitsList exits = spnode->r->getExitsList();
+    for(int dir = 0; dir < exits.size(); dir++)
+    {
+      const Exit & e = exits[dir];
+      std::set<uint>::const_iterator outbegin = e.outBegin();
+      std::set<uint>::const_iterator outend = e.outEnd();
+      if (outbegin == outend) // Not mapped
+        continue;
+      ++outbegin;
+      if (outbegin != outend) // Random, so no clear directions; skip it.
+        continue;
+      if (!(getFlags(e) & EF_EXIT))
+        continue;
+      const Room * nextr = roomIndex[*e.outBegin()];
+      if (visited.contains(nextr->getId()))
+        continue;
+      double length = getLength(e, spnode->r, nextr);
+      sp_nodes.push_back(SPNode(nextr, spindex, spnode->dist + length, (ExitDirection)dir));
+      future_paths.push(std::make_pair(-(spnode->dist + length), sp_nodes.size()-1));
+    }
+  }
+}

--- a/src/mapdata/shortestpath.h
+++ b/src/mapdata/shortestpath.h
@@ -1,0 +1,28 @@
+#ifndef SHORTESTPATH_H
+#define SHORTESTPATH_H
+
+#include "abstractparser.h"
+#include "mmapper2exit.h"
+#include "roomfilter.h"
+#include <QSet>
+
+class SPNode
+{
+public:
+  const Room * r;
+  int parent;
+  double dist;
+  ExitDirection lastdir;
+  SPNode(){};
+  SPNode(const Room *r, const int parent, double dist, ExitDirection lastdir) : r(r), parent(parent), dist(dist), lastdir(lastdir) {}
+};
+
+class ShortestPathRecipient
+{
+public:
+  virtual void receiveShortestPath(RoomAdmin * admin, QVector<SPNode> spnodes, int endpoint) = 0;
+  virtual ~ShortestPathRecipient() {};
+};
+
+
+#endif

--- a/src/mapfrontend/mapfrontend.h
+++ b/src/mapfrontend/mapfrontend.h
@@ -30,6 +30,7 @@
 #include "roomadmin.h"
 #include "component.h"
 
+#include "shortestpath.h"
 #include "intermediatenode.h"
 #include "map.h"
 

--- a/src/mapstorage/basemapsavefilter.cpp
+++ b/src/mapstorage/basemapsavefilter.cpp
@@ -128,7 +128,7 @@ void BaseMapSaveFilter::prepare( ProgressCounter *counter )
   set<uint> considered;
 
   // Seed room
-  m_impl->mapData->searchNames( this, "The Fountain Square", Qt::CaseSensitive );
+  m_impl->mapData->genericSearch( this, RoomFilter("The Fountain Square", Qt::CaseSensitive, PAT_NAME) );
 
   // Walk the whole map through non-hidden exits without recursing
   while ( !m_impl->roomsTodo.empty() )

--- a/src/parser/abstractparser.cpp
+++ b/src/parser/abstractparser.cpp
@@ -32,6 +32,8 @@
 #include "roomselection.h"
 #include "mapdata.h"
 
+#include <unistd.h>
+
 #include <QDesktopServices>
 #include <QUrl>
 
@@ -1283,6 +1285,7 @@ void AbstractParser::offlineCharacterMove(CommandIdType direction)
     }
   }
   m_mapData->unselect(rs1);
+  usleep(40000);
 }
 
 void AbstractParser::sendRoomInfoToUser(const Room* r)

--- a/src/parser/abstractparser.cpp
+++ b/src/parser/abstractparser.cpp
@@ -930,7 +930,7 @@ bool AbstractParser::parseUserCommands(QString& command)
       QString pattern_str = str.section(' ', 1).trimmed();
       if(pattern_str.size() == 0)
       {
-        emit sendToUser("Usage: _search <pattern in quotes> [section to search]\r\n");
+        emit sendToUser("Usage: _dirs [-(name|desc|note|exits|all)] pattern\r\n");
         return false;
       }
       RoomFilter f;
@@ -988,8 +988,8 @@ bool AbstractParser::parseUserCommands(QString& command)
       emit sendToUser((QByteArray)"  _grouphelp - help for group manager console commands\r\n");
 
       emit sendToUser((QByteArray)"\r\nOther commands:\n");
-      emit sendToUser((QByteArray)("  _vote     - vote for MUME on TMC!"));
-      emit sendToUser((QByteArray)"\r\n");
+      emit sendToUser((QByteArray)("  _vote                    - vote for MUME on TMC!\r\n"));
+      emit sendToUser((QByteArray)("  _dirs [-options] pattern - directions to matching rooms\r\n"));
       sendPromptToUser();
       return false;
     }

--- a/src/parser/abstractparser.h
+++ b/src/parser/abstractparser.h
@@ -29,6 +29,7 @@
 
 #include "telnetfilter.h"
 #include "defs.h"
+#include "roomfilter.h"
 
 #include <QQueue>
 #include <QObject>
@@ -173,6 +174,8 @@ protected:
   static const QByteArray emptyByteArray;
 
   QString& latinToAscii(QString& str);
+
+  void dirs_command(RoomFilter f);
 };
 
 #endif


### PR DESCRIPTION
Adds a new command, _dirs, that prints the shortest path to rooms satisfying a condition.

By default it searches the room name, but different flags can give different options.  The format is
`_dirs [-(name|desc|note|exits|all)] search pattern`.

For example,
```
>_dirs caras
Distance 19.45: The Gates of Caras Galadhon
dirs: e3n4e2ne
Distance 20.05: Before the Walls of Caras Galadhon
dirs: e3n2ene3n2e
>_dirs -a ferry
Distance 14.9: Landing in the Forest
dirs: 2en3ese
Distance 64.75: A Landing
dirs: 2s6e
Distance 586.45: Road to Standelf
dirs: nwn6ws3wn6w2s4wsw2sw3s8ws9wn4w11nwn2wu8wsw3de3dn8ws8wswsw2usds3wn3wnws3wu6wswnwnwnwnwn6ws5w2sw4s3wsws2ws3wsws4wsws3ws3wsws4ws2wswsws10ws2wn6wn2wn6wsws4wnwnwnwn3wnw2n9ws3w4s4w2s2ws2ws6wnwnwnwnwnw2n2e2n2w2ne10nwnwnwnwnwn2wnwnw2nwnwnwnwn3wnwn3wn7wn2wn2w2nwn4w3n2w2nw5nw2nw8nw3ne3ne2nene2ne4ne5nenene2ne4ne4ne4n2wnw6nw5n2w4n3wn2wn6wn5ws4wswsw4sws2ws
[...]
```
(Why does the path to the ferry jog north? Because doing so avoids a noride room.)

or you can search for a specific exit, e.g.:
```
>_dirs -e hatch
Distance 13.75: An Abandoned Cellar
dirs: wdse8sw2usw
Distance 16.25: Old Ruins
dirs: wdse8sw2uswu
[...]
```
or search your notes with `_dirs -n` or `_dirs -note`.

The last commit here adds a delay to offline character moving, giving it time to sync up when speedwalking.

[This is a pretty big commit, so you probably want me to reorganize it/conform to the style more; just let me know how.  I also have a similar _search command to highlight rooms, which shares the filter code here and for which I'll submit a PR once this lands.]