### PR TITLE
Troll exit automapping for directly and indirectly sunlit rooms

### DIFF
--- a/src/display/mapcanvas.cpp
+++ b/src/display/mapcanvas.cpp
@@ -296,7 +296,7 @@ void MapCanvas::forceMapperToRoom() {
         if (Config().m_mapMode == 2)
         {
             const Room *r = tmpSel->values().front();
-            emit charMovedEvent(createEvent( CID_UNKNOWN, getName(r), getDynamicDescription(r), getDescription(r), 0, 0));
+            emit charMovedEvent(createEvent( CID_UNKNOWN, getName(r), getDynamicDescription(r), getDescription(r), 0, 0, 0));
         }
         else
             emit setCurrentRoom(tmpSel->keys().front());
@@ -1842,15 +1842,18 @@ void MapCanvas::drawRoom(const Room *room, const std::vector<Room *> & rooms, co
         RoomMobFlags mf = getMobFlags(room);
         RoomLoadFlags lf = getLoadFlags(room);
 
-        // Make dark rooms look dark
-        if (getLightType(room)==RLT_DARK)
+        // Make dark and troll safe rooms look dark
+        if (getSundeathType(room)==RST_NOSUNDEATH || getLightType(room)==RLT_DARK)
         {
             GLdouble oldcolour[4];
             glGetDoublev(GL_CURRENT_COLOR, oldcolour);
 
             glTranslated(0, 0, 0.005);
 
-            qglColor(Qt::lightGray);
+            if (getLightType(room)==RLT_DARK)
+                qglColor(Qt::darkGray);
+            else
+                qglColor(Qt::lightGray);
             //glColor4d(0.1f, 0.0f, 0.0f, 0.2f);
 
             glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);

--- a/src/expandoracommon/mmapper2event.cpp
+++ b/src/expandoracommon/mmapper2event.cpp
@@ -30,7 +30,7 @@
 
 using namespace std;
 
-ParseEvent * createEvent(const CommandIdType & c, const QString & roomName, const QString & roomDesc, const QString & parsedRoomDesc, const ExitsFlagsType & exitFlags, const PromptFlagsType & promptFlags)
+ParseEvent * createEvent(const CommandIdType & c, const QString & roomName, const QString & roomDesc, const QString & parsedRoomDesc, const ExitsFlagsType & exitFlags, const PromptFlagsType & promptFlags, const ConnectedRoomFlagsType & connectedRoomFlags)
 {
   
   ParseEvent * event = new ParseEvent(c);
@@ -66,6 +66,7 @@ ParseEvent * createEvent(const CommandIdType & c, const QString & roomName, cons
     event->push_back(new Property(true));
   }
   optional.push_back((uint)promptFlags);
+  optional.push_back((uint)connectedRoomFlags);
   event->countSkipped();
   return event;
 }
@@ -81,5 +82,7 @@ ExitsFlagsType getExitFlags(const ParseEvent * e)
   {return e->getOptional()[EV_EXITS].toUInt();}
 PromptFlagsType getPromptFlags(const ParseEvent * e)
   {return e->getOptional()[EV_PROMPT].toUInt();}
+ConnectedRoomFlagsType getConnectedRoomFlags(const ParseEvent * e)
+  {return e->getOptional()[EV_CROOM].toUInt();}
 
 

--- a/src/expandoracommon/mmapper2event.h
+++ b/src/expandoracommon/mmapper2event.h
@@ -40,7 +40,7 @@ class ParseEvent;
 
 ParseEvent * createEvent(const CommandIdType & c, const QString & roomName, const QString & roomDesc, 
                          const QString & parsedRoomDesc, const ExitsFlagsType & exitFlags, 
-                         const PromptFlagsType & promptFlags, const ConnectedRoomFlagsType & connectedRoomFlagsb);
+                         const PromptFlagsType & promptFlags, const ConnectedRoomFlagsType & connectedRoomFlags);
 
 QString getRoomName(const ParseEvent * e);
 

--- a/src/expandoracommon/mmapper2event.h
+++ b/src/expandoracommon/mmapper2event.h
@@ -36,10 +36,11 @@ class ParseEvent;
 #define EV_PDESC 2
 #define EV_EXITS 3
 #define EV_PROMPT 4
+#define EV_CROOM 5
 
 ParseEvent * createEvent(const CommandIdType & c, const QString & roomName, const QString & roomDesc, 
                          const QString & parsedRoomDesc, const ExitsFlagsType & exitFlags, 
-                         const PromptFlagsType & promptFlags);
+                         const PromptFlagsType & promptFlags, const ConnectedRoomFlagsType & connectedRoomFlagsb);
 
 QString getRoomName(const ParseEvent * e);
 
@@ -50,6 +51,7 @@ QString getParsedRoomDesc(const ParseEvent * e);
 ExitsFlagsType getExitFlags(const ParseEvent * e);
   
 PromptFlagsType getPromptFlags(const ParseEvent * e);
-  
+
+ConnectedRoomFlagsType getConnectedRoomFlags(const ParseEvent * e);
 
 #endif

--- a/src/mainwindow/roomeditattrdlg.cpp
+++ b/src/mainwindow/roomeditattrdlg.cpp
@@ -182,6 +182,10 @@ void RoomEditAttrDlg::connectAll()
     connect(darkRadioButton, SIGNAL(toggled(bool)), this, SLOT(darkRadioButtonToggled(bool)));
     connect(lightUndefRadioButton, SIGNAL(toggled(bool)), this, SLOT(lightUndefRadioButtonToggled(bool)));
 
+    connect(sundeathRadioButton, SIGNAL(toggled(bool)), this, SLOT(sundeathRadioButtonToggled(bool)));
+    connect(noSundeathRadioButton, SIGNAL(toggled(bool)), this, SLOT(noSundeathRadioButtonToggled(bool)));
+    connect(sundeathUndefRadioButton, SIGNAL(toggled(bool)), this, SLOT(sundeathUndefRadioButtonToggled(bool)));
+
 	connect(mobFlagsListWidget, SIGNAL(itemChanged(QListWidgetItem*)), this, SLOT(mobFlagsListItemChanged(QListWidgetItem*)));
 	connect(loadFlagsListWidget, SIGNAL(itemChanged(QListWidgetItem*)), this, SLOT(loadFlagsListItemChanged(QListWidgetItem*)));
 
@@ -745,6 +749,19 @@ void RoomEditAttrDlg::updateDialog(const Room *r)
 				lightUndefRadioButton->setChecked(true);
 				break;
 		}
+
+        switch (getSundeathType(r))
+        {
+            case RST_NOSUNDEATH:
+                noSundeathRadioButton->setChecked(true);
+                break;
+            case RST_SUNDEATH:
+                sundeathRadioButton->setChecked(true);
+                break;
+            case RST_UNDEFINED:
+                sundeathUndefRadioButton->setChecked(true);
+                break;
+        }
 	}
 
 	connectAll();
@@ -955,6 +972,51 @@ void RoomEditAttrDlg::lightUndefRadioButtonToggled(bool val)
 	}
 }
 
+
+void RoomEditAttrDlg::sundeathRadioButtonToggled(bool val)
+{
+    if (val)
+    {
+        const Room* r = getSelectedRoom();
+        if (r)
+            m_mapData->execute(new SingleRoomAction(new UpdateRoomField(RST_SUNDEATH, R_SUNDEATHTYPE), r->getId()), m_roomSelection);
+        else
+            m_mapData->execute(new GroupAction(new UpdateRoomField(RST_SUNDEATH, R_SUNDEATHTYPE), m_roomSelection), m_roomSelection);
+
+        emit mapChanged();
+        updateDialog( getSelectedRoom() );
+    }
+}
+
+void RoomEditAttrDlg::noSundeathRadioButtonToggled(bool val)
+{
+    if (val)
+    {
+        const Room* r = getSelectedRoom();
+        if (r)
+            m_mapData->execute(new SingleRoomAction(new UpdateRoomField(RST_NOSUNDEATH, R_SUNDEATHTYPE), r->getId()), m_roomSelection);
+        else
+            m_mapData->execute(new GroupAction(new UpdateRoomField(RST_NOSUNDEATH, R_SUNDEATHTYPE), m_roomSelection), m_roomSelection);
+
+        emit mapChanged();
+        updateDialog( getSelectedRoom() );
+    }
+}
+
+void RoomEditAttrDlg::sundeathUndefRadioButtonToggled(bool val)
+{
+    if (val)
+    {
+        const Room* r = getSelectedRoom();
+        if (r)
+            m_mapData->execute(new SingleRoomAction(new UpdateRoomField(RST_UNDEFINED, R_SUNDEATHTYPE), r->getId()), m_roomSelection);
+        else
+            m_mapData->execute(new GroupAction(new UpdateRoomField(RST_UNDEFINED, R_SUNDEATHTYPE), m_roomSelection), m_roomSelection);
+
+        emit mapChanged();
+        updateDialog( getSelectedRoom() );
+    }
+}
 
 void RoomEditAttrDlg::mobFlagsListItemChanged(QListWidgetItem* item)
 {

--- a/src/mainwindow/roomeditattrdlg.cpp
+++ b/src/mainwindow/roomeditattrdlg.cpp
@@ -60,7 +60,22 @@ RoomEditAttrDlg::RoomEditAttrDlg(QWidget *parent)
 	mobListItems[13] = (QListWidgetItem*) new QListWidgetItem("Quest mob");
 	mobListItems[14] = (QListWidgetItem*) new QListWidgetItem("Any mob");
 	mobListItems[15] = NULL;
-
+    mobListItems[16] = NULL;
+    mobListItems[17] = NULL;
+    mobListItems[18] = NULL;
+    mobListItems[19] = NULL;
+    mobListItems[20] = NULL;
+    mobListItems[21] = NULL;
+    mobListItems[22] = NULL;
+    mobListItems[23] = NULL;
+    mobListItems[24] = NULL;
+    mobListItems[25] = NULL;
+    mobListItems[26] = NULL;
+    mobListItems[27] = NULL;
+    mobListItems[28] = NULL;
+    mobListItems[29] = NULL;
+    mobListItems[30] = NULL;
+    mobListItems[31] = NULL;
 	mobFlagsListWidget->clear();
 	for (int i=0; i<15; i++)
 	{
@@ -85,7 +100,21 @@ RoomEditAttrDlg::RoomEditAttrDlg(QWidget *parent)
 	loadListItems[14] = (QListWidgetItem*) new QListWidgetItem("Attention");
 	loadListItems[15] = (QListWidgetItem*) new QListWidgetItem("Tower");
 	loadListItems[16] = NULL;
-
+    loadListItems[17] = NULL;
+    loadListItems[18] = NULL;
+    loadListItems[19] = NULL;
+    loadListItems[20] = NULL;
+    loadListItems[21] = NULL;
+    loadListItems[22] = NULL;
+    loadListItems[23] = NULL;
+    loadListItems[24] = NULL;
+    loadListItems[25] = NULL;
+    loadListItems[26] = NULL;
+    loadListItems[27] = NULL;
+    loadListItems[28] = NULL;
+    loadListItems[29] = NULL;
+    loadListItems[30] = NULL;
+    loadListItems[31] = NULL;
 	loadFlagsListWidget->clear();
 	for (int i=0; i<16; i++)
 	{
@@ -101,10 +130,16 @@ RoomEditAttrDlg::RoomEditAttrDlg(QWidget *parent)
 	exitListItems[5] = (QListWidgetItem*) new QListWidgetItem("Special");
 	exitListItems[6] = (QListWidgetItem*) new QListWidgetItem("No match");
 	exitListItems[7] = (QListWidgetItem*) new QListWidgetItem("Flow dir"); // Added in schema 040
-  exitListItems[8] = NULL; // Don't add an item here: file schema doesn't support value > 7
-
+    exitListItems[8] = NULL;
+    exitListItems[9] = NULL;
+    exitListItems[10] = NULL;
+    exitListItems[11] = NULL;
+    exitListItems[12] = NULL;
+    exitListItems[13] = NULL;
+    exitListItems[14] = NULL;
+    exitListItems[15] = NULL;
 	exitFlagsListWidget->clear();
-	for (int i=0; i<8; i++)
+    for (int i=0; i<8; i++)
 	{
 		exitListItems[i]->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled);
 		exitFlagsListWidget->addItem(exitListItems[i]);
@@ -502,9 +537,8 @@ void RoomEditAttrDlg::updateDialog(const Room *r)
 		else
 			exitListItems[7]->setCheckState(Qt::Unchecked);
 
-		roomNoteTextEdit->clear();
-		roomNoteTextEdit->setEnabled(false);
-
+        roomNoteTextEdit->clear();
+        roomNoteTextEdit->setEnabled(false);
 
 		int index = 0;
 		while(loadListItems[index]!=NULL)

--- a/src/mainwindow/roomeditattrdlg.h
+++ b/src/mainwindow/roomeditattrdlg.h
@@ -109,11 +109,11 @@ private:
 	uint getSelectedExit();
 	void updateDialog(const Room *r);
 
-	QListWidgetItem* loadListItems[20];
-	QListWidgetItem* mobListItems[20];
+    QListWidgetItem* loadListItems[31];
+    QListWidgetItem* mobListItems[31];
 
-	QListWidgetItem* exitListItems[20];
-	QListWidgetItem* doorListItems[20];
+    QListWidgetItem* exitListItems[15];
+    QListWidgetItem* doorListItems[15];
 
 	const RoomSelection* 	m_roomSelection;
     MapData* 		        m_mapData;

--- a/src/mainwindow/roomeditattrdlg.h
+++ b/src/mainwindow/roomeditattrdlg.h
@@ -67,6 +67,10 @@ public slots:
 	void darkRadioButtonToggled(bool);
 	void lightUndefRadioButtonToggled(bool);
 
+    void noSundeathRadioButtonToggled(bool);
+    void sundeathRadioButtonToggled(bool);
+    void sundeathUndefRadioButtonToggled(bool);
+
 	void mobFlagsListItemChanged(QListWidgetItem*);
 	void loadFlagsListItemChanged(QListWidgetItem*);
 
@@ -77,7 +81,7 @@ public slots:
 	void doorNameLineEditTextChanged(QString);
 	void doorFlagsListItemChanged(QListWidgetItem*);
 
-  void toggleHiddenDoor();
+    void toggleHiddenDoor();
 
 	//terrain tab
 	void terrainToolButtonToggled(bool);
@@ -112,9 +116,9 @@ private:
 	QListWidgetItem* doorListItems[20];
 
 	const RoomSelection* 	m_roomSelection;
-	MapData* 		          m_mapData;
+    MapData* 		        m_mapData;
 	MapCanvas* 		        m_mapCanvas;
-  QShortcut*            m_hiddenShortcut;
+    QShortcut*              m_hiddenShortcut;
 };
 
 

--- a/src/mainwindow/roomeditattrdlg.ui
+++ b/src/mainwindow/roomeditattrdlg.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>541</width>
+    <width>564</width>
     <height>595</height>
    </rect>
   </property>
@@ -30,7 +30,16 @@
        <string>Selection</string>
       </attribute>
       <layout class="QGridLayout">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>9</number>
+       </property>
+       <property name="topMargin">
+        <number>9</number>
+       </property>
+       <property name="rightMargin">
+        <number>9</number>
+       </property>
+       <property name="bottomMargin">
         <number>9</number>
        </property>
        <property name="spacing">
@@ -88,258 +97,31 @@
       </layout>
      </widget>
      <widget class="QWidget" name="attributesTab">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
       <attribute name="title">
        <string>Attributes</string>
       </attribute>
       <layout class="QGridLayout">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>9</number>
+       </property>
+       <property name="topMargin">
+        <number>9</number>
+       </property>
+       <property name="rightMargin">
+        <number>9</number>
+       </property>
+       <property name="bottomMargin">
         <number>9</number>
        </property>
        <property name="spacing">
         <number>6</number>
        </property>
-       <item row="0" column="0" colspan="2">
-        <widget class="QGroupBox" name="rideGroupBox">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>84</width>
-           <height>103</height>
-          </size>
-         </property>
-         <property name="title">
-          <string>Ridable</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="flat">
-          <bool>false</bool>
-         </property>
-         <property name="checkable">
-          <bool>false</bool>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-         <layout class="QGridLayout">
-          <property name="margin">
-           <number>9</number>
-          </property>
-          <property name="spacing">
-           <number>6</number>
-          </property>
-          <item row="2" column="0">
-           <widget class="QRadioButton" name="noRideRadioButton">
-            <property name="text">
-             <string>No-Ride</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QRadioButton" name="ridableRadioButton">
-            <property name="text">
-             <string>Ridable</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QRadioButton" name="rideUndefRadioButton">
-            <property name="text">
-             <string>Undefined</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="0" column="2" colspan="2">
-        <widget class="QGroupBox" name="teleportGroupBox">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>84</width>
-           <height>103</height>
-          </size>
-         </property>
-         <property name="title">
-          <string>Teleport</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="flat">
-          <bool>false</bool>
-         </property>
-         <property name="checkable">
-          <bool>false</bool>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-         <layout class="QVBoxLayout">
-          <property name="spacing">
-           <number>3</number>
-          </property>
-          <property name="margin">
-           <number>3</number>
-          </property>
-          <item>
-           <widget class="QRadioButton" name="portUndefRadioButton">
-            <property name="text">
-             <string>Undefined</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QRadioButton" name="portableRadioButton">
-            <property name="text">
-             <string>Portable</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QRadioButton" name="noPortRadioButton">
-            <property name="text">
-             <string>No-Port</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="0" column="4" colspan="2">
-        <widget class="QGroupBox" name="lightGroupBox">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>84</width>
-           <height>103</height>
-          </size>
-         </property>
-         <property name="title">
-          <string>Light</string>
-         </property>
-         <layout class="QVBoxLayout">
-          <property name="spacing">
-           <number>3</number>
-          </property>
-          <property name="margin">
-           <number>3</number>
-          </property>
-          <item>
-           <widget class="QRadioButton" name="lightUndefRadioButton">
-            <property name="text">
-             <string>Undefined</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QRadioButton" name="darkRadioButton">
-            <property name="text">
-             <string>Dark</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QRadioButton" name="litRadioButton">
-            <property name="text">
-             <string>Lit</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="0" column="6" colspan="2">
-        <widget class="QGroupBox" name="alignGroupBox">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>84</width>
-           <height>128</height>
-          </size>
-         </property>
-         <property name="title">
-          <string>Align</string>
-         </property>
-         <layout class="QVBoxLayout">
-          <property name="spacing">
-           <number>3</number>
-          </property>
-          <property name="margin">
-           <number>3</number>
-          </property>
-          <item>
-           <widget class="QRadioButton" name="alignUndefRadioButton">
-            <property name="text">
-             <string>Undefined</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QRadioButton" name="neutralRadioButton">
-            <property name="text">
-             <string>Neutral</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QRadioButton" name="goodRadioButton">
-            <property name="text">
-             <string>Good</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QRadioButton" name="evilRadioButton">
-            <property name="text">
-             <string>Evil</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="1" column="0" colspan="4">
-        <widget class="QLabel" name="label_21">
-         <property name="text">
-          <string>Load flags</string>
-         </property>
-        </widget>
-       </item>
        <item row="1" column="4" colspan="2">
         <widget class="QLabel" name="label_22">
          <property name="text">
@@ -347,45 +129,7 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="0" colspan="4">
-        <widget class="QListWidget" name="loadFlagsListWidget">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>100</width>
-           <height>100</height>
-          </size>
-         </property>
-         <property name="selectionMode">
-          <enum>QAbstractItemView::MultiSelection</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="4" colspan="3">
-        <widget class="QListWidget" name="mobFlagsListWidget">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>100</width>
-           <height>100</height>
-          </size>
-         </property>
-         <property name="selectionMode">
-          <enum>QAbstractItemView::MultiSelection</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="7">
+       <item row="2" column="8">
         <widget class="QFrame" name="frame">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -400,7 +144,16 @@
           <enum>QFrame::Raised</enum>
          </property>
          <layout class="QGridLayout">
-          <property name="margin">
+          <property name="leftMargin">
+           <number>9</number>
+          </property>
+          <property name="topMargin">
+           <number>9</number>
+          </property>
+          <property name="rightMargin">
+           <number>9</number>
+          </property>
+          <property name="bottomMargin">
            <number>9</number>
           </property>
           <property name="spacing">
@@ -431,7 +184,240 @@
          </layout>
         </widget>
        </item>
-       <item row="3" column="0" colspan="8">
+       <item row="1" column="0" colspan="4">
+        <widget class="QLabel" name="label_21">
+         <property name="text">
+          <string>Load flags</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2" colspan="2">
+        <widget class="QGroupBox" name="teleportGroupBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>103</height>
+          </size>
+         </property>
+         <property name="title">
+          <string>Teleport</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="flat">
+          <bool>false</bool>
+         </property>
+         <property name="checkable">
+          <bool>false</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+         <layout class="QVBoxLayout">
+          <property name="spacing">
+           <number>3</number>
+          </property>
+          <property name="leftMargin">
+           <number>3</number>
+          </property>
+          <property name="topMargin">
+           <number>3</number>
+          </property>
+          <property name="rightMargin">
+           <number>3</number>
+          </property>
+          <property name="bottomMargin">
+           <number>3</number>
+          </property>
+          <item>
+           <widget class="QRadioButton" name="portUndefRadioButton">
+            <property name="text">
+             <string>Undefined</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="portableRadioButton">
+            <property name="text">
+             <string>Portable</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="noPortRadioButton">
+            <property name="text">
+             <string>No-Port</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="2" column="4" colspan="4">
+        <widget class="QListWidget" name="mobFlagsListWidget">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>100</height>
+          </size>
+         </property>
+         <property name="selectionMode">
+          <enum>QAbstractItemView::MultiSelection</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0" colspan="2">
+        <widget class="QGroupBox" name="rideGroupBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>103</height>
+          </size>
+         </property>
+         <property name="title">
+          <string>Ridable</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="flat">
+          <bool>false</bool>
+         </property>
+         <property name="checkable">
+          <bool>false</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+         <layout class="QGridLayout">
+          <property name="leftMargin">
+           <number>3</number>
+          </property>
+          <property name="topMargin">
+           <number>3</number>
+          </property>
+          <property name="rightMargin">
+           <number>3</number>
+          </property>
+          <property name="bottomMargin">
+           <number>3</number>
+          </property>
+          <property name="spacing">
+           <number>3</number>
+          </property>
+          <item row="2" column="0">
+           <widget class="QRadioButton" name="noRideRadioButton">
+            <property name="text">
+             <string>No-Ride</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QRadioButton" name="ridableRadioButton">
+            <property name="text">
+             <string>Ridable</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QRadioButton" name="rideUndefRadioButton">
+            <property name="text">
+             <string>Undefined</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="0" column="6">
+        <widget class="QGroupBox" name="sunGroupBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>103</height>
+          </size>
+         </property>
+         <property name="title">
+          <string>Sundeath</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <property name="spacing">
+           <number>3</number>
+          </property>
+          <property name="leftMargin">
+           <number>3</number>
+          </property>
+          <property name="topMargin">
+           <number>3</number>
+          </property>
+          <property name="rightMargin">
+           <number>3</number>
+          </property>
+          <property name="bottomMargin">
+           <number>3</number>
+          </property>
+          <item>
+           <widget class="QRadioButton" name="sundeathUndefRadioButton">
+            <property name="text">
+             <string>Undefined</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="noSundeathRadioButton">
+            <property name="text">
+             <string>Safe</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="sundeathRadioButton">
+            <property name="text">
+             <string>Sundeath</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="3" column="0" colspan="9">
         <widget class="QFrame" name="exitsFrame">
          <property name="frameShape">
           <enum>QFrame::Box</enum>
@@ -440,7 +426,16 @@
           <enum>QFrame::Raised</enum>
          </property>
          <layout class="QGridLayout">
-          <property name="margin">
+          <property name="leftMargin">
+           <number>9</number>
+          </property>
+          <property name="topMargin">
+           <number>9</number>
+          </property>
+          <property name="rightMargin">
+           <number>9</number>
+          </property>
+          <property name="bottomMargin">
            <number>9</number>
           </property>
           <property name="spacing">
@@ -614,7 +609,16 @@
              <enum>QFrame::Raised</enum>
             </property>
             <layout class="QGridLayout">
-             <property name="margin">
+             <property name="leftMargin">
+              <number>9</number>
+             </property>
+             <property name="topMargin">
+              <number>9</number>
+             </property>
+             <property name="rightMargin">
+              <number>9</number>
+             </property>
+             <property name="bottomMargin">
               <number>9</number>
              </property>
              <property name="spacing">
@@ -664,6 +668,158 @@
          </layout>
         </widget>
        </item>
+       <item row="0" column="7" colspan="2">
+        <widget class="QGroupBox" name="alignGroupBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>128</height>
+          </size>
+         </property>
+         <property name="title">
+          <string>Align</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <layout class="QVBoxLayout">
+          <property name="spacing">
+           <number>3</number>
+          </property>
+          <property name="leftMargin">
+           <number>3</number>
+          </property>
+          <property name="topMargin">
+           <number>3</number>
+          </property>
+          <property name="rightMargin">
+           <number>3</number>
+          </property>
+          <property name="bottomMargin">
+           <number>3</number>
+          </property>
+          <item>
+           <widget class="QRadioButton" name="alignUndefRadioButton">
+            <property name="text">
+             <string>Undefined</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="neutralRadioButton">
+            <property name="text">
+             <string>Neutral</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="goodRadioButton">
+            <property name="text">
+             <string>Good</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="evilRadioButton">
+            <property name="text">
+             <string>Evil</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="2" column="0" colspan="4">
+        <widget class="QListWidget" name="loadFlagsListWidget">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>100</height>
+          </size>
+         </property>
+         <property name="selectionMode">
+          <enum>QAbstractItemView::MultiSelection</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="4" colspan="2">
+        <widget class="QGroupBox" name="lightGroupBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>103</height>
+          </size>
+         </property>
+         <property name="title">
+          <string>Light</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <layout class="QVBoxLayout">
+          <property name="spacing">
+           <number>3</number>
+          </property>
+          <property name="leftMargin">
+           <number>3</number>
+          </property>
+          <property name="topMargin">
+           <number>3</number>
+          </property>
+          <property name="rightMargin">
+           <number>3</number>
+          </property>
+          <property name="bottomMargin">
+           <number>3</number>
+          </property>
+          <item>
+           <widget class="QRadioButton" name="lightUndefRadioButton">
+            <property name="text">
+             <string>Undefined</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="darkRadioButton">
+            <property name="text">
+             <string>Dark</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="litRadioButton">
+            <property name="text">
+             <string>Lit</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="terrainTab">
@@ -671,7 +827,16 @@
        <string>Terrain</string>
       </attribute>
       <layout class="QGridLayout">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>9</number>
+       </property>
+       <property name="topMargin">
+        <number>9</number>
+       </property>
+       <property name="rightMargin">
+        <number>9</number>
+       </property>
+       <property name="bottomMargin">
         <number>9</number>
        </property>
        <property name="spacing">
@@ -686,7 +851,16 @@
           <bool>false</bool>
          </property>
          <layout class="QGridLayout">
-          <property name="margin">
+          <property name="leftMargin">
+           <number>9</number>
+          </property>
+          <property name="topMargin">
+           <number>9</number>
+          </property>
+          <property name="rightMargin">
+           <number>9</number>
+          </property>
+          <property name="bottomMargin">
            <number>9</number>
           </property>
           <property name="spacing">
@@ -1185,7 +1359,16 @@
        <property name="spacing">
         <number>6</number>
        </property>
-       <property name="margin">
+       <property name="leftMargin">
+        <number>9</number>
+       </property>
+       <property name="topMargin">
+        <number>9</number>
+       </property>
+       <property name="rightMargin">
+        <number>9</number>
+       </property>
+       <property name="bottomMargin">
         <number>9</number>
        </property>
        <item>
@@ -1239,7 +1422,6 @@
   </layout>
  </widget>
  <resources>
-  <include location="../resources/mmapper2.qrc"/>
   <include location="../resources/mmapper2.qrc"/>
  </resources>
  <connections/>

--- a/src/mapdata/mmapper2exit.h
+++ b/src/mapdata/mmapper2exit.h
@@ -35,6 +35,7 @@ enum ExitType { ET_NORMAL, ET_LOOP, ET_ONEWAY, ET_UNDEFINED };
 
 enum ExitDirection { ED_NORTH=0, ED_SOUTH, ED_EAST, ED_WEST, ED_UP,
 			   ED_DOWN, ED_UNKNOWN, ED_NONE };
+#define NUM_EXITS 7
 
 ExitDirection opposite(ExitDirection in);
 uint opposite(uint in);
@@ -64,6 +65,7 @@ typedef class QString DoorName;
 #define DF_ACTION     bit10
 
 enum ExitField {E_DOORNAME = 0, E_FLAGS, E_DOORFLAGS};
+#define NUM_EXIT_PROPS 3
 
 typedef quint8 ExitFlags;
 typedef quint16 DoorFlags;

--- a/src/mapdata/mmapper2exit.h
+++ b/src/mapdata/mmapper2exit.h
@@ -67,7 +67,7 @@ typedef class QString DoorName;
 enum ExitField {E_DOORNAME = 0, E_FLAGS, E_DOORFLAGS};
 #define NUM_EXIT_PROPS 3
 
-typedef quint8 ExitFlags;
+typedef quint16 ExitFlags;
 typedef quint16 DoorFlags;
 
 ExitFlags getFlags(const Exit & e);

--- a/src/mapdata/mmapper2room.cpp
+++ b/src/mapdata/mmapper2room.cpp
@@ -61,3 +61,5 @@ RoomAlignType getAlignType(const Room * room)
 RoomRidableType getRidableType(const Room * room) 
   { return (RoomRidableType)(*room)[R_RIDABLETYPE].toUInt(); }
 
+RoomSundeathType getSundeathType(const Room * room)
+  { return (RoomSundeathType)(*room)[R_SUNDEATHTYPE].toUInt(); }

--- a/src/mapdata/mmapper2room.h
+++ b/src/mapdata/mmapper2room.h
@@ -61,7 +61,7 @@ enum RoomSundeathType   { RST_UNDEFINED = 0, RST_SUNDEATH, RST_NOSUNDEATH };
 #define RMF_QUEST           bit14
 #define RMF_ANY             bit15
 #define RMF_RESERVED2       bit16
-typedef quint16 RoomMobFlags;
+typedef quint32 RoomMobFlags;
 
 #define RLF_TREASURE        bit1
 #define RLF_ARMOUR          bit2
@@ -79,7 +79,7 @@ typedef quint16 RoomMobFlags;
 #define RLF_BOAT            bit14
 #define RLF_ATTENTION 		bit15
 #define RLF_TOWER     		bit16
-typedef quint16 RoomLoadFlags;
+typedef quint32 RoomLoadFlags;
 
 enum RoomField {R_NAME, R_DESC, R_TERRAINTYPE, R_DYNAMICDESC, R_NOTE, R_MOBFLAGS, R_LOADFLAGS, R_PORTABLETYPE, R_LIGHTTYPE, R_ALIGNTYPE, R_RIDABLETYPE, R_SUNDEATHTYPE, R_KEYWORDS, ROOMFIELD_LAST};
 

--- a/src/mapdata/mmapper2room.h
+++ b/src/mapdata/mmapper2room.h
@@ -25,9 +25,6 @@
 
 #ifndef MMAPPER2ROOM_H
 #define MMAPPER2ROOM_H
-//#include "room.h"
-//#include "exit.h"
-//#include "mapdata.h"
 
 #include <QtGlobal>
 
@@ -45,6 +42,8 @@ enum RoomPortableType   { RPT_UNDEFINED = 0, RPT_PORTABLE, RPT_NOTPORTABLE };
 enum RoomLightType      { RLT_UNDEFINED = 0, RLT_DARK, RLT_LIT };
 enum RoomAlignType      { RAT_UNDEFINED = 0, RAT_GOOD, RAT_NEUTRAL, RAT_EVIL };
 enum RoomRidableType    { RRT_UNDEFINED = 0, RRT_RIDABLE, RRT_NOTRIDABLE };
+enum RoomSundeathType   { RST_UNDEFINED = 0, RST_SUNDEATH, RST_NOSUNDEATH };
+#define NUM_ROOM_PROPS      12
 
 #define RMF_RENT            bit1
 #define RMF_SHOP            bit2
@@ -82,7 +81,7 @@ typedef quint16 RoomMobFlags;
 #define RLF_TOWER     		bit16
 typedef quint16 RoomLoadFlags;
 
-enum RoomField {R_NAME, R_DESC, R_TERRAINTYPE, R_DYNAMICDESC, R_NOTE, R_MOBFLAGS, R_LOADFLAGS, R_PORTABLETYPE, R_LIGHTTYPE, R_ALIGNTYPE, R_RIDABLETYPE, R_KEYWORDS, ROOMFIELD_LAST};
+enum RoomField {R_NAME, R_DESC, R_TERRAINTYPE, R_DYNAMICDESC, R_NOTE, R_MOBFLAGS, R_LOADFLAGS, R_PORTABLETYPE, R_LIGHTTYPE, R_ALIGNTYPE, R_RIDABLETYPE, R_SUNDEATHTYPE, R_KEYWORDS, ROOMFIELD_LAST};
 
 RoomName getName(const Room * room);
 
@@ -105,5 +104,7 @@ RoomLightType getLightType(const Room * room);
 RoomAlignType getAlignType(const Room * room);
 
 RoomRidableType getRidableType(const Room * room);
+
+RoomSundeathType getSundeathType(const Room * room);
 
 #endif

--- a/src/mapstorage/jsonmapstorage.cpp
+++ b/src/mapstorage/jsonmapstorage.cpp
@@ -398,8 +398,8 @@ void JsonWorld::addRoom( QJsonArray &jRooms, const Room *room ) const
   jr["portable"]  = (quint8)getPortableType(room);
   jr["rideable"]  = (quint8)getRidableType(room);
   jr["sundeath"]  = (quint8)getSundeathType(room);
-  jr["mobflags"]  = (quint16)getMobFlags(room);
-  jr["loadflags"] = (quint16)getLoadFlags(room);
+  jr["mobflags"]  = (qint64)getMobFlags(room);
+  jr["loadflags"] = (qint64)getLoadFlags(room);
 
   addExits( room, jr );
 

--- a/src/mapstorage/jsonmapstorage.cpp
+++ b/src/mapstorage/jsonmapstorage.cpp
@@ -397,6 +397,7 @@ void JsonWorld::addRoom( QJsonArray &jRooms, const Room *room ) const
   jr["light"]     = (quint8)getLightType(room);
   jr["portable"]  = (quint8)getPortableType(room);
   jr["rideable"]  = (quint8)getRidableType(room);
+  jr["sundeath"]  = (quint8)getSundeathType(room);
   jr["mobflags"]  = (quint16)getMobFlags(room);
   jr["loadflags"] = (quint16)getLoadFlags(room);
 

--- a/src/mapstorage/mapstorage.cpp
+++ b/src/mapstorage/mapstorage.cpp
@@ -80,6 +80,7 @@ Room * MapStorage::loadOldRoom(QDataStream & stream, ConnectionList & connection
   RoomTerrainType     terrainType = RTT_UNDEFINED;
   RoomPortableType    portableType = RPT_UNDEFINED;
   RoomRidableType     ridableType = RRT_UNDEFINED;
+  RoomSundeathType    sundeathType = RST_UNDEFINED;
   RoomLightType       lightType = RLT_UNDEFINED;
   RoomAlignType       alignType = RAT_UNDEFINED;
   RoomMobFlags        mobFlags = 0;
@@ -288,6 +289,7 @@ Room * MapStorage::loadOldRoom(QDataStream & stream, ConnectionList & connection
   room->replace(R_ALIGNTYPE, alignType);
   room->replace(R_PORTABLETYPE, portableType);
   room->replace(R_RIDABLETYPE, ridableType);
+  room->replace(R_SUNDEATHTYPE, sundeathType);
   room->replace(R_MOBFLAGS, mobFlags);
   room->replace(R_LOADFLAGS, loadFlags);
 
@@ -324,6 +326,11 @@ Room * MapStorage::loadRoom(QDataStream & stream, qint32 version)
   else
 	  vquint8 = 0;
   room->replace(R_RIDABLETYPE, vquint8);
+  if (version >= 041)
+      stream >> vquint8;
+  else
+      vquint8 = 0;
+  room->replace(R_SUNDEATHTYPE, vquint8);
   stream >> vquint16; room->replace(R_MOBFLAGS, vquint16);
   stream >> vquint16; room->replace(R_LOADFLAGS, vquint16);
 
@@ -433,7 +440,7 @@ bool MapStorage::mergeData()
     stream >> magic;
     if ( magic != 0xFFB2AF01 ) return false;
     stream >> version;
-    if ( version != 040 && version != 031 && version != 030 &&
+    if ( version != 041 && version != 040 && version != 031 && version != 030 &&
 	 version != 020 && version != 021 && version != 007 ) return false;
 
     // We currently force serialization to Qt4.8 since Qt5 broke QDateTime serialization
@@ -835,6 +842,7 @@ void MapStorage::saveRoom(const Room * room, QDataStream & stream)
   stream << (quint8)getAlignType(room);
   stream << (quint8)getPortableType(room);
   stream << (quint8)getRidableType(room);
+  stream << (quint8)getSundeathType(room);
   stream << (quint16)getMobFlags(room);
   stream << (quint16)getLoadFlags(room);
 
@@ -904,7 +912,7 @@ bool MapStorage::saveData( bool baseMapOnly )
 
   // Write a header with a "magic number" and a version
   stream << (quint32)0xFFB2AF01;
-  stream << (qint32)040;
+  stream << (qint32)041;
   stream.setVersion(QDataStream::Qt_4_8);
 
   // QtIOCompressor

--- a/src/parser/abstractparser.cpp
+++ b/src/parser/abstractparser.cpp
@@ -38,7 +38,6 @@
 
 #include <QDesktopServices>
 #include <QUrl>
-#include <QDebug>
 
 const QString AbstractParser::nullString;
 const QString AbstractParser::emptyString("");

--- a/src/parser/abstractparser.h
+++ b/src/parser/abstractparser.h
@@ -4,7 +4,7 @@
 **            Marek Krejza <krejza@gmail.com> (Caligor),
 **            Nils Schimmelmann <nschimme@gmail.com> (Jahara)
 **
-** This file is part of the MMapper project. 
+** This file is part of the MMapper project.
 ** Maintained by Nils Schimmelmann <nschimme@gmail.com>
 **
 ** This program is free software; you can redistribute it and/or
@@ -42,43 +42,25 @@ class Room;
 class Coordinate;
 
 enum CommandIdType   { CID_NORTH = 0, CID_SOUTH, CID_EAST, CID_WEST, CID_UP, CID_DOWN,
-						CID_UNKNOWN, CID_LOOK, CID_FLEE, CID_SCOUT, /*CID_SYNC, CID_RESET, */CID_NONE };
+                        CID_UNKNOWN, CID_LOOK, CID_FLEE, CID_SCOUT, /*CID_SYNC, CID_RESET, */CID_NONE };
 
 enum DoorActionType { DAT_OPEN, DAT_CLOSE, DAT_LOCK, DAT_UNLOCK, DAT_PICK, DAT_ROCK, DAT_BASH, DAT_BREAK, DAT_BLOCK, DAT_NONE };
 
-#define EXIT_N bit1
-#define EXIT_S bit5
-#define EXIT_E bit9
-#define EXIT_W bit13
-#define EXIT_U bit17
-#define EXIT_D bit21
-
-#define DOOR_N bit2
-#define DOOR_S bit6
-#define DOOR_E bit10
-#define DOOR_W bit14
-#define DOOR_U bit18
-#define DOOR_D bit22
-
-#define ROAD_N bit3
-#define ROAD_S bit7
-#define ROAD_E bit11
-#define ROAD_W bit15
-#define ROAD_U bit19
-#define ROAD_D bit23
-
-#define CLIMB_N bit4
-#define CLIMB_S bit8
-#define CLIMB_E bit12
-#define CLIMB_W bit16
-#define CLIMB_U bit20
-#define CLIMB_D bit24
-
-#define EXITS_FLAGS_VALID bit25
+// bit1 through bit24
+// EF_EXIT, EF_DOOR, EF_ROAD, EF_CLIMB
+#define EXITS_FLAGS_VALID bit31
 typedef quint32 ExitsFlagsType;
 
+// bit1 through bit12
+#define DIRECT_SUN_ROOM bit1
+#define INDIRECT_SUN_ROOM bit2
+
+#define ANY_DIRECT_SUNLIGHT (bit1 + bit3 + bit5 + bit9 + bit11)
+#define CONNECTED_ROOM_FLAGS_VALID bit15
+typedef quint16 ConnectedRoomFlagsType;
+
 // 0-3 terrain type (bit1 through bit4)
-#define SUN_ROOM bit5
+#define LIT_ROOM bit5
 #define DARK_ROOM bit6
 #define PROMPT_FLAGS_VALID bit7
 typedef quint8 PromptFlagsType;
@@ -102,7 +84,7 @@ signals:
   void releaseAllPaths();
 
   //used to log
-  void logText( const QString& );
+  void log(const QString&, const QString&);
 
   //for main move/search algorithm
   void event(ParseEvent* );
@@ -121,6 +103,7 @@ public slots:
   virtual void parseNewMudInput(IncomingData&) = 0;
   void parseNewUserInput(IncomingData&);
 
+  void reset();
   void emptyQueue();
   void sendGTellToUser(const QByteArray& );
 
@@ -130,6 +113,7 @@ protected:
   void sendPromptToUser();
   void sendPromptToUser(const Room* r);
   void sendRoomExitsInfoToUser(const Room* r);
+  const Coordinate getPosition();
 
   //command handling
   void performDoorCommand(DirectionType direction, DoorActionType action);
@@ -159,7 +143,9 @@ protected:
   QString m_dynamicRoomDesc;
   ExitsFlagsType m_exitsFlags;
   PromptFlagsType m_promptFlags;
+  ConnectedRoomFlagsType m_connectedRoomFlags;
   QString m_lastPrompt;
+  bool m_trollExitMapping;
 
   CommandQueue queue;
   MumeClock* m_mumeClock;

--- a/src/parser/mumexmlparser.cpp
+++ b/src/parser/mumexmlparser.cpp
@@ -467,7 +467,7 @@ void MumeXmlParser::move()
     if ( c != CID_SCOUT )
     {
       emit showPath(queue, false);
-      emit event(createEvent(m_move, m_roomName, m_dynamicRoomDesc, m_staticRoomDesc, m_exitsFlags, m_promptFlags));
+      emit event(createEvent(m_move, m_roomName, m_dynamicRoomDesc, m_staticRoomDesc, m_exitsFlags, m_promptFlags, m_connectedRoomFlags));
       if (c != m_move)
         queue.clear();
       m_move = CID_LOOK;
@@ -476,7 +476,7 @@ void MumeXmlParser::move()
   else
   {
     //emit showPath(queue, false);
-      emit event(createEvent(m_move, m_roomName, m_dynamicRoomDesc, m_staticRoomDesc, m_exitsFlags, m_promptFlags));
+      emit event(createEvent(m_move, m_roomName, m_dynamicRoomDesc, m_staticRoomDesc, m_exitsFlags, m_promptFlags, m_connectedRoomFlags));
     m_move = CID_LOOK;
   }
 }

--- a/src/pathmachine/pathmachine.h
+++ b/src/pathmachine/pathmachine.h
@@ -27,24 +27,10 @@
 #ifndef PARSER
 #define PARSER
 
-//#include "parseevent.h"
-//#include "property.h"
-//#include "path.h"
 #include "room.h"
-//#include "coordinate.h"
-//#include "crossover.h"
-//#include "onebyone.h"
-//#include "approved.h"
-//#include "syncing.h"
 #include "component.h"
 #include "roomsignalhandler.h"
-//#include "abstractroomfactory.h"
 #include "pathparameters.h"
-
-//#include <queue>
-//#include <list>
-//#include <queue>
-//#include <qobject.h>
 
 #define APPROVED 0
 #define EXPERIMENTING 1

--- a/src/preferences/parserpage.cpp
+++ b/src/preferences/parserpage.cpp
@@ -93,9 +93,7 @@ ParserPage::ParserPage(QWidget *parent)
 		
 	connect( IACPromptCheckBox, SIGNAL(stateChanged(int)),SLOT(IACPromptCheckBoxStateChanged(int)));	
 	connect( suppressXmlTagsCheckBox, SIGNAL(stateChanged(int)),SLOT(suppressXmlTagsCheckBoxStateChanged(int)));	
-        connect( charset, SIGNAL(currentIndexChanged(int)),SLOT(charsetChanged(int)));
-
-
+    connect( charset, SIGNAL(currentIndexChanged(int)),SLOT(charsetChanged(int)));
 }
 
 void ParserPage::charsetChanged(int index)

--- a/src/preferences/parserpage.ui
+++ b/src/preferences/parserpage.ui
@@ -65,46 +65,6 @@
       <property name="spacing">
        <number>6</number>
       </property>
-      <item row="2" column="3" colspan="2">
-       <widget class="QLabel" name="roomDescColorLabel">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="3" colspan="2">
-       <widget class="QLabel" name="roomNameColorLabel">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="AnsiCombo" name="roomNameAnsiColorBG" native="true"/>
-      </item>
-      <item row="3" column="1">
-       <widget class="AnsiCombo" name="roomDescAnsiColorBG" native="true"/>
-      </item>
-      <item row="5" column="0" colspan="5">
-       <widget class="QCheckBox" name="suppressXmlTagsCheckBox">
-        <property name="text">
-         <string>Suppress XML tags</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0" colspan="5">
-       <widget class="QCheckBox" name="IACPromptCheckBox">
-        <property name="text">
-         <string>IAC-GA prompt recognition (changes needs reconnect with client!!!)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="AnsiCombo" name="roomNameAnsiColor" native="true"/>
-      </item>
-      <item row="3" column="0">
-       <widget class="AnsiCombo" name="roomDescAnsiColor" native="true"/>
-      </item>
       <item row="3" column="4">
        <widget class="QLabel" name="labelRoomDesc">
         <property name="sizePolicy">
@@ -135,55 +95,27 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="3">
-       <widget class="QLabel" name="textLabel1_7">
-        <property name="minimumSize">
-         <size>
-          <width>280</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Descriptions color: fg/bg/attr</string>
-        </property>
+      <item row="6" column="2" colspan="3">
+       <widget class="QComboBox" name="charset">
+        <item>
+         <property name="text">
+          <string notr="true">ASCII or Latin1</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string notr="true">UTF-8</string>
+         </property>
+        </item>
        </widget>
       </item>
-      <item row="1" column="2">
-       <widget class="QCheckBox" name="roomNameAnsiBold">
-        <property name="maximumSize">
-         <size>
-          <width>38</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>B</string>
-        </property>
-       </widget>
+      <item row="1" column="0">
+       <widget class="AnsiCombo" name="roomNameAnsiColor" native="true"/>
       </item>
-      <item row="1" column="3">
-       <widget class="QCheckBox" name="roomNameAnsiUnderline">
-        <property name="maximumSize">
-         <size>
-          <width>38</width>
-          <height>16777215</height>
-         </size>
-        </property>
+      <item row="0" column="3" colspan="2">
+       <widget class="QLabel" name="roomNameColorLabel">
         <property name="text">
-         <string>U</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="3">
-       <widget class="QCheckBox" name="roomDescAnsiUnderline">
-        <property name="maximumSize">
-         <size>
-          <width>38</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>U</string>
+         <string/>
         </property>
        </widget>
       </item>
@@ -197,6 +129,65 @@
         </property>
         <property name="text">
          <string>B</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0" colspan="5">
+       <widget class="QCheckBox" name="suppressXmlTagsCheckBox">
+        <property name="text">
+         <string>Suppress XML tags</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="AnsiCombo" name="roomNameAnsiColorBG" native="true"/>
+      </item>
+      <item row="3" column="1">
+       <widget class="AnsiCombo" name="roomDescAnsiColorBG" native="true"/>
+      </item>
+      <item row="2" column="0" colspan="3">
+       <widget class="QLabel" name="textLabel1_7">
+        <property name="minimumSize">
+         <size>
+          <width>280</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Descriptions color: fg/bg/attr</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="3" colspan="2">
+       <widget class="QLabel" name="roomDescColorLabel">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="3">
+       <widget class="QLabel" name="textLabel1_3">
+        <property name="minimumSize">
+         <size>
+          <width>280</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Room name color: fg/bg/attr</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="3">
+       <widget class="QCheckBox" name="roomDescAnsiUnderline">
+        <property name="maximumSize">
+         <size>
+          <width>38</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>U</string>
         </property>
        </widget>
       </item>
@@ -230,37 +221,46 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="0" colspan="3">
-       <widget class="QLabel" name="textLabel1_3">
-        <property name="minimumSize">
+      <item row="1" column="2">
+       <widget class="QCheckBox" name="roomNameAnsiBold">
+        <property name="maximumSize">
          <size>
-          <width>280</width>
-          <height>0</height>
+          <width>38</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="text">
-         <string>Room name color: fg/bg/attr</string>
+         <string>B</string>
         </property>
-       </widget>
-      </item>
-      <item row="6" column="2" colspan="3">
-       <widget class="QComboBox" name="charset">
-        <item>
-         <property name="text">
-          <string notr="true">ASCII or Latin1</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string notr="true">UTF-8</string>
-         </property>
-        </item>
        </widget>
       </item>
       <item row="6" column="0" colspan="2">
        <widget class="QLabel" name="label">
         <property name="text">
          <string>&quot;change charset&quot; is:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="QCheckBox" name="roomNameAnsiUnderline">
+        <property name="maximumSize">
+         <size>
+          <width>38</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>U</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="AnsiCombo" name="roomDescAnsiColor" native="true"/>
+      </item>
+      <item row="4" column="0" colspan="5">
+       <widget class="QCheckBox" name="IACPromptCheckBox">
+        <property name="text">
+         <string>IAC-GA prompt recognition (changes needs reconnect with client!!!)</string>
         </property>
        </widget>
       </item>

--- a/src/proxy/proxy.cpp
+++ b/src/proxy/proxy.cpp
@@ -158,6 +158,8 @@ bool Proxy::init()
   connect(m_parserXml, SIGNAL(event(ParseEvent* )), m_pathMachine, SLOT(event(ParseEvent* )), Qt::QueuedConnection);
   connect(m_parserXml, SIGNAL(releaseAllPaths()), m_pathMachine, SLOT(releaseAllPaths()), Qt::QueuedConnection);
   connect(m_parserXml, SIGNAL(showPath(CommandQueue, bool)), m_prespammedPath, SLOT(setPath(CommandQueue, bool)), Qt::QueuedConnection);
+  connect(m_parserXml, SIGNAL(log(const QString&, const QString&)), m_parent->parent(), SLOT(log(const QString&, const QString&)));
+  connect(m_userSocket, SIGNAL(disconnected()), m_parserXml, SLOT(reset()) );
 
   //Group Manager Support
   connect(m_parserXml, SIGNAL(sendScoreLineEvent(QByteArray)), m_groupManager, SLOT(parseScoreInformation(QByteArray)), Qt::QueuedConnection);
@@ -175,6 +177,7 @@ bool Proxy::init()
   m_mudSocket = new QTcpSocket(this);
   m_mudSocket->setSocketOption(QAbstractSocket::KeepAliveOption, true);
   connect(m_mudSocket, SIGNAL(disconnected()), this, SLOT(mudTerminatedConnection()) );
+  connect(m_mudSocket, SIGNAL(disconnected()), m_parserXml, SLOT(reset()) );
   connect(m_mudSocket, SIGNAL(readyRead()), this, SLOT(processMudStream()) );
 
   m_mudSocket->connectToHost(m_remoteHost, m_remotePort, QIODevice::ReadWrite);


### PR DESCRIPTION
Trolls and orcs are now able to map sunlit rooms using exits like \*north\*. Trolls can do this at night as well because they can detect outdoor rooms exit flags like ^south^.

Other new features:
* `_trollexit` command to toggle Troll exit mapping manually
* Dark rooms are differentiated from troll safe sunlit rooms by amount of darkness

*Note: Mapper mode needs to be enabled for this to work*

This PR provides some additional features as part of #38 as per discussion with @tomaswindsor