### PR TITLE
Multisample anti-aliasing support

### DIFF
--- a/src/configuration/configuration.cpp
+++ b/src/configuration/configuration.cpp
@@ -63,6 +63,7 @@ void Configuration::read()
   m_drawUpperLayersTextured = conf.value("Draw upper layers textured", false).toBool();
   m_drawDoorNames = conf.value("Draw door names", true).toBool();
   m_backgroundColor = QColor(conf.value("Background color", QColor(110,110,110).name()).toString());
+  m_antialiasingSamples = conf.value("Number of anti-aliasing samples", 1).toInt();
   conf.endGroup();
 
   conf.beginGroup("Auto load world");
@@ -159,6 +160,7 @@ void Configuration::write() const {
   conf.setValue("Draw upper layers textured", m_drawUpperLayersTextured);
   conf.setValue("Draw door names", m_drawDoorNames);
   conf.setValue("Background color", m_backgroundColor.name());
+  conf.setValue("Number of anti-aliasing samples", m_antialiasingSamples);
   conf.endGroup();
 
   conf.beginGroup("Auto load world");

--- a/src/configuration/configuration.h
+++ b/src/configuration/configuration.h
@@ -56,6 +56,7 @@ class Configuration {
     quint32   m_localPort;         /// Port to bind to on local machine
 
     QColor m_backgroundColor;
+    int    m_antialiasingSamples;
 
     bool m_autoLog;         // enables log to file
     QString m_logFileName;  // file name to log

--- a/src/mapdata/mapdata.h
+++ b/src/mapdata/mapdata.h
@@ -86,16 +86,16 @@ public:
   bool execute(AbstractAction * action, const RoomSelection * unlock);
     
   Coordinate & getPosition() {return m_position;}
-  MarkerList& getMarkersList(){ return m_markers; };
-  uint getRoomsCount(){ return greatestUsedId == UINT_MAX ? 0 : greatestUsedId+1; };
-  int getMarkersCount(){ return m_markers.count(); };
+  MarkerList& getMarkersList(){ return m_markers; }
+  uint getRoomsCount(){ return greatestUsedId == UINT_MAX ? 0 : greatestUsedId+1; }
+  int getMarkersCount(){ return m_markers.count(); }
 
   void addMarker(InfoMark* im);
   void removeMarker(InfoMark* im);
 
-  bool isEmpty(){return (greatestUsedId == UINT_MAX && m_markers.isEmpty());};
-  bool dataChanged(){return m_dataChanged;};
-  QString getFileName(){ return m_fileName; };
+  bool isEmpty(){return (greatestUsedId == UINT_MAX && m_markers.isEmpty());}
+  bool dataChanged(){return m_dataChanged;}
+  QString getFileName(){ return m_fileName; }
   QList<Coordinate> getPath(const QList<CommandIdType> dirs);
   virtual void clear();
 
@@ -123,9 +123,9 @@ signals:
   void updateCanvas();
 
 public slots:
-  void setFileName(QString filename){ m_fileName = filename; };
-  void unsetDataChanged(){m_dataChanged = false;};
-  void setDataChanged(){m_dataChanged = true;};
+  void setFileName(QString filename){ m_fileName = filename; }
+  void unsetDataChanged(){m_dataChanged = false;}
+  void setDataChanged(){m_dataChanged = true;}
   void setPosition(const Coordinate & pos) {m_position = pos;}
 
 protected:

--- a/src/preferences/generalpage.cpp
+++ b/src/preferences/generalpage.cpp
@@ -39,6 +39,7 @@ GeneralPage::GeneralPage(QWidget *parent)
   connect( localPort, SIGNAL( valueChanged(int) ), this, SLOT( localPortValueChanged(int) )  );
 
   connect( changeColor, SIGNAL(clicked()),SLOT(changeColorClicked()));
+  connect( antialiasingSamplesSpinBox, SIGNAL( valueChanged(int) ), this, SLOT( antialiasingSamplesValueChanged(int) )  );
 
   connect ( emulatedExits, SIGNAL(stateChanged(int)),SLOT(emulatedExitsStateChanged(int)));
   connect ( updated, SIGNAL(stateChanged(int)),SLOT(updatedStateChanged(int)));
@@ -57,6 +58,7 @@ GeneralPage::GeneralPage(QWidget *parent)
 
   colorLabel->setPalette(QPalette(Config().m_backgroundColor));
   colorLabel->setAutoFillBackground(true);
+  antialiasingSamplesSpinBox->setValue(Config().m_antialiasingSamples);
 
   emulatedExits->setChecked( Config().m_emulatedExits );
   updated->setChecked( Config().m_showUpdated );
@@ -77,6 +79,12 @@ void GeneralPage::changeColorClicked()
     Config().m_backgroundColor = newColor;
   }
 }
+
+void GeneralPage::antialiasingSamplesValueChanged(int)
+{
+    Config().m_antialiasingSamples = antialiasingSamplesSpinBox->value();
+}
+
 
 void GeneralPage::selectWorldFileButtonClicked()
 {

--- a/src/preferences/generalpage.h
+++ b/src/preferences/generalpage.h
@@ -41,6 +41,7 @@ public slots:
 	void localPortValueChanged(int);
 
     void changeColorClicked();
+    void antialiasingSamplesValueChanged(int);
 
 	void emulatedExitsStateChanged(int);
 	void updatedStateChanged(int);

--- a/src/preferences/generalpage.ui
+++ b/src/preferences/generalpage.ui
@@ -168,10 +168,30 @@
       <property name="spacing">
        <number>6</number>
       </property>
-      <item row="0" column="3">
-       <widget class="QPushButton" name="changeColor">
+      <item row="1" column="3">
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
         <property name="text">
-         <string>Change Color</string>
+         <string>Background color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Anti-aliasing samples</string>
         </property>
        </widget>
       </item>
@@ -182,12 +202,32 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
+      <item row="0" column="3">
+       <widget class="QPushButton" name="changeColor">
         <property name="text">
-         <string>Background color</string>
+         <string>Change Color</string>
         </property>
        </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QSpinBox" name="antialiasingSamplesSpinBox">
+        <property name="maximum">
+         <number>16</number>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="4">
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
Anti-aliasing is now enabled by default. You can disable it in the settings.

Also included are fixes to a bunch of OpenGL regressions from the Qt5 migration. This might fix the issue in #28 because I am unable to reproduce the problem.