### PR TITLE
Room lighting in prompts now updates older maps

### DIFF
--- a/src/expandoracommon/mmapper2event.cpp
+++ b/src/expandoracommon/mmapper2event.cpp
@@ -58,7 +58,7 @@ ParseEvent * createEvent(const CommandIdType & c, const QString & roomName, cons
   if (promptFlags & PROMPT_FLAGS_VALID)
   {
     char terrain = 0;
-    terrain += (promptFlags & 15); //bit0-3 -> char representation of RoomTerrainType
+    terrain += (promptFlags & (bit1 + bit2 + bit3 + bit4)); //bit0-3 -> char representation of RoomTerrainType
     event->push_back(new Property(QByteArray(1, terrain)));
   }
   else

--- a/src/mainwindow/findroomsdlg.h
+++ b/src/mainwindow/findroomsdlg.h
@@ -29,14 +29,12 @@
 #include <QDialog>
 #include "ui_findroomsdlg.h"
 #include "roomrecipient.h"
+#include "abstractparser.h"
 
 class MapData;
 class MapCanvas;
 class QShortcut;
 class RoomSelection;
-
-typedef quint32 ExitsFlagsType;
-typedef quint16 PromptFlagsType;
 
 class FindRoomsDlg : public QDialog, public RoomRecipient, private Ui::FindRoomsDlg
 {

--- a/src/mapdata/roomfactory.cpp
+++ b/src/mapdata/roomfactory.cpp
@@ -180,6 +180,18 @@ ComparisonResult RoomFactory::compareWeakProps(const Room * room, const ParseEve
   bool different = false;
   bool tolerance = false;
   ExitsFlagsType eFlags = getExitFlags(event);
+  PromptFlagsType pFlags = getPromptFlags(event);
+
+  if (pFlags & PROMPT_FLAGS_VALID)
+  {
+      const RoomLightType lightType = getLightType(room);
+      if ((pFlags & SUN_ROOM) && lightType != RLT_LIT) {
+          tolerance = true;
+      }
+      else if ((pFlags & DARK_ROOM) && lightType != RLT_DARK) {
+          tolerance = true;
+      }
+  }
   if (eFlags & EXITS_FLAGS_VALID)
   {
     for (uint dir = 0; dir < 6; ++dir)
@@ -228,7 +240,7 @@ void RoomFactory::update(Room * room, const ParseEvent * event) const
   (*room)[R_DYNAMICDESC] = getRoomDesc(event);
 
   ExitsFlagsType eFlags = getExitFlags(event);
-  PromptFlagsType rt = getPromptFlags(event);
+  PromptFlagsType pFlags = getPromptFlags(event);
   if (eFlags & EXITS_FLAGS_VALID)
   {
     eFlags ^= EXITS_FLAGS_VALID;
@@ -266,12 +278,16 @@ void RoomFactory::update(Room * room, const ParseEvent * event) const
   else
     room->setOutDated();
 
-  if (rt & PROMPT_FLAGS_VALID)
+  if (pFlags & PROMPT_FLAGS_VALID)
   {
+    PromptFlagsType rt = pFlags;
     rt &= (bit1 + bit2 + bit3 + bit4);
     (*room)[R_TERRAINTYPE] = (RoomTerrainType)rt;
-    if (rt & SUN_ROOM) {
+    if (pFlags & SUN_ROOM) {
       (*room)[R_LIGHTTYPE] = RLT_LIT;
+    }
+    else if (pFlags & DARK_ROOM) {
+      (*room)[R_LIGHTTYPE] = RLT_DARK;
     }
   }
   else

--- a/src/parser/abstractparser.cpp
+++ b/src/parser/abstractparser.cpp
@@ -151,6 +151,13 @@ void AbstractParser::parseExits(QString& str)
     case 92: climb=true;break;    /* \ */
     case 123: portal=true;break;  /* { */
 
+    case 32: // empty space means reset for next exit
+        doors=false;
+        road=false;
+        climb=false;
+        portal=false;
+        break;
+
     case 110:  // n
       if ( (i+2)<length && (str.at(i+2).toLatin1()) == 'r') //north
         {

--- a/src/parser/abstractparser.cpp
+++ b/src/parser/abstractparser.cpp
@@ -106,26 +106,26 @@ void AbstractParser::parsePrompt(QString& prompt){
   case 42: index++;m_promptFlags=SUN_ROOM;break; // *  indoor/cloudy sun
   case 33: index++;break;                        // !  artifical light
   case 41: index++;m_promptFlags=SUN_ROOM;break; // )  moonlight
-  case 111:index++;break;                        // o  darkness
+  case 111:index++;m_promptFlags=DARK_ROOM;break;// o  darkness
   default:;
   }
 
   switch ( sv = (int)(prompt[index]).toLatin1() )
   {
-    case 91: SET(m_promptFlags,RTT_INDOORS); break; // [  // indoors
-    case 35: SET(m_promptFlags,RTT_CITY); break; // #  // city
-    case 46: SET(m_promptFlags,RTT_FIELD); break; // .  // field
-    case 102: SET(m_promptFlags,RTT_FOREST); break; // f  // forest
-    case 40: SET(m_promptFlags,RTT_HILLS); break; // (  // hills
+    case 91: SET(m_promptFlags,RTT_INDOORS); break;   // [  // indoors
+    case 35: SET(m_promptFlags,RTT_CITY); break;      // #  // city
+    case 46: SET(m_promptFlags,RTT_FIELD); break;     // .  // field
+    case 102: SET(m_promptFlags,RTT_FOREST); break;   // f  // forest
+    case 40: SET(m_promptFlags,RTT_HILLS); break;     // (  // hills
     case 60: SET(m_promptFlags,RTT_MOUNTAINS); break; // <  // mountains
-    case 37: SET(m_promptFlags,RTT_SHALLOW); break; // %  // shallow
-    case 126:SET(m_promptFlags,RTT_WATER); break; // ~w  // water
-    case 87: SET(m_promptFlags,RTT_RAPIDS); break; // W  // rapids
-    case 85: SET(m_promptFlags,RTT_UNDERWATER); break; // U  // underwater
-    case 43: SET(m_promptFlags,RTT_ROAD); break; // +  // road
-    case 61: SET(m_promptFlags,RTT_TUNNEL); break; // =  // tunnel
-    case 79: SET(m_promptFlags,RTT_CAVERN); break; // O  // cavern
-    case 58: SET(m_promptFlags,RTT_BRUSH); break; // :  // brush
+    case 37: SET(m_promptFlags,RTT_SHALLOW); break;   // %  // shallow
+    case 126:SET(m_promptFlags,RTT_WATER); break;     // ~  // water
+    case 87: SET(m_promptFlags,RTT_RAPIDS); break;    // W  // rapids
+    case 85: SET(m_promptFlags,RTT_UNDERWATER); break;// U  // underwater
+    case 43: SET(m_promptFlags,RTT_ROAD); break;      // +  // road
+    case 61: SET(m_promptFlags,RTT_TUNNEL); break;    // =  // tunnel
+    case 79: SET(m_promptFlags,RTT_CAVERN); break;    // O  // cavern
+    case 58: SET(m_promptFlags,RTT_BRUSH); break;     // :  // brush
     default:;
   }
   SET(m_promptFlags,PROMPT_FLAGS_VALID);
@@ -168,7 +168,7 @@ void AbstractParser::parseExits(QString& str)
 	  if (road){
 	    SET(m_exitsFlags,ROAD_N);
 	    road=false;
-	  }
+         }
         }
       else
 	i+=4;  //none
@@ -329,8 +329,6 @@ void AbstractParser::parseExits(QString& str)
     }
 
   emit sendToUser(str.toLatin1()+cn);
-  //emit sendToUser(str.toLatin1()+QByteArray("\r\n"));
-  //emit sendToUser(cn);
 }
 
 void AbstractParser::emulateExits()

--- a/src/parser/abstractparser.h
+++ b/src/parser/abstractparser.h
@@ -76,10 +76,11 @@ enum DoorActionType { DAT_OPEN, DAT_CLOSE, DAT_LOCK, DAT_UNLOCK, DAT_PICK, DAT_R
 #define EXITS_FLAGS_VALID bit25
 typedef quint32 ExitsFlagsType;
 
-// 0-3 terrain type
-#define PROMPT_FLAGS_VALID bit8
-#define SUN_ROOM bit9
-typedef quint16 PromptFlagsType;
+// 0-3 terrain type (bit1 through bit4)
+#define SUN_ROOM bit5
+#define DARK_ROOM bit6
+#define PROMPT_FLAGS_VALID bit7
+typedef quint8 PromptFlagsType;
 
 typedef QQueue<CommandIdType> CommandQueue;
 


### PR DESCRIPTION
If your prompt has:
* `*` or `!` or `)` means lit
* `o` means dark

This PR begins support for #38