### PR TITLE
Fix exits/emulated behavior

### DIFF
--- a/src/expandoracommon/parseevent.cpp
+++ b/src/expandoracommon/parseevent.cpp
@@ -66,3 +66,12 @@ void ParseEvent::countSkipped() {
   }
 }
 
+void ParseEvent::setParsed() {
+  parsedMutex.unlock();
+}
+
+bool ParseEvent::waitForParsed(int timeout) {
+  bool result = parsedMutex.tryLock(timeout);
+  if (result) parsedMutex.unlock();
+  return result;
+}

--- a/src/expandoracommon/parseevent.h
+++ b/src/expandoracommon/parseevent.h
@@ -29,6 +29,7 @@
 #include <deque>
 #include "listcycler.h"
 #include <QVariant>
+#include <QMutex>
 
 class Property;
 
@@ -38,7 +39,7 @@ class Property;
 class ParseEvent : public ListCycler<Property *, std::deque<Property *> >
 {
 public:
-  ParseEvent(uint move) : moveType(move), numSkipped(0) {}
+  ParseEvent(uint move) : moveType(move), numSkipped(0) {parsedMutex.lock();}
   ParseEvent(const ParseEvent & other);
   virtual ~ParseEvent();
   ParseEvent & operator=(const ParseEvent & other);
@@ -49,12 +50,16 @@ public:
   const std::deque<QVariant> & getOptional() const {return optional;}
   uint getMoveType() const {return moveType;}
   uint getNumSkipped() const {return numSkipped;}
-  
+
+  void setParsed();
+  bool waitForParsed(int timeout=-1);
+
 private:
   std::deque<QVariant> optional;
   uint moveType;
   uint numSkipped;
-  
+  QMutex parsedMutex;
+
 };
 
 #endif

--- a/src/parser/abstractparser.cpp
+++ b/src/parser/abstractparser.cpp
@@ -31,6 +31,7 @@
 #include "configuration.h"
 #include "roomselection.h"
 #include "mapdata.h"
+#include "parseevent.h"
 
 #include <unistd.h>
 
@@ -59,7 +60,9 @@ AbstractParser::AbstractParser(MapData* md, QObject *parent)
 
 void AbstractParser::characterMoved(CommandIdType c, const QString& roomName, const QString& dynamicRoomDesc, const QString& staticRoomDesc, ExitsFlagsType exits, PromptFlagsType prompt)
 {
-  emit event(createEvent(c, roomName, dynamicRoomDesc, staticRoomDesc, exits, prompt));
+  ParseEvent *ev = createEvent(c, roomName, dynamicRoomDesc, staticRoomDesc, exits, prompt);
+  emit event(ev);
+  ev->waitForParsed();
 }
 
 void AbstractParser::emptyQueue()
@@ -327,7 +330,7 @@ void AbstractParser::parseExits(QString& str)
   //emit sendToUser(cn);
 }
 
-void AbstractParser::emulateExits()
+void AbstractParser::emulateExits(CommandIdType dir)
 {
   Coordinate c;
 //    QByteArray dn = "";
@@ -336,8 +339,8 @@ void AbstractParser::emulateExits()
   CommandQueue tmpqueue;
 //      bool noDoors = true;
 
-  if (!queue.isEmpty())
-    tmpqueue.enqueue(queue.head());
+  if (dir != CID_NONE)
+    tmpqueue.enqueue(dir);
 
   QList<Coordinate> cl = m_mapData->getPath(tmpqueue);
   if (!cl.isEmpty())

--- a/src/parser/abstractparser.h
+++ b/src/parser/abstractparser.h
@@ -144,7 +144,7 @@ protected:
   //utility functions
   QString& removeAnsiMarks(QString& str);
 
-  void emulateExits();
+  void emulateExits(CommandIdType dir=CID_NONE);
 
   void parseExits(QString& str);
   void parsePrompt(QString& prompt);

--- a/src/pathmachine/pathmachine.cpp
+++ b/src/pathmachine/pathmachine.cpp
@@ -145,6 +145,7 @@ void PathMachine::event(ParseEvent * ev)
     syncing(ev);
     break;
   }
+  ev->setParsed();
 }
 
 void PathMachine::deleteMostLikelyRoom()


### PR DESCRIPTION
Currently, the Exits/emulated: lines are pretty buggy, and often
display information for the wrong room.  The output is printed before
the character's location is synced, so mmapper tries to guess where
the room will be based on the queued movement commands.
Unfortunately, this is pretty problematic:

 * following doesn't work, because the order MUME sends information is
    like:

Arwen Undómiel leaves east.
You follow Arwen Undómiel.
<movement dir=east/><room><name>The Courtyard</name>

m_move is set to CID_EAST on the <movement> tag, but it's enqueued the
line before, on the "You follow" line, at which point it's still
CID_LOOK.

 * Scouting doesn't work, because the queue is prepended with
   CID_SCOUT rather than CID_EAST.

 * Regular movement in the Old Forest doesn't work, because the
   prediction isn't reliable -- even if you go to a recognizable room.

 * Teleporting/scrying don't work, because there's no way to guess the
   location from just the commands.

Instead, the emulated exits should be printed _after_ the pathmachine
syncs up.

This patch makes that happen in XML mode.  It doesn't fix it for
regular mode, but it shouldn't make things worse there either.

It doesn't fix teleport/scry, though.  Scry is hard, since you don't really want to move the character to where you're scrying.  Teleport should be doable in principle, but it's a bit tricky.  Pathmachine doesn't go from ACCEPTED to SYNCING in one try, and I don't know how the parser can identify teleportation to tell pathmachine to releaseAllPaths.  Maybe when you receive a <movement/> tag, it should prioritize nearby rooms (e.g. because of currents) but make sure to sync globally if that doesn't work?