### PR TITLE
Search function

### DIFF
--- a/src/display/mapcanvas.cpp
+++ b/src/display/mapcanvas.cpp
@@ -129,6 +129,7 @@ MapCanvas::MapCanvas( MapData *mapData, PrespammedPath* prespammedPath, CGroup* 
     m_infoMarksEditDlg = new InfoMarksEditDlg(mapData, this);
     connect(m_infoMarksEditDlg, SIGNAL(mapChanged()), this, SLOT(update()));
     connect(m_infoMarksEditDlg, SIGNAL(closeEventReceived()), this, SLOT(onInfoMarksEditDlgClose()));
+    connect(m_data, SIGNAL(updateCanvas()), this, SLOT(update()));
 
     memset(m_terrainTextures, 0, sizeof(m_terrainTextures));
     memset(m_roadTextures, 0, sizeof(m_roadTextures));

--- a/src/display/mapcanvas.cpp
+++ b/src/display/mapcanvas.cpp
@@ -937,8 +937,6 @@ void MapCanvas::resizeGL(int width, int height)
         return;
     }
 
-    qDebug() << "resizeGL width " << width << " height " << height;
-
     float swp = m_scaleFactor * (1.0f - ((float)(width - BASESIZEX) / width));
     float shp = m_scaleFactor * (1.0f - ((float)(height - BASESIZEY) / height));
 

--- a/src/mapdata/mapdata.h
+++ b/src/mapdata/mapdata.h
@@ -120,6 +120,7 @@ signals:
   void log( const QString&, const QString& );
   void onDataLoaded();
   void onDataChanged();
+  void updateCanvas();
 
 public slots:
   void setFileName(QString filename){ m_fileName = filename; };

--- a/src/parser/abstractparser.h
+++ b/src/parser/abstractparser.h
@@ -30,6 +30,7 @@
 #include "telnetfilter.h"
 #include "defs.h"
 #include "roomfilter.h"
+#include "roomselection.h"
 
 #include <QQueue>
 #include <QObject>
@@ -88,7 +89,9 @@ class AbstractParser : public QObject
 public:
 
    AbstractParser(MapData*, QObject *parent = 0);
+   ~AbstractParser();
 
+   const RoomSelection *search_rs;
 signals:
   //telnet
   void sendToMud(const QByteArray&);
@@ -177,6 +180,7 @@ protected:
 
   QString& latinToAscii(QString& str);
 
+  void search_command(RoomFilter f);
   void dirs_command(RoomFilter f);
 };
 


### PR DESCRIPTION
Adds a `_search` function similar `_dirs`, except it highlights matching rooms rather than prints directions to them.  I'm not quite sure why selected things are highlighted in red -- maybe it was intended to debug leaks? -- but it seems to work ok.

Addresses #5 (just `_search -n note text`).