### PR TITLE
MMapper now has a built in Mume clock

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,8 @@
 SET(mmapper_SRCS
     main.cpp
+    clock/mumemoment.cpp
+    clock/mumeclock.cpp
+    clock/mumeclockwidget.cpp
     configuration/configuration.cpp
     display/connectionselection.cpp
     display/mapcanvas.cpp
@@ -82,6 +85,7 @@ SET(mmapper_UIS
     mainwindow/findroomsdlg.ui
     mainwindow/infomarkseditdlg.ui
     mainwindow/roomeditattrdlg.ui
+    clock/mumeclockwidget.ui
     preferences/generalpage.ui
     preferences/groupmanagerpage.ui
     preferences/parserpage.ui
@@ -89,6 +93,7 @@ SET(mmapper_UIS
 )
 
 INCLUDE_DIRECTORIES(
+    ${CMAKE_CURRENT_SOURCE_DIR}/clock
     ${CMAKE_CURRENT_SOURCE_DIR}/configuration
     ${CMAKE_CURRENT_SOURCE_DIR}/display
     ${CMAKE_CURRENT_SOURCE_DIR}/expandoracommon

--- a/src/clock/mumeclock.cpp
+++ b/src/clock/mumeclock.cpp
@@ -1,0 +1,317 @@
+/************************************************************************
+**
+** Authors:   Nils Schimmelmann <nschimme@gmail.com> (Jahara)
+**
+** This file is part of the MMapper project.
+** Maintained by Nils Schimmelmann <nschimme@gmail.com>
+**
+** This program is free software; you can redistribute it and/or
+** modify it under the terms of the GNU General Public License
+** as published by the Free Software Foundation; either version 2
+** of the License, or (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the:
+** Free Software Foundation, Inc.
+** 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+**
+************************************************************************/
+
+#include <QRegExp>
+#include <QDateTime>
+#include <QDebug>
+
+#include "mumeclock.h"
+#include "mumemoment.h"
+
+#define DEFAULT_MUME_START_EPOCH 1420070400
+#define DEFAULT_TOLERANCE_LIMIT 10
+
+QList<int> MumeClock::m_dawnHour = QList<int>() << 8 << 9 << 8 << 7 << 7 << 6 << 5 << 4 << 5 << 6 << 7 << 7;
+QList<int> MumeClock::m_duskHour = QList<int>() << 6+12 << 5+12 << 6+12 << 7+12 << 8+12 << 8+12 << 9+12 << 10+12 << 9+12 << 8+12 << 8+12 << 7+12;
+QMetaEnum MumeClock::m_westronMonthNames = QMetaEnum::fromType<MumeClock::WestronMonthNames>();
+QMetaEnum MumeClock::m_sindarinMonthNames = QMetaEnum::fromType<MumeClock::SindarinMonthNames>();
+
+MumeClock::MumeClock(int mumeEpoch, QObject *parent)
+    : QObject(parent),
+      m_mumeStartEpoch(mumeEpoch),
+      m_precision(MUMECLOCK_UNSET),
+      m_clockTolerance(DEFAULT_TOLERANCE_LIMIT)
+{}
+
+
+MumeClock::MumeClock(QObject *parent)
+    : MumeClock(DEFAULT_MUME_START_EPOCH, parent)
+{}
+
+MumeMoment MumeClock::getMumeMoment(int secsSinceUnixEpoch)
+{
+    if (secsSinceUnixEpoch < 0)
+        secsSinceUnixEpoch = QDateTime::QDateTime::currentDateTimeUtc().toTime_t();
+    return MumeMoment(secsSinceUnixEpoch - m_mumeStartEpoch);
+}
+
+void MumeClock::parseMumeTime(const QString& mumeTime)
+{
+    int secsSinceEpoch = QDateTime::QDateTime::currentDateTimeUtc().toTime_t();
+    parseMumeTime(mumeTime, secsSinceEpoch);
+}
+
+void MumeClock::parseMumeTime(const QString& mumeTime, int secsSinceEpoch)
+{
+    MumeMoment moment(secsSinceEpoch - m_mumeStartEpoch);
+    int minute = moment.m_minute;
+    int hour = moment.m_hour;
+    int day = 0;
+    int month = 0;
+    int year = MUME_START_YEAR;
+
+    if (mumeTime.at(0).isDigit())
+    {
+        // 3pm on Highday, the 18th of Halimath, Year 3030 of the Third Age.
+        QRegExp rx("(\\d+)(am|pm) on \\w+, the (\\d+).{2} of (\\w+), Year (\\d+) of the Third Age.");
+        if (rx.indexIn(mumeTime) != -1) {
+            hour = rx.cap(1).toInt();
+            if (rx.cap(2).at(0) == 'p')
+            {   // pm
+                if (hour != 12)
+                {   // add 12 if not noon
+                    hour += 12;
+                }
+            }
+            else if (hour == 12)
+            {   // midnight
+                hour = 0;
+            }
+            day = rx.cap(3).toInt() - 1;
+            month = m_westronMonthNames.keyToValue(rx.cap(4).toLatin1().data());
+            if (month == UnknownWestronMonth)
+            {
+                month = m_sindarinMonthNames.keyToValue(rx.cap(4).toLatin1().data());
+            }
+            year = rx.cap(5).toInt();
+            if (m_precision <= MUMECLOCK_DAY)
+                m_precision = MUMECLOCK_HOUR;
+        }
+    }
+    else
+    {
+        // "Highday, the 18th of Halimath, Year 3030 of the Third Age."
+        QRegExp rx("\\w+, the (\\d+).{2} of (\\w+), Year (\\d+) of the Third Age.");
+        if (rx.indexIn(mumeTime) != -1) {
+            day = rx.cap(1).toInt() - 1;
+            month = m_westronMonthNames.keyToValue(rx.cap(2).toLatin1().data());
+            if (month == UnknownWestronMonth)
+            {
+                month = m_sindarinMonthNames.keyToValue(rx.cap(2).toLatin1().data());
+            }
+            year = rx.cap(3).toInt();
+            if (m_precision <= MUMECLOCK_UNSET)
+                m_precision = MUMECLOCK_DAY;
+        }
+    }
+
+    // Calculate start of Mume epoch
+    int mumeSecsSinceEpoch = MumeMoment(year, month, day, hour, minute).toSeconds();
+    int newStartEpoch = secsSinceEpoch - mumeSecsSinceEpoch;
+    if (newStartEpoch != m_mumeStartEpoch)
+        emit log("MumeClock", "Detected new Mume start epoch " + QString::number(newStartEpoch) + " (" + QString::number(newStartEpoch - m_mumeStartEpoch) + " seconds from previous)");
+    m_mumeStartEpoch = newStartEpoch;
+}
+
+void MumeClock::tickSync(MumeTime time)
+{
+    int secsSinceEpoch = QDateTime::QDateTime::currentDateTimeUtc().toTime_t();
+    if (time == TIME_UNKNOWN)
+        return tickSync(secsSinceEpoch);
+
+    MumeMoment moment(secsSinceEpoch - m_mumeStartEpoch);
+    moment.m_minute = 0;
+
+    // Predict current hour given the month
+    int dawn = m_dawnHour[moment.m_month];
+    int dusk = m_duskHour[moment.m_month];
+    switch (time)
+    {
+    case TIME_DAWN: moment.m_hour=dawn;break;
+    case TIME_DAY: moment.m_hour=dawn+1;break;
+    case TIME_DUSK: moment.m_hour=dusk;break;
+    case TIME_NIGHT: moment.m_hour=dusk+1;break;
+    }
+
+    // Update epoch
+    m_precision = MUMECLOCK_MINUTE;
+    m_mumeStartEpoch = secsSinceEpoch - moment.toSeconds();
+    emit log("MumeClock", "Synchronized tick using weather");
+}
+
+void MumeClock::tickSync(int secsSinceEpoch)
+{
+    MumeMoment moment(secsSinceEpoch - m_mumeStartEpoch);
+    // Only sync on ticks if we know the time with some reliability
+    if (m_precision <= MUMECLOCK_DAY && moment.m_minute != 0)
+    {
+        emit log("MumeClock", "Tick detected but discarded until the hour is recognized");
+        return ;
+    }
+
+    // Sync
+    if (m_precision == MUMECLOCK_HOUR)
+    {
+        // Assume we are moving forward in time
+        moment.m_hour = moment.m_hour + 1;
+        moment.m_minute = 0;
+        m_precision = MUMECLOCK_MINUTE;
+        emit log("MumeClock", "Synchronized tick and raised precision");
+    }
+    else
+    {
+        if (moment.m_minute == 0)
+        {
+            m_precision = MUMECLOCK_MINUTE;
+            emit log("MumeClock", "Tick detected");
+            return ;
+        }
+        else
+        {
+            if (moment.m_minute > 0 && moment.m_minute <= m_clockTolerance)
+            {
+                emit log("MumeClock", "Synchronized tick but Mume seems to be running slow by " + QString::number(moment.m_minute) + " seconds");
+                moment.m_minute = 0;
+            }
+            else if (moment.m_minute >= (60 - m_clockTolerance) && moment.m_minute < 60)
+            {
+                emit log("MumeClock", "Synchronized tick but Mume seems to be running fast by " + QString::number(moment.m_minute) + " seconds");
+                moment.m_hour = moment.m_hour + 1;
+                moment.m_minute = 0;
+            }
+            else
+            {
+                m_precision = MUMECLOCK_DAY;
+                emit log("MumeClock", "Precision lowered because tick was off by " + QString::number(moment.m_minute) + " seconds)");
+                return ;
+            }
+
+        }
+    }
+    // Update epoch
+    m_mumeStartEpoch = secsSinceEpoch - moment.toSeconds();
+}
+
+void MumeClock::parseClockTime(const QString& clockTime)
+{
+    int secsSinceEpoch = QDateTime::QDateTime::currentDateTimeUtc().toTime_t();
+    parseClockTime(clockTime, secsSinceEpoch);
+}
+
+void MumeClock::parseClockTime(const QString& clockTime, int secsSinceEpoch)
+{
+    // The current time is 5:23 pm.
+    QRegExp rx("The current time is (\\d+):(\\d+) (am|pm).");
+    if (rx.indexIn(clockTime) != -1) {
+        int hour = rx.cap(1).toInt();
+        int minute = rx.cap(2).toInt();
+        if (rx.cap(3).at(0) == 'p')
+        {   // pm
+            if (hour != 12)
+            {   // add 12 if not noon
+                hour += 12;
+            }
+        }
+        else if (hour == 12)
+        {   // midnight
+            hour = 0;
+        }
+
+        m_precision = MUMECLOCK_MINUTE;
+        MumeMoment moment(secsSinceEpoch - m_mumeStartEpoch);
+        moment.m_minute = minute;
+        moment.m_hour = hour;
+        int newStartEpoch = secsSinceEpoch - moment.toSeconds();
+        emit log("MumeClock", "Synchronized with clock in room (" + QString::number(newStartEpoch - m_mumeStartEpoch) + " seconds from previous)");
+        m_mumeStartEpoch = newStartEpoch;
+    }
+}
+
+const QString MumeClock::toMumeTime(const MumeMoment &moment)
+{
+    int hour = moment.m_hour;
+    QString period;
+    if (hour == 0)
+    {
+        hour = 12;
+        period = "am";
+    }
+    else if (hour == 12)
+    {
+        period = "pm";
+    }
+    else if (hour > 12)
+    {
+        hour -= 12;
+        period = "pm";
+    }
+    else
+    {
+        period = "am";
+    }
+    QString time;
+    switch (m_precision)
+    {
+    case MUMECLOCK_HOUR:
+        time = QString("%1%2 on the ").arg(hour).arg(period);
+        break;
+    case MUMECLOCK_MINUTE:
+        time = QString("%1:%2%3 on the ").arg(hour).arg(QString().sprintf("%02d", moment.m_minute)).arg(period);
+        break;
+    }
+    int day = moment.m_day + 1;
+    QString daySuffix;
+    if (day == 1 || day == 21)
+        daySuffix = "st";
+    else if (day == 2 || day == 22)
+        daySuffix = "nd";
+    else if (day == 3 || day == 23)
+        daySuffix = "rd";
+    else
+        daySuffix = "th";
+
+    // TODO: Figure out how to reverse engineer the day of the week
+    QString monthName = MumeClock::m_westronMonthNames.valueToKey((WestronMonthNames)moment.m_month);
+    return QString("%1%2%3 of %4, Year %5 of the Third Age.")
+            .arg(time)
+            .arg(day)
+            .arg(daySuffix)
+            .arg(monthName)
+            .arg(moment.m_year);
+}
+
+
+const QString MumeClock::toCountdown(const MumeMoment &moment) {
+    int dawn = m_dawnHour[moment.m_month];
+    int dusk = m_duskHour[moment.m_month];
+
+    // Add seconds until night or day
+    int secondsToCountdown = (m_precision == MUMECLOCK_MINUTE) ? 60 - moment.m_minute : 0;
+    if (moment.m_hour <= dawn)
+    {   // Add seconds until dawn
+        secondsToCountdown += (dawn - moment.m_hour) * 60;
+    }
+    else if (moment.m_hour >= dusk)
+    {   // Add seconds until dawn
+        secondsToCountdown += (24 - moment.m_hour + dawn) * 60;
+    }
+    else
+    {   // Add seconds until dusk
+        secondsToCountdown += (dusk - 1 - moment.m_hour) * 60;
+    }
+    if (m_precision <= MUMECLOCK_HOUR)
+        return QString("~%1").arg((secondsToCountdown / 60) + 1);
+    else
+        return QString("%1:%2").arg(secondsToCountdown / 60).arg(QString().sprintf("%02d", secondsToCountdown % 60));
+}

--- a/src/clock/mumeclock.h
+++ b/src/clock/mumeclock.h
@@ -1,0 +1,82 @@
+/************************************************************************
+**
+** Authors:   Nils Schimmelmann <nschimme@gmail.com> (Jahara)
+**
+** This file is part of the MMapper project.
+** Maintained by Nils Schimmelmann <nschimme@gmail.com>
+**
+** This program is free software; you can redistribute it and/or
+** modify it under the terms of the GNU General Public License
+** as published by the Free Software Foundation; either version 2
+** of the License, or (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the:
+** Free Software Foundation, Inc.
+** 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+**
+************************************************************************/
+
+#ifndef MUMECLOCK_H
+#define MUMECLOCK_H
+
+enum MumeClockPrecision { MUMECLOCK_UNSET = -1, MUMECLOCK_DAY, MUMECLOCK_HOUR, MUMECLOCK_MINUTE };
+
+#include <QObject>
+#include <QList>
+#include <QMetaEnum>
+
+#include "mumemoment.h"
+
+class MumeClock : public QObject
+{
+    Q_OBJECT
+    friend class TestClock;
+
+public:
+    MumeClock(int mumeEpoch, QObject *parent = 0);
+    MumeClock(QObject *parent = 0);
+
+    MumeMoment getMumeMoment(int secsSinceUnixEpoch = -1);
+    MumeClockPrecision getPrecision() { return m_precision; }
+    const QString toMumeTime(const MumeMoment &moment);
+    const QString toCountdown(const MumeMoment &moment);
+    int getMumeStartEpoch() { return m_mumeStartEpoch; }
+
+    enum WestronMonthNames { UnknownWestronMonth=-1, Afteryule,Solmath,Rethe,Astron,Thrimidge,Forelithe,Afterlithe,Wedmath,Halimath,Winterfilth,Blotmath,Foreyule };
+    Q_ENUM(WestronMonthNames)
+
+    enum SindarinMonthNames { UnknownSindarinMonth=-1, Narwain,Ninui,Gwaeron,Gwirith,Lothron,Norui,Cerveth,Urui,Ivanneth,Narbeleth,Hithui,Girithron };
+    Q_ENUM(SindarinMonthNames)
+
+    static QList<int> m_dawnHour;
+    static QList<int> m_duskHour;
+    static QMetaEnum m_westronMonthNames;
+    static QMetaEnum m_sindarinMonthNames;
+
+signals:
+    void log(const QString&, const QString&);
+
+public slots:
+    void parseMumeTime(const QString& mumeTime);
+    void parseClockTime(const QString& clockTime);
+    void tickSync(MumeTime time = TIME_UNKNOWN);
+
+protected:
+    void setPrecision(MumeClockPrecision state) { m_precision = state; }
+    void parseMumeTime(const QString& mumeString, int secsSinceUnixEpoch);
+    void parseClockTime(const QString& clockTime, int secsSinceUnixEpoch);
+    void tickSync(int secsSinceEpoch);
+
+private:
+    int m_mumeStartEpoch;
+    int m_clockTolerance;
+    MumeClockPrecision m_precision;
+};
+
+#endif // MUMECLOCK_H

--- a/src/clock/mumeclockwidget.cpp
+++ b/src/clock/mumeclockwidget.cpp
@@ -1,0 +1,141 @@
+/************************************************************************
+**
+** Authors:   Nils Schimmelmann <nschimme@gmail.com> (Jahara)
+**
+** This file is part of the MMapper project.
+** Maintained by Nils Schimmelmann <nschimme@gmail.com>
+**
+** This program is free software; you can redistribute it and/or
+** modify it under the terms of the GNU General Public License
+** as published by the Free Software Foundation; either version 2
+** of the License, or (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the:
+** Free Software Foundation, Inc.
+** 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+**
+************************************************************************/
+
+#include <QSettings>
+#include <QTimer>
+
+#include "mumeclockwidget.h"
+#include "mumeclock.h"
+#include "configuration.h"
+
+MumeClockWidget::MumeClockWidget(MumeClock* clock, QWidget *parent)
+    : QWidget(parent),
+      m_clock(clock)
+{
+    setupUi(this);
+
+    m_lastSeason = SEASON_UNKNOWN;
+    m_lastTime = TIME_UNKNOWN;
+
+    m_timer = new QTimer(this);
+    connect(m_timer, SIGNAL(timeout()), this, SLOT(updateLabel()));
+    m_timer->start(1000);
+
+    updateLabel();
+}
+
+MumeClockWidget::~MumeClockWidget()
+{
+    if (m_timer) delete m_timer;
+}
+
+void MumeClockWidget::updateLabel()
+{
+    // Ensure we have updated the epoch
+    Config().m_mumeStartEpoch = m_clock->getMumeStartEpoch();
+
+    // Hide or show the widget if necessary
+    if (!Config().m_displayMumeClock)
+    {
+        hide();
+        // Slow down the interval to a reasonable number
+        m_timer->setInterval(60 * 1000);
+        return ;
+    }
+    else if (m_timer->interval() != 1000)
+    {
+        show();
+        // Speed up the interval again if the display needs to be shown
+        m_timer->setInterval(1000);
+    }
+
+    MumeMoment moment = m_clock->getMumeMoment();
+    MumeClockPrecision precision = m_clock->getPrecision();
+
+    seasonLabel->setStatusTip(m_clock->toMumeTime(moment));
+
+    MumeSeason season = moment.toSeason();
+    if (season != m_lastSeason)
+    {
+        m_lastSeason = season;
+        QString styleSheet = "color:black";
+        QString text = "Unknown";
+        switch (season)
+        {
+        case SEASON_WINTER:
+            styleSheet="color:black;background:white";
+            text="Winter";
+            break;
+        case SEASON_SPRING:
+            styleSheet="color:white;background:teal";
+            text="Spring";
+            break;
+        case SEASON_SUMMER:
+            styleSheet="color:white;background:green";
+            text="Summer";
+            break;
+        case SEASON_AUTUMN:
+            styleSheet="color:black;background:orange";
+            text="Autumn";
+            break;
+        case SEASON_UNKNOWN:
+        default:
+            break;
+        }
+        seasonLabel->setStyleSheet(styleSheet);
+        seasonLabel->setText(text);
+    }
+
+    MumeTime time = moment.toTimeOfDay();
+    if (time != m_lastTime)
+    {
+        m_lastTime = time;
+        // The current time is 12:15 am.
+        QString styleSheet = "color:black";
+        QString statusTip = "";
+        if (time == TIME_DAWN)
+        {
+            styleSheet="color:white;background:red";
+            statusTip ="Ticks left until day";
+        } else if (time >= TIME_DUSK)
+        {
+            styleSheet="color:white;background:blue";
+            statusTip ="Ticks left until day";
+        }
+        else
+        {
+            styleSheet="color:black;background:yellow";
+            statusTip="Ticks left until night";
+        }
+        timeLabel->setStyleSheet(styleSheet);
+        timeLabel->setStatusTip(statusTip);
+    }
+    if (precision > MUMECLOCK_DAY)
+    {
+        timeLabel->setText(m_clock->toCountdown(moment));
+        timeLabel->show();
+    } else {
+        timeLabel->hide();
+    }
+}

--- a/src/clock/mumeclockwidget.h
+++ b/src/clock/mumeclockwidget.h
@@ -1,10 +1,8 @@
 /************************************************************************
 **
-** Authors:   Ulf Hermann <ulfonk_mennhar@gmx.de> (Alve),
-**            Marek Krejza <krejza@gmail.com> (Caligor),
-**            Nils Schimmelmann <nschimme@gmail.com> (Jahara)
+** Authors:   Nils Schimmelmann <nschimme@gmail.com> (Jahara)
 **
-** This file is part of the MMapper project. 
+** This file is part of the MMapper project.
 ** Maintained by Nils Schimmelmann <nschimme@gmail.com>
 **
 ** This program is free software; you can redistribute it and/or
@@ -24,15 +22,33 @@
 **
 ************************************************************************/
 
-#ifndef PARSERUTILS_H
-#define PARSERUTILS_H
+#ifndef MUMECLOCKWIDGET_H
+#define MUMECLOCKWIDGET_H
 
-#include <QString>
+#include <QWidget>
+#include "ui_mumeclockwidget.h"
+#include "mumemoment.h"
 
-namespace ParserUtils
+class QTimer;
+class MumeClock;
+
+class MumeClockWidget : public QWidget, private Ui::MumeClockWidget
 {
-  QString& removeAnsiMarks(QString& str);
-  QString& latinToAscii(QString& str);
-}
+    Q_OBJECT
+public:
+    MumeClockWidget(MumeClock* clock = 0, QWidget *parent = 0);
+    ~MumeClockWidget();
+
+public slots:
+    void updateLabel();
+
+private:
+    MumeClock* m_clock;
+    QTimer* m_timer;
+
+    MumeTime m_lastTime;
+    MumeSeason m_lastSeason;
+};
+
 
 #endif

--- a/src/clock/mumeclockwidget.ui
+++ b/src/clock/mumeclockwidget.ui
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MumeClockWidget</class>
+ <widget class="QWidget" name="MumeClockWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>88</width>
+    <height>20</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Mume Clock</string>
+  </property>
+  <property name="toolTip">
+   <string>Mume Clock</string>
+  </property>
+  <property name="statusTip">
+   <string>Current time in Mume</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="seasonLabel">
+       <property name="text">
+        <string>Season</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="timeLabel">
+       <property name="text">
+        <string>Clock not set</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/clock/mumemoment.cpp
+++ b/src/clock/mumemoment.cpp
@@ -1,0 +1,106 @@
+/************************************************************************
+**
+** Authors:   Nils Schimmelmann <nschimme@gmail.com> (Jahara)
+**
+** This file is part of the MMapper project.
+** Maintained by Nils Schimmelmann <nschimme@gmail.com>
+**
+** This program is free software; you can redistribute it and/or
+** modify it under the terms of the GNU General Public License
+** as published by the Free Software Foundation; either version 2
+** of the License, or (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the:
+** Free Software Foundation, Inc.
+** 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+**
+************************************************************************/
+#include "mumemoment.h"
+#include "mumeclock.h"
+
+#define MUME_MINUTES_PER_HOUR 60
+#define MUME_HOURS_PER_DAY 24
+#define MUME_DAYS_PER_MONTH 30
+#define MUME_MONTHS_PER_YEAR 12
+
+#define MUME_MINUTES_PER_DAY     (MUME_HOURS_PER_DAY * MUME_MINUTES_PER_HOUR)
+#define MUME_MINUTES_PER_MONTH   (MUME_DAYS_PER_MONTH * MUME_MINUTES_PER_DAY)
+#define MUME_MINUTES_PER_YEAR    (MUME_MONTHS_PER_YEAR * MUME_MINUTES_PER_MONTH)
+
+MumeMoment::MumeMoment(int year, int month, int day, int hour, int minute)
+{
+    m_year = year;
+    m_month = month;
+    m_day = day;
+    m_hour = hour;
+    m_minute = minute;
+}
+
+MumeMoment::MumeMoment(int secsSinceMumeStartEpoch)
+{   // https://github.com/iheartdisraptor/mume/blob/master/mudlet/scrolls/Clock/lua/clock.lua
+    int mumeTimeYears = (secsSinceMumeStartEpoch / MUME_MINUTES_PER_YEAR);
+    m_year = MUME_START_YEAR + mumeTimeYears;
+
+    int mumeTimeMinusYears = secsSinceMumeStartEpoch - mumeTimeYears * MUME_MINUTES_PER_YEAR;
+    m_month = mumeTimeMinusYears / MUME_MINUTES_PER_MONTH;
+
+    int mumeTimeMinusYearsAndMonths = mumeTimeMinusYears - m_month * MUME_MINUTES_PER_MONTH;
+    m_day = mumeTimeMinusYearsAndMonths / MUME_MINUTES_PER_DAY;
+
+    int mumeTimeMinusYearsMonthsAndDays = mumeTimeMinusYearsAndMonths - m_day * MUME_MINUTES_PER_DAY;
+    m_hour = mumeTimeMinusYearsMonthsAndDays / MUME_MINUTES_PER_HOUR;
+
+    int mumeTimeMinusYearsMonthDaysAndMinutes = mumeTimeMinusYearsMonthsAndDays - m_hour * MUME_MINUTES_PER_HOUR;
+    m_minute = mumeTimeMinusYearsMonthsAndDays <= 0 ? 0 : mumeTimeMinusYearsMonthDaysAndMinutes;
+}
+
+int MumeMoment::toSeconds()
+{
+    return m_minute
+            + m_hour * MUME_MINUTES_PER_HOUR
+            + m_day * MUME_MINUTES_PER_DAY
+            + m_month * MUME_MINUTES_PER_MONTH
+            + (m_year - MUME_START_YEAR) * MUME_MINUTES_PER_YEAR;
+}
+
+MumeSeason MumeMoment::toSeason() {
+    switch (m_month) {
+    case MumeClock::Afteryule:
+    case MumeClock::Solmath:
+    case MumeClock::Rethe:
+        return SEASON_WINTER;
+    case MumeClock::Astron:
+    case MumeClock::Thrimidge:
+    case MumeClock::Forelithe:
+        return SEASON_SPRING;
+    case MumeClock::Afterlithe:
+    case MumeClock::Wedmath:
+    case MumeClock::Halimath:
+        return SEASON_SUMMER;
+    case MumeClock::Winterfilth:
+    case MumeClock::Blotmath:
+    case MumeClock::Foreyule:
+        return SEASON_AUTUMN;
+    default:
+        return SEASON_UNKNOWN;
+    };
+}
+
+MumeTime MumeMoment::toTimeOfDay() {
+    int dawn = MumeClock::m_dawnHour[m_month];
+    int dusk = MumeClock::m_duskHour[m_month];
+    if (m_hour == dawn)
+        return TIME_DAWN;
+    else if (m_hour == dusk)
+        return TIME_DUSK;
+    else if (m_hour < dawn || m_hour > dusk)
+        return TIME_NIGHT;
+    else
+        return TIME_DAY;
+}

--- a/src/clock/mumemoment.h
+++ b/src/clock/mumemoment.h
@@ -1,10 +1,8 @@
 /************************************************************************
 **
-** Authors:   Ulf Hermann <ulfonk_mennhar@gmx.de> (Alve),
-**            Marek Krejza <krejza@gmail.com> (Caligor),
-**            Nils Schimmelmann <nschimme@gmail.com> (Jahara)
+** Authors:   Nils Schimmelmann <nschimme@gmail.com> (Jahara)
 **
-** This file is part of the MMapper project. 
+** This file is part of the MMapper project.
 ** Maintained by Nils Schimmelmann <nschimme@gmail.com>
 **
 ** This program is free software; you can redistribute it and/or
@@ -24,15 +22,32 @@
 **
 ************************************************************************/
 
-#ifndef PARSERUTILS_H
-#define PARSERUTILS_H
+#ifndef MUMEMOMENT_H
+#define MUMEMOMENT_H
 
-#include <QString>
+#define MUME_START_YEAR 2850
 
-namespace ParserUtils
+enum MumeTime {TIME_UNKNOWN = 0, TIME_DAWN, TIME_DAY, TIME_DUSK, TIME_NIGHT};
+enum MumeSeason {SEASON_UNKNOWN = 0, SEASON_WINTER, SEASON_SPRING, SEASON_SUMMER, SEASON_AUTUMN};
+
+class QString;
+
+class MumeMoment
 {
-  QString& removeAnsiMarks(QString& str);
-  QString& latinToAscii(QString& str);
-}
+public:
+    MumeMoment(int year, int month, int day, int hour, int minute);
+    MumeMoment(int secsSinceMumeStartEpoch);
 
-#endif
+    int toSeconds();
+
+    MumeSeason toSeason();
+    MumeTime toTimeOfDay();
+
+    int m_year = 0;
+    int m_month = 0;
+    int m_day = 0;
+    int m_hour = 0;
+    int m_minute = 0;
+};
+
+#endif // MUMEMOMENT_H

--- a/src/configuration/configuration.cpp
+++ b/src/configuration/configuration.cpp
@@ -124,13 +124,13 @@ void Configuration::read()
   m_groupManagerHost = conf.value("host", "localhost").toByteArray();
   m_groupManagerCharName = conf.value("character name", "MMapper").toByteArray();
   m_showGroupManager = conf.value("show", false).toBool();
-  m_showGroupManager = false;
   m_groupManagerColor = (QColor) conf.value("color", "#ffff00").toString();
-  m_groupManagerRect.setRect(conf.value("rectangle x", 0).toInt(),
-                             conf.value("rectangle y", 0).toInt(),
-                             conf.value("rectangle width", 0).toInt(),
-                             conf.value("rectangle height", 0).toInt());
   m_groupManagerRulesWarning = conf.value("rules warning", true).toBool();
+  conf.endGroup();
+
+  conf.beginGroup("Mume Clock");
+  m_mumeStartEpoch = conf.value("Mume start epoch", 1420070400).toInt();
+  m_displayMumeClock =conf.value("Display clock", true).toBool();
   conf.endGroup();
 }
 
@@ -209,11 +209,12 @@ void Configuration::write() const {
   conf.setValue("character name", m_groupManagerCharName);
   conf.setValue("show", m_showGroupManager);
   conf.setValue("color", m_groupManagerColor.name());
-  conf.setValue("rectangle x", m_groupManagerRect.x());
-  conf.setValue("rectangle y", m_groupManagerRect.y());
-  conf.setValue("rectangle width", m_groupManagerRect.width());
-  conf.setValue("rectangle height", m_groupManagerRect.height());
   conf.setValue("rules warning", m_groupManagerRulesWarning);
+  conf.endGroup();
+
+  conf.beginGroup("Mume Clock");
+  conf.setValue("Mume start epoch", m_mumeStartEpoch);
+  conf.setValue("Display clock", m_displayMumeClock);
   conf.endGroup();
 }
 

--- a/src/configuration/configuration.h
+++ b/src/configuration/configuration.h
@@ -27,11 +27,12 @@
 #ifndef _CONFIGURATION_H_
 #define _CONFIGURATION_H_
 
-#include "defs.h"
 #include <QStringList>
-#include <QRect>
+#include <QPoint>
 #include <QSize>
 #include <QColor>
+
+#include "defs.h"
 
 class Configuration {
   public:
@@ -98,9 +99,11 @@ class Configuration {
     QByteArray m_groupManagerHost;
     QByteArray m_groupManagerCharName;
     bool m_showGroupManager;
-    QRect m_groupManagerRect;
     QColor m_groupManagerColor;
     bool m_groupManagerRulesWarning;
+
+    int m_mumeStartEpoch;
+    bool m_displayMumeClock;
 
   private:
     Configuration();

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -46,6 +46,8 @@
 #include "CGroupCommunicator.h"
 #include "progresscounter.h"
 #include "mapstorage/filesaver.h"
+#include "mumeclockwidget.h"
+#include "mumeclock.h"
 
 #include <QMessageBox>
 #include <QMenuBar>
@@ -142,6 +144,8 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
   m_findRoomsDlg = new FindRoomsDlg(m_mapData, this);
   m_findRoomsDlg->setObjectName("FindRoomsDlg");
 
+  m_mumeClock = new MumeClock(Config().m_mumeStartEpoch);
+
   createActions();
   setupMenuBar();
   setupToolBars();
@@ -153,7 +157,7 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
   setCorner(Qt::BottomRightCorner, Qt::BottomDockWidgetArea);
 
 
-  ConnectionListener* server = new ConnectionListener(m_mapData, m_pathMachine, m_commandEvaluator, m_prespammedPath, m_groupManager, this);
+  ConnectionListener* server = new ConnectionListener(m_mapData, m_pathMachine, m_commandEvaluator, m_prespammedPath, m_groupManager, m_mumeClock, this);
   server->setMaxPendingConnections (1);
   server->setRemoteHost(Config().m_remoteServerName);
   server->setRemotePort(Config().m_remotePort);
@@ -269,6 +273,8 @@ void MainWindow::currentMapWindowChanged()
   connect(m_groupManager, SIGNAL(log(const QString&, const QString&)), this, SLOT(log(const QString&, const QString&)));
   connect(m_pathMachine, SIGNAL(setCharPosition(uint)), m_groupManager, SLOT(setCharPosition(uint)));
   connect(m_groupManager, SIGNAL(drawCharacters()), getCurrentMapWindow()->getCanvas(), SLOT(update()));
+
+  QObject::connect(m_mumeClock, SIGNAL(log( const QString&, const QString& )), this, SLOT(log( const QString&, const QString& )));
 }
 
 
@@ -790,6 +796,7 @@ void MainWindow::setupToolBars()
 void MainWindow::setupStatusBar()
 {
   statusBar()->showMessage(tr("Welcome to MMapper ..."));
+  statusBar()->insertPermanentWidget(0, new MumeClockWidget(m_mumeClock));
 }
 
 void MainWindow::onPreferences()

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -49,6 +49,7 @@ class RoomPropertySetter;
 class FindRoomsDlg;
 class CGroup;
 class CGroupCommunicator;
+class MumeClock;
 
 class DockWidget : public QDockWidget
 {
@@ -165,6 +166,7 @@ private:
   RoomPropertySetter * m_propertySetter;
   CommandEvaluator *m_commandEvaluator;
   PrespammedPath *m_prespammedPath;
+  MumeClock *m_mumeClock;
 
   // Pandora Ported
   FindRoomsDlg *m_findRoomsDlg;

--- a/src/parser/abstractparser.h
+++ b/src/parser/abstractparser.h
@@ -35,6 +35,7 @@
 #include <QQueue>
 #include <QObject>
 
+class MumeClock;
 class ParseEvent;
 class MapData;
 class Room;
@@ -89,7 +90,7 @@ class AbstractParser : public QObject
   Q_OBJECT
 public:
 
-   AbstractParser(MapData*, QObject *parent = 0);
+   AbstractParser(MapData*, MumeClock*, QObject *parent = 0);
    ~AbstractParser();
 
    const RoomSelection *search_rs;
@@ -141,16 +142,11 @@ protected:
 
   void printRoomInfo(uint fieldset);
 
-  //utility functions
-  QString& removeAnsiMarks(QString& str);
-
   void emulateExits();
 
   void parseExits(QString& str);
   void parsePrompt(QString& prompt);
   virtual bool parseUserCommands(QString& command);
-
-  static const QChar escChar;
 
   QString m_stringBuffer;
   QByteArray m_byteBuffer;
@@ -166,7 +162,7 @@ protected:
   QString m_lastPrompt;
 
   CommandQueue queue;
-
+  MumeClock* m_mumeClock;
   MapData* m_mapData;
 
   static const QString nullString;

--- a/src/parser/mumexmlparser.h
+++ b/src/parser/mumexmlparser.h
@@ -32,7 +32,7 @@
 
 //#define XMLPARSER_STREAM_DEBUG_INPUT_TO_FILE
 
-enum XmlMode            {XML_NONE, XML_ROOM, XML_NAME, XML_DESCRIPTION, XML_EXITS, XML_PROMPT, XML_TERRAIN};
+enum XmlMode            {XML_NONE, XML_ROOM, XML_NAME, XML_DESCRIPTION, XML_EXITS, XML_PROMPT, XML_TERRAIN, XML_WEATHER};
 
 class MumeXmlParser : public AbstractParser
 {
@@ -40,14 +40,10 @@ class MumeXmlParser : public AbstractParser
 
   public:
 
-    MumeXmlParser(MapData*, QObject *parent = 0);
+    MumeXmlParser(MapData*, MumeClock*, QObject *parent = 0);
     ~MumeXmlParser();
 
-
     void parse(const QByteArray& );
-
-signals:
-    void suggestTime(const QString&, const QString&);
 
   public slots:
     void parseNewMudInput(IncomingData& que);
@@ -81,6 +77,7 @@ signals:
     QString m_mumeTime;
     bool m_readingTag;
     bool m_readStatusTag;
+    bool m_readWeatherTag;
     bool m_gratuitous;
     CommandIdType m_move;
 
@@ -88,6 +85,7 @@ signals:
 
   signals:
     void sendScoreLineEvent(QByteArray);
+    void mumeTime(QString);
 };
 
 #endif

--- a/src/parser/parserutils.cpp
+++ b/src/parser/parserutils.cpp
@@ -28,85 +28,106 @@
 
 namespace ParserUtils {
 
+static const unsigned char colorEndMark = 'm';
+static const unsigned char escChar = '\033';
+
+// latin1 to 7-bit Ascii
+static const unsigned char latin1ToAscii[] = {
+/*192*/ 'A',
+        'A',
+        'A',
+        'A',
+        'A',
+        'A',
+        'A',
+        'C',
+        'E',
+        'E',
+        'E',
+        'E',
+        'I',
+        'I',
+        'I',
+        'I',
+        'D',
+        'N',
+        'O',
+        'O',
+        'O',
+        'O',
+        'O',
+        'x',
+        'O',
+        'U',
+        'U',
+        'U',
+        'U',
+        'Y',
+        'b',
+        'B',
+        'a',
+        'a',
+        'a',
+        'a',
+        'a',
+        'a',
+        'a',
+        'c',
+        'e',
+        'e',
+        'e',
+        'e',
+        'i',
+        'i',
+        'i',
+        'i',
+        'o',
+        'n',
+        'o',
+        'o',
+        'o',
+        'o',
+        'o',
+        ':',
+        'o',
+        'u',
+        'u',
+        'u',
+        'u',
+        'y',
+        'b',
+        'y'
+};
+
+QString& removeAnsiMarks(QString& str) {
+  QString out="";
+  bool started=false;
+  for ( int i=0; i< str.length(); i++ ){
+    if ( started && (str.at(i).toLatin1() == colorEndMark)){
+      started = false;
+      continue;
+    }
+    if (str.at(i).toLatin1() == escChar){
+      started = true;
+      continue;
+    }
+    if (started) continue;
+    out.append(str.at(i));
+  }
+  str = out;
+  return str;
+}
+
 QString& latinToAscii(QString& str) {
-    // latin1 to 7-bit Ascii
-    // taken from Pandora
-  const static unsigned char table[] = {
-/*192*/   'A',
-          'A',
-          'A',
-          'A',
-          'A',
-          'A',
-          'A',
-          'C',
-          'E',
-          'E',
-          'E',
-          'E',
-          'I',
-          'I',
-          'I',
-          'I',
-          'D',
-          'N',
-          'O',
-          'O',
-          'O',
-          'O',
-          'O',
-          'x',
-          'O',
-          'U',
-          'U',
-          'U',
-          'U',
-          'Y',
-          'b',
-          'B',
-          'a',
-          'a',
-          'a',
-          'a',
-          'a',
-          'a',
-          'a',
-          'c',
-          'e',
-          'e',
-          'e',
-          'e',
-          'i',
-          'i',
-          'i',
-          'i',
-          'o',
-          'n',
-          'o',
-          'o',
-          'o',
-          'o',
-          'o',
-          ':',
-          'o',
-          'u',
-          'u',
-          'u',
-          'u',
-          'y',
-          'b',
-          'y'
-  };
   unsigned char ch;
   int pos;
-
   for (pos = 0; pos < str.length(); pos++) {
     ch = str.at(pos).toLatin1();
     if (ch > 128) {
       if (ch < 192)
         ch = 'z';
       else
-        ch = table[ ch - 192 ];
+        ch = latin1ToAscii[ ch - 192 ];
       str[pos] = ch;
     }
   }

--- a/src/parser/patterns.cpp
+++ b/src/parser/patterns.cpp
@@ -113,6 +113,7 @@ bool Patterns::matchScore(QString& str)
     return m_score.exactMatch(str);
 }
 
+
 bool Patterns::matchMoveForcePatterns(QString& str)
 {
 	for ( QStringList::iterator it = Config().m_moveForcePatternsList.begin(); 

--- a/src/preferences/generalpage.cpp
+++ b/src/preferences/generalpage.cpp
@@ -53,6 +53,8 @@ GeneralPage::GeneralPage(QWidget *parent)
 
   connect( sellectWorldFileButton, SIGNAL(clicked()), this, SLOT(selectWorldFileButtonClicked()));
 
+  connect( displayMumeClockCheckBox, SIGNAL(stateChanged(int)),SLOT(displayMumeClockStateChanged(int)));
+
   remoteName->setText( Config().m_remoteServerName );
   remotePort->setValue( Config().m_remotePort );
   localPort->setValue( Config().m_localPort );
@@ -72,6 +74,8 @@ GeneralPage::GeneralPage(QWidget *parent)
 
   autoLoadCheck->setChecked( Config().m_autoLoadWorld ); 
   autoLoadFileName->setText( Config().m_autoLoadFileName );
+
+  displayMumeClockCheckBox->setChecked(Config().m_displayMumeClock);
 }
 
 void GeneralPage::changeColorClicked()
@@ -156,4 +160,7 @@ void GeneralPage::autoLoadCheckStateChanged(int)
   Config().m_autoLoadWorld = autoLoadCheck->isChecked(); 
 }
 
-
+void GeneralPage::displayMumeClockStateChanged(int)
+{
+  Config().m_displayMumeClock = displayMumeClockCheckBox->isChecked();
+}

--- a/src/preferences/generalpage.h
+++ b/src/preferences/generalpage.h
@@ -55,6 +55,8 @@ public slots:
 	
 	void selectWorldFileButtonClicked();	
 
+    void displayMumeClockStateChanged(int);
+
 public:
     GeneralPage(QWidget *parent = 0);
 };

--- a/src/preferences/generalpage.ui
+++ b/src/preferences/generalpage.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>487</width>
-    <height>535</height>
+    <height>552</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -184,7 +184,7 @@
       <item row="1" column="0">
        <widget class="QLabel" name="label_2">
         <property name="text">
-         <string>Anti-aliasing samples</string>
+         <string>Anti-aliasing samples:</string>
         </property>
        </widget>
       </item>
@@ -198,7 +198,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>Background color</string>
+         <string>Background color:</string>
         </property>
        </widget>
       </item>
@@ -376,6 +376,40 @@
        <widget class="QCheckBox" name="autoLoadCheck">
         <property name="text">
          <string>Auto load world:</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="frame_4">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Sunken</enum>
+     </property>
+     <layout class="QGridLayout">
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
+      <property name="topMargin">
+       <number>9</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
+      <property name="bottomMargin">
+       <number>9</number>
+      </property>
+      <property name="spacing">
+       <number>6</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="displayMumeClockCheckBox">
+        <property name="text">
+         <string>Display Mume clock</string>
         </property>
        </widget>
       </item>

--- a/src/proxy/connectionlistener.cpp
+++ b/src/proxy/connectionlistener.cpp
@@ -27,7 +27,7 @@
 #include "connectionlistener.h"
 #include "proxy.h"
 
-ConnectionListener::ConnectionListener(MapData* md, Mmapper2PathMachine* pm, CommandEvaluator* ce, PrespammedPath* pp, CGroup* gm, QObject *parent)
+ConnectionListener::ConnectionListener(MapData* md, Mmapper2PathMachine* pm, CommandEvaluator* ce, PrespammedPath* pp, CGroup* gm, MumeClock* mc, QObject *parent)
   : QTcpServer(parent)
 {
   m_accept = true;
@@ -37,6 +37,7 @@ ConnectionListener::ConnectionListener(MapData* md, Mmapper2PathMachine* pm, Com
   m_commandEvaluator = ce;
   m_prespammedPath = pp;
   m_groupManager = gm;
+  m_mumeClock = mc;
 
   connect(this, SIGNAL(log(const QString&, const QString&)), parent, SLOT(log(const QString&, const QString&)));
 }
@@ -48,7 +49,7 @@ void ConnectionListener::incomingConnection(qintptr socketDescriptor)
   {
     emit log ("Listener", "New connection: accepted.");
     doNotAcceptNewConnections();
-    Proxy *proxy = new Proxy(m_mapData, m_pathMachine, m_commandEvaluator, m_prespammedPath, m_groupManager, socketDescriptor, m_remoteHost, m_remotePort, true, this);
+    Proxy *proxy = new Proxy(m_mapData, m_pathMachine, m_commandEvaluator, m_prespammedPath, m_groupManager, m_mumeClock, socketDescriptor, m_remoteHost, m_remotePort, true, this);
     proxy->start();
   }
   else

--- a/src/proxy/connectionlistener.h
+++ b/src/proxy/connectionlistener.h
@@ -35,10 +35,11 @@ class Mmapper2PathMachine;
 class CommandEvaluator;
 class PrespammedPath;
 class CGroup;
+class MumeClock;
 
 class ConnectionListener : public QTcpServer {
   public:
-    ConnectionListener(MapData*, Mmapper2PathMachine*, CommandEvaluator*, PrespammedPath*, CGroup*, QObject *parent);
+    ConnectionListener(MapData*, Mmapper2PathMachine*, CommandEvaluator*, PrespammedPath*, CGroup*, MumeClock*, QObject *parent);
 
     QString getRemoteHost() const {return m_remoteHost;}
     void setRemoteHost(QString i) {m_remoteHost = i;}
@@ -66,6 +67,7 @@ class ConnectionListener : public QTcpServer {
     CommandEvaluator* m_commandEvaluator;
     PrespammedPath* m_prespammedPath;
     CGroup* m_groupManager;
+    MumeClock* m_mumeClock;
 
         bool m_accept;
 };

--- a/src/proxy/proxy.cpp
+++ b/src/proxy/proxy.cpp
@@ -33,6 +33,7 @@
 #include "prespammedpath.h"
 #include "CGroup.h"
 #include "configuration.h"
+#include "mumeclock.h"
 
 #include <qvariant.h>
 
@@ -57,7 +58,7 @@ void ProxyThreader::run() {
 
 
 
-Proxy::Proxy(MapData* md, Mmapper2PathMachine* pm, CommandEvaluator* ce, PrespammedPath* pp, CGroup* gm, qintptr & socketDescriptor, QString & host, int & port, bool threaded, QObject *parent)
+Proxy::Proxy(MapData* md, Mmapper2PathMachine* pm, CommandEvaluator* ce, PrespammedPath* pp, CGroup* gm, MumeClock* mc, qintptr & socketDescriptor, QString & host, int & port, bool threaded, QObject *parent)
   : QObject(NULL),
             m_socketDescriptor(socketDescriptor),
                                m_remoteHost(host),
@@ -71,6 +72,7 @@ Proxy::Proxy(MapData* md, Mmapper2PathMachine* pm, CommandEvaluator* ce, Prespam
                                                                     m_commandEvaluator(ce),
                                                                         m_prespammedPath(pp),
                                                                             m_groupManager(gm),
+                                                                            m_mumeClock(mc),
                                                                                 m_threaded(threaded),
                                                                                 m_parent(parent)
 {
@@ -147,7 +149,7 @@ bool Proxy::init()
   connect(m_filter, SIGNAL(sendToMud(const QByteArray&)), this, SLOT(sendToMud(const QByteArray&)));
   connect(m_filter, SIGNAL(sendToUser(const QByteArray&)), this, SLOT(sendToUser(const QByteArray&)));
 
-  m_parserXml = new MumeXmlParser(m_mapData, this);
+  m_parserXml = new MumeXmlParser(m_mapData, m_mumeClock, this);
   connect(m_filter, SIGNAL(parseNewMudInputXml(IncomingData&)), m_parserXml, SLOT(parseNewMudInput(IncomingData&)));
   connect(m_filter, SIGNAL(parseNewUserInputXml(IncomingData&)), m_parserXml, SLOT(parseNewUserInput(IncomingData&)));
   connect(m_parserXml, SIGNAL(sendToMud(const QByteArray&)), this, SLOT(sendToMud(const QByteArray&)));

--- a/src/proxy/proxy.h
+++ b/src/proxy/proxy.h
@@ -44,6 +44,7 @@ class Mmapper2PathMachine;
 class CommandEvaluator;
 class PrespammedPath;
 class CGroup;
+class MumeClock;
 
 class ProxyThreader: public QThread
 {
@@ -66,7 +67,7 @@ class Proxy : public QObject
     Q_OBJECT
 
   public:
-    Proxy(MapData*, Mmapper2PathMachine*, CommandEvaluator*, PrespammedPath*, CGroup*, qintptr & socketDescriptor, QString & host, int & port, bool threaded, QObject *parent);
+    Proxy(MapData*, Mmapper2PathMachine*, CommandEvaluator*, PrespammedPath*, CGroup*, MumeClock*, qintptr & socketDescriptor, QString & host, int & port, bool threaded, QObject *parent);
     ~Proxy();
 
     void start();
@@ -114,6 +115,7 @@ class Proxy : public QObject
     CommandEvaluator* m_commandEvaluator;
     PrespammedPath* m_prespammedPath;
     CGroup* m_groupManager;
+    MumeClock* m_mumeClock;
 
     ProxyThreader *m_thread;
     bool m_threaded;

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,5 +1,20 @@
+# Clock
+SET(clock_SRCS ../clock/mumeclock.cpp ../clock/mumemoment.cpp)
+SET(TestClock_SRCS testclock.cpp)
+ADD_EXECUTABLE(TestClock ${TestClock_SRCS} ${clock_SRCS})
+TARGET_LINK_LIBRARIES(TestClock Qt5::Test)
+ADD_TEST(NAME TestClock COMMAND TestClock)
+
+# Expandora
 FILE(GLOB_RECURSE expandoracommon_SRCS ../expandoracommon/*.cpp)
 SET(TestExpandoraCommon_SRCS testexpandoracommon.cpp)
 ADD_EXECUTABLE(TestExpandoraCommon ${TestExpandoraCommon_SRCS} ${expandoracommon_SRCS})
 TARGET_LINK_LIBRARIES(TestExpandoraCommon Qt5::Test)
 ADD_TEST(NAME TestExpandoraCommon COMMAND TestExpandoraCommon)
+
+# Parser
+SET(parser_SRCS ../parser/parserutils.cpp)
+SET(TestParser_SRCS testparser.cpp)
+ADD_EXECUTABLE(TestParser ${TestParser_SRCS} ${parser_SRCS})
+TARGET_LINK_LIBRARIES(TestParser Qt5::Test)
+ADD_TEST(NAME TestParser COMMAND TestParser)

--- a/src/tests/testclock.cpp
+++ b/src/tests/testclock.cpp
@@ -1,0 +1,187 @@
+#include <QtTest/QtTest>
+#include <QDebug>
+
+#include "testclock.h"
+#include "mumeclock.h"
+
+using namespace std;
+
+TestClock::TestClock()
+    : QObject()
+{}
+
+TestClock::~TestClock()
+{
+}
+
+int convertMumeRealTime(const QString& realTime)
+{
+    // Real time is Wed Dec 20 07:03:27 2017 UTC.
+    QString dateString = realTime.mid(13, 24);
+    QDateTime parsedTime = QDateTime::fromString(dateString, "ddd MMM dd hh:mm:ss yyyy");
+    return parsedTime.toTime_t();
+}
+
+QString testMumeStartEpochTime(MumeClock &clock, int time)
+{
+    return clock.toMumeTime(clock.getMumeMoment(clock.getMumeStartEpoch() + time));
+}
+
+void TestClock::mumeClockTest()
+{
+    MumeClock clock;
+    clock.setPrecision(MUMECLOCK_HOUR);
+
+    QString zeroTime = "12am on the 1st of Afteryule, Year 2850 of the Third Age.";
+    QString actualTime = testMumeStartEpochTime(clock, 0);
+    QCOMPARE(actualTime, zeroTime);
+
+    QString oneSecond = "12am on the 1st of Afteryule, Year 2850 of the Third Age.";
+    actualTime = testMumeStartEpochTime(clock, 1);
+    QCOMPARE(actualTime, oneSecond);
+
+    QString oneTick = "1am on the 1st of Afteryule, Year 2850 of the Third Age.";
+    actualTime = testMumeStartEpochTime(clock, 60);
+    QCOMPARE(actualTime, oneTick);
+
+    QString oneDay = "12am on the 2nd of Afteryule, Year 2850 of the Third Age.";
+    actualTime = testMumeStartEpochTime(clock, 60 *24);
+    QCOMPARE(actualTime, oneDay);
+
+    QString oneMonth = "12am on the 1st of Solmath, Year 2850 of the Third Age.";
+    actualTime = testMumeStartEpochTime(clock, 60 * 24 * 30);
+    QCOMPARE(actualTime, oneMonth);
+
+    QString oneYear = "12am on the 1st of Afteryule, Year 2851 of the Third Age.";
+    actualTime = testMumeStartEpochTime(clock, 60 * 24 * 30 * 12);
+    QCOMPARE(actualTime, oneYear);
+}
+
+void TestClock::parseMumeTimeTest()
+{
+    MumeClock clock;
+
+    // Defaults to epoch time of zero
+    QString expectedZeroEpoch = "1st of Afteryule, Year 2850 of the Third Age.";
+    QCOMPARE(testMumeStartEpochTime(clock, 0), expectedZeroEpoch);
+
+    // Real time is Wed Dec 20 07:03:27 2017 UTC.
+    QString snapShot1 = "3pm on Highday, the 18th of Halimath, Year 3030 of the Third Age.";
+    QString expected1 = "3pm on the 18th of Halimath, Year 3030 of the Third Age.";
+    clock.parseMumeTime(snapShot1);
+    QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), expected1);
+
+    // Real time is Wed Dec 20 07:18:02 2017 UTC.
+    QString snapShot2 = "5am on Sterday, the 19th of Halimath, Year 3030 of the Third Age.";
+    QString expected2 = "5am on the 19th of Halimath, Year 3030 of the Third Age.";
+    clock.parseMumeTime(snapShot2);
+    QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), expected2);
+
+    // Real time is Wed Dec 20 07:38:44 2017 UTC.
+    QString snapShot3 = "2am on Sunday, the 20th of Halimath, Year 3030 of the Third Age.";
+    QString expected3 = "2am on the 20th of Halimath, Year 3030 of the Third Age.";
+    clock.parseMumeTime(snapShot3);
+    QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), expected3);
+
+    // Real time is Thu Dec 21 05:27:35 2017 UTC.
+    QString snapShot4 = "3pm on Highday, the 14th of Blotmath, Year 3030 of the Third Age.";
+    QString expected4 = "3pm on the 14th of Blotmath, Year 3030 of the Third Age.";
+    clock.parseMumeTime(snapShot4);
+    QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), expected4);
+
+    // Sindarin Calendar
+    QString sindarin = "3pm on Oraearon, the 14th of Hithui, Year 3030 of the Third Age.";
+    QString expectedSindarin = expected4;
+    clock.parseMumeTime(sindarin);
+    QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), expectedSindarin);
+}
+
+void TestClock::tickSyncTest()
+{
+    MumeClock clock;
+
+    QString snapShot1 = "3pm on Highday, the 18th of Halimath, Year 3030 of the Third Age.";
+    QString expected1 = "3pm on the 18th of Halimath, Year 3030 of the Third Age.";
+    int realTime1 = convertMumeRealTime("Real time is Wed Dec 20 07:03:27 2017 UTC.");
+    clock.parseMumeTime(snapShot1, realTime1);
+    QCOMPARE(clock.toMumeTime(clock.getMumeMoment(realTime1)), expected1);
+
+    // First sync
+    int timeOccuredAt = 1;
+    QString expectedTime = "4:00pm on the 18th of Halimath, Year 3030 of the Third Age.";
+    clock.tickSync(realTime1 + timeOccuredAt);
+    QCOMPARE(clock.toMumeTime(clock.getMumeMoment(realTime1 + timeOccuredAt)), expectedTime);
+
+    // Mume running on time
+    timeOccuredAt = 1 + 60;
+    expectedTime = "5:00pm on the 18th of Halimath, Year 3030 of the Third Age.";
+    clock.tickSync(realTime1 + timeOccuredAt);
+    QCOMPARE(clock.toMumeTime(clock.getMumeMoment(realTime1 + timeOccuredAt)), expectedTime);
+
+    // Mume running fast
+    timeOccuredAt = 1 + 60 + 58;
+    expectedTime = "6:00pm on the 18th of Halimath, Year 3030 of the Third Age.";
+    clock.tickSync(realTime1 + timeOccuredAt);
+    QCOMPARE(clock.toMumeTime(clock.getMumeMoment(realTime1 + timeOccuredAt)), expectedTime);
+
+    // Mume running on time
+    timeOccuredAt = 1 + 60 + 58 + 60;
+    expectedTime = "7:00pm on the 18th of Halimath, Year 3030 of the Third Age.";
+    clock.tickSync(realTime1 + timeOccuredAt);
+    QCOMPARE(clock.toMumeTime(clock.getMumeMoment(realTime1 + timeOccuredAt)), expectedTime);
+
+    // Mume running slow
+    timeOccuredAt = 1 + 60 + 58 + 60 + 65;
+    expectedTime = "8:00pm on the 18th of Halimath, Year 3030 of the Third Age.";
+    clock.tickSync(realTime1 + timeOccuredAt);
+    QCOMPARE(clock.toMumeTime(clock.getMumeMoment(realTime1 + timeOccuredAt)), expectedTime);
+}
+
+void TestClock::partOfDayTickSyncTest()
+{
+    MumeClock clock;
+
+    QString snapShot1 = "3pm on Highday, the 18th of Halimath, Year 3030 of the Third Age.";
+    QString expectedTime = "3pm on the 18th of Halimath, Year 3030 of the Third Age.";
+    clock.parseMumeTime(snapShot1);
+    QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), expectedTime);
+
+    expectedTime = "5:00am on the 18th of Halimath, Year 3030 of the Third Age.";
+    clock.tickSync(TIME_DAWN);
+    QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), expectedTime);
+
+    expectedTime = "6:00am on the 18th of Halimath, Year 3030 of the Third Age.";
+    clock.tickSync(TIME_DAY);
+    QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), expectedTime);
+
+    expectedTime = "9:00pm on the 18th of Halimath, Year 3030 of the Third Age.";
+    clock.tickSync(TIME_DUSK);
+    QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), expectedTime);
+
+    expectedTime = "10:00pm on the 18th of Halimath, Year 3030 of the Third Age.";
+    clock.tickSync(TIME_NIGHT);
+    QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), expectedTime);
+}
+
+void TestClock::parseClockTimeTest()
+{
+    MumeClock clock;
+
+    // Clock set to coarse
+    // Real time is Wed Dec 20 07:03:27 2017 UTC.
+    QString snapShot1 = "3pm on Highday, the 18th of Halimath, Year 3030 of the Third Age.";
+    QString expected1 = "3pm on the 18th of Halimath, Year 3030 of the Third Age.";
+    clock.parseMumeTime(snapShot1);
+    QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), expected1);
+
+    QString afternoon = "3:34pm on the 18th of Halimath, Year 3030 of the Third Age.";
+    clock.parseClockTime("The current time is 3:34 pm.");
+    QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), afternoon);
+
+    QString midnight = "12:51am on the 18th of Halimath, Year 3030 of the Third Age.";
+    clock.parseClockTime("The current time is 12:51 am.");
+    QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), midnight);
+
+}
+
+QTEST_MAIN(TestClock)

--- a/src/tests/testclock.h
+++ b/src/tests/testclock.h
@@ -1,10 +1,8 @@
 /************************************************************************
 **
-** Authors:   Ulf Hermann <ulfonk_mennhar@gmx.de> (Alve),
-**            Marek Krejza <krejza@gmail.com> (Caligor),
-**            Nils Schimmelmann <nschimme@gmail.com> (Jahara)
+** Authors:   Nils Schimmelmann <nschimme@gmail.com>
 **
-** This file is part of the MMapper project. 
+** This file is part of the MMapper project.
 ** Maintained by Nils Schimmelmann <nschimme@gmail.com>
 **
 ** This program is free software; you can redistribute it and/or
@@ -24,15 +22,27 @@
 **
 ************************************************************************/
 
-#ifndef PARSERUTILS_H
-#define PARSERUTILS_H
+#ifndef TESTCLOCK_H
+#define TESTCLOCK_H
 
-#include <QString>
+#include <QObject>
 
-namespace ParserUtils
+class TestClock : public QObject
 {
-  QString& removeAnsiMarks(QString& str);
-  QString& latinToAscii(QString& str);
-}
+    Q_OBJECT
+public:
+    TestClock();
+    ~TestClock() override;
+
+private:
+
+private Q_SLOTS:
+    // MumeClock
+    void mumeClockTest();
+    void parseMumeTimeTest();
+    void tickSyncTest();
+    void partOfDayTickSyncTest();
+    void parseClockTimeTest();
+};
 
 #endif

--- a/src/tests/testparser.cpp
+++ b/src/tests/testparser.cpp
@@ -1,0 +1,41 @@
+#include <QtTest/QtTest>
+#include <QDebug>
+
+#include "testparser.h"
+#include "parserutils.h"
+
+using namespace std;
+
+TestParser::TestParser()
+    : QObject()
+{}
+
+TestParser::~TestParser()
+{
+}
+
+int convertMumeRealTime(const QString& realTime)
+{
+    // Real time is Wed Dec 20 07:03:27 2017 UTC.
+    QString dateString = realTime.mid(13, 24);
+    QDateTime parsedTime = QDateTime::fromString(dateString, "ddd MMM dd hh:mm:ss yyyy");
+    return parsedTime.toTime_t();
+}
+
+void TestParser::removeAnsiMarksTest()
+{
+    QString ansiString("\033[32mHello world\033[0m");
+    QString expected("Hello world");
+    ParserUtils::removeAnsiMarks(ansiString);
+    QCOMPARE(ansiString, expected);
+}
+
+void TestParser::latinToAsciiTest()
+{
+    QString latin("Nórui Nínui");
+    QString expectedAscii("Norui Ninui");
+    ParserUtils::latinToAscii(latin);
+    QCOMPARE(latin, expectedAscii);
+}
+
+QTEST_MAIN(TestParser)

--- a/src/tests/testparser.h
+++ b/src/tests/testparser.h
@@ -1,10 +1,8 @@
 /************************************************************************
 **
-** Authors:   Ulf Hermann <ulfonk_mennhar@gmx.de> (Alve),
-**            Marek Krejza <krejza@gmail.com> (Caligor),
-**            Nils Schimmelmann <nschimme@gmail.com> (Jahara)
+** Authors:   Nils Schimmelmann <nschimme@gmail.com>
 **
-** This file is part of the MMapper project. 
+** This file is part of the MMapper project.
 ** Maintained by Nils Schimmelmann <nschimme@gmail.com>
 **
 ** This program is free software; you can redistribute it and/or
@@ -24,15 +22,24 @@
 **
 ************************************************************************/
 
-#ifndef PARSERUTILS_H
-#define PARSERUTILS_H
+#ifndef TESTPARSER_H
+#define TESTPARSER_H
 
-#include <QString>
+#include <QObject>
 
-namespace ParserUtils
+class TestParser : public QObject
 {
-  QString& removeAnsiMarks(QString& str);
-  QString& latinToAscii(QString& str);
-}
+    Q_OBJECT
+public:
+    TestParser();
+    ~TestParser() override;
+
+private:
+
+private Q_SLOTS:
+    // ParserUtils
+    void removeAnsiMarksTest();
+    void latinToAsciiTest();
+};
 
 #endif


### PR DESCRIPTION
This add support for Issue #44 and supports all races. MMapper will be very cautious in the beginning of the game because MUME has Clock skew over time. It will only show the time when it is certain enough that the time it has is correct.