### PR TITLE
Display more exits flags on map and introduce the NO_FLEE flag

### DIFF
--- a/src/configuration/configuration.cpp
+++ b/src/configuration/configuration.cpp
@@ -60,6 +60,7 @@ void Configuration::read()
   conf.beginGroup("Canvas");
   m_showUpdated = conf.value("Show updated rooms", true).toBool();
   m_drawNotMappedExits = conf.value("Draw not mapped exits", true).toBool();
+  m_drawNoMatchExits = conf.value("Draw no match exits", false).toBool();
   m_drawUpperLayersTextured = conf.value("Draw upper layers textured", false).toBool();
   m_drawDoorNames = conf.value("Draw door names", true).toBool();
   m_backgroundColor = QColor(conf.value("Background color", QColor(110,110,110).name()).toString());
@@ -158,6 +159,7 @@ void Configuration::write() const {
   conf.beginGroup("Canvas");
   conf.setValue("Show updated rooms", m_showUpdated);
   conf.setValue("Draw not mapped exits", m_drawNotMappedExits);
+  conf.setValue("Draw no match exits", m_drawNoMatchExits);
   conf.setValue("Draw upper layers textured", m_drawUpperLayersTextured);
   conf.setValue("Draw door names", m_drawDoorNames);
   conf.setValue("Background color", m_backgroundColor.name());

--- a/src/configuration/configuration.h
+++ b/src/configuration/configuration.h
@@ -70,6 +70,7 @@ class Configuration {
     bool m_emulatedExits;
     bool m_showUpdated;
     bool m_drawNotMappedExits;
+    bool m_drawNoMatchExits;
     bool m_drawUpperLayersTextured;
     bool m_drawDoorNames;
     

--- a/src/display/mapcanvas.cpp
+++ b/src/display/mapcanvas.cpp
@@ -90,6 +90,7 @@ GLubyte quadtone[] = {
     0x88, 0x88, 0x88, 0x88, 0x22, 0x22, 0x22, 0x22,
     0x88, 0x88, 0x88, 0x88, 0x22, 0x22, 0x22, 0x22};
 
+QColor MapCanvas::m_noFleeColor = QColor(123, 63, 0);
 
 MapCanvas::MapCanvas( MapData *mapData, PrespammedPath* prespammedPath, CGroup* groupManager, QWidget * parent )
     : QOpenGLWidget(parent)
@@ -2007,15 +2008,15 @@ void MapCanvas::drawRoom(const Room *room, const std::vector<Room *> & rooms, co
     }
     else
     {
-        if ( ISSET(getFlags(room->exit(ED_NORTH)), EF_CLIMB))
+        if ( ISSET(ef_north, EF_NO_FLEE))
         {
             glEnable(GL_LINE_STIPPLE);
-            glColor4d(0.7, 0.7, 0.7, 0.0);
+            qglColor(m_noFleeColor);
             glCallList(m_wall_north_gllist);
             qglColor(Qt::black);
             glDisable(GL_LINE_STIPPLE);
         }
-        if ( ISSET(getFlags(room->exit(ED_NORTH)), EF_RANDOM))
+        else if ( ISSET(ef_north, EF_RANDOM))
         {
             glEnable(GL_LINE_STIPPLE);
             glColor4d(1.0, 0.0, 0.0, 0.0);
@@ -2023,7 +2024,7 @@ void MapCanvas::drawRoom(const Room *room, const std::vector<Room *> & rooms, co
             qglColor(Qt::black);
             glDisable(GL_LINE_STIPPLE);
         }
-        if ( ISSET(getFlags(room->exit(ED_NORTH)), EF_SPECIAL))
+        else if ( ISSET(ef_north, EF_SPECIAL))
         {
             glEnable(GL_LINE_STIPPLE);
             glColor4d(0.8, 0.1, 0.8, 0.0);
@@ -2031,7 +2032,23 @@ void MapCanvas::drawRoom(const Room *room, const std::vector<Room *> & rooms, co
             qglColor(Qt::black);
             glDisable(GL_LINE_STIPPLE);
         }
-        if ( ISSET(getFlags(room->exit(ED_NORTH)), EF_FLOW))
+        else if ( ISSET(ef_north, EF_CLIMB))
+        {
+            glEnable(GL_LINE_STIPPLE);
+            glColor4d(0.7, 0.7, 0.7, 0.0);
+            glCallList(m_wall_north_gllist);
+            qglColor(Qt::black);
+            glDisable(GL_LINE_STIPPLE);
+        }
+        else if (Config().m_drawNoMatchExits && ISSET(ef_north, EF_NO_MATCH))
+        {
+            glEnable(GL_LINE_STIPPLE);
+            qglColor(Qt::blue);
+            glCallList(m_wall_north_gllist);
+            qglColor(Qt::black);
+            glDisable(GL_LINE_STIPPLE);
+        }
+        if ( ISSET(ef_north, EF_FLOW))
         {
             drawFlow(room, rooms, ED_NORTH);
         }
@@ -2066,15 +2083,15 @@ void MapCanvas::drawRoom(const Room *room, const std::vector<Room *> & rooms, co
     }
     else
     {
-        if ( ISSET(getFlags(room->exit(ED_SOUTH)), EF_CLIMB))
+        if ( ISSET(ef_south, EF_NO_FLEE))
         {
             glEnable(GL_LINE_STIPPLE);
-            glColor4d(0.7, 0.7, 0.7, 0.0);
+            qglColor(m_noFleeColor);
             glCallList(m_wall_south_gllist);
             qglColor(Qt::black);
             glDisable(GL_LINE_STIPPLE);
         }
-        if ( ISSET(getFlags(room->exit(ED_SOUTH)), EF_RANDOM))
+        else if ( ISSET(ef_south, EF_RANDOM))
         {
             glEnable(GL_LINE_STIPPLE);
             glColor4d(1.0, 0.0, 0.0, 0.0);
@@ -2082,7 +2099,7 @@ void MapCanvas::drawRoom(const Room *room, const std::vector<Room *> & rooms, co
             qglColor(Qt::black);
             glDisable(GL_LINE_STIPPLE);
         }
-        if ( ISSET(getFlags(room->exit(ED_SOUTH)), EF_SPECIAL))
+        else if ( ISSET(ef_south, EF_SPECIAL))
         {
             glEnable(GL_LINE_STIPPLE);
             glColor4d(0.8, 0.1, 0.8, 0.0);
@@ -2090,7 +2107,23 @@ void MapCanvas::drawRoom(const Room *room, const std::vector<Room *> & rooms, co
             qglColor(Qt::black);
             glDisable(GL_LINE_STIPPLE);
         }
-        if ( ISSET(getFlags(room->exit(ED_SOUTH)), EF_FLOW))
+        else if ( ISSET(ef_south, EF_CLIMB))
+        {
+            glEnable(GL_LINE_STIPPLE);
+            glColor4d(0.7, 0.7, 0.7, 0.0);
+            glCallList(m_wall_south_gllist);
+            qglColor(Qt::black);
+            glDisable(GL_LINE_STIPPLE);
+        }
+        else if (Config().m_drawNoMatchExits && ISSET(ef_south, EF_NO_MATCH))
+        {
+            glEnable(GL_LINE_STIPPLE);
+            qglColor(Qt::blue);
+            glCallList(m_wall_south_gllist);
+            qglColor(Qt::black);
+            glDisable(GL_LINE_STIPPLE);
+        }
+        if ( ISSET(ef_south, EF_FLOW))
         {
             drawFlow(room, rooms, ED_SOUTH);
         }
@@ -2126,15 +2159,15 @@ void MapCanvas::drawRoom(const Room *room, const std::vector<Room *> & rooms, co
     }
     else
     {
-        if ( ISSET(getFlags(room->exit(ED_EAST)), EF_CLIMB))
+        if ( ISSET(ef_east, EF_NO_FLEE))
         {
             glEnable(GL_LINE_STIPPLE);
-            glColor4d(0.7, 0.7, 0.7, 0.0);
+            qglColor(m_noFleeColor);
             glCallList(m_wall_east_gllist);
             qglColor(Qt::black);
             glDisable(GL_LINE_STIPPLE);
         }
-        if ( ISSET(getFlags(room->exit(ED_EAST)), EF_RANDOM))
+        else if ( ISSET(ef_east, EF_RANDOM))
         {
             glEnable(GL_LINE_STIPPLE);
             glColor4d(1.0, 0.0, 0.0, 0.0);
@@ -2142,7 +2175,7 @@ void MapCanvas::drawRoom(const Room *room, const std::vector<Room *> & rooms, co
             qglColor(Qt::black);
             glDisable(GL_LINE_STIPPLE);
         }
-        if ( ISSET(getFlags(room->exit(ED_EAST)), EF_SPECIAL))
+        else if ( ISSET(ef_east, EF_SPECIAL))
         {
             glEnable(GL_LINE_STIPPLE);
             glColor4d(0.8, 0.1, 0.8, 0.0);
@@ -2150,7 +2183,23 @@ void MapCanvas::drawRoom(const Room *room, const std::vector<Room *> & rooms, co
             qglColor(Qt::black);
             glDisable(GL_LINE_STIPPLE);
         }
-        if ( ISSET(getFlags(room->exit(ED_EAST)), EF_FLOW))
+        else if ( ISSET(ef_east, EF_CLIMB))
+        {
+            glEnable(GL_LINE_STIPPLE);
+            glColor4d(0.7, 0.7, 0.7, 0.0);
+            glCallList(m_wall_east_gllist);
+            qglColor(Qt::black);
+            glDisable(GL_LINE_STIPPLE);
+        }
+        else if (Config().m_drawNoMatchExits && ISSET(ef_east, EF_NO_MATCH))
+        {
+            glEnable(GL_LINE_STIPPLE);
+            qglColor(Qt::blue);
+            glCallList(m_wall_east_gllist);
+            qglColor(Qt::black);
+            glDisable(GL_LINE_STIPPLE);
+        }
+        if ( ISSET(ef_east, EF_FLOW))
         {
             drawFlow(room, rooms, ED_EAST);
         }
@@ -2186,15 +2235,15 @@ void MapCanvas::drawRoom(const Room *room, const std::vector<Room *> & rooms, co
     }
     else
     {
-        if ( ISSET(getFlags(room->exit(ED_WEST)), EF_CLIMB))
+        if ( ISSET(ef_west, EF_NO_FLEE))
         {
             glEnable(GL_LINE_STIPPLE);
-            glColor4d(0.7, 0.7, 0.7, 0.0);
+            qglColor(m_noFleeColor);
             glCallList(m_wall_west_gllist);
             qglColor(Qt::black);
             glDisable(GL_LINE_STIPPLE);
         }
-        if ( ISSET(getFlags(room->exit(ED_WEST)), EF_RANDOM))
+        else if ( ISSET(ef_west, EF_RANDOM))
         {
             glEnable(GL_LINE_STIPPLE);
             glColor4d(1.0, 0.0, 0.0, 0.0);
@@ -2202,7 +2251,7 @@ void MapCanvas::drawRoom(const Room *room, const std::vector<Room *> & rooms, co
             qglColor(Qt::black);
             glDisable(GL_LINE_STIPPLE);
         }
-        if ( ISSET(getFlags(room->exit(ED_WEST)), EF_SPECIAL))
+        else if ( ISSET(ef_west, EF_SPECIAL))
         {
             glEnable(GL_LINE_STIPPLE);
             glColor4d(0.8, 0.1, 0.8, 0.0);
@@ -2210,7 +2259,23 @@ void MapCanvas::drawRoom(const Room *room, const std::vector<Room *> & rooms, co
             qglColor(Qt::black);
             glDisable(GL_LINE_STIPPLE);
         }
-        if ( ISSET(getFlags(room->exit(ED_WEST)), EF_FLOW))
+        else if ( ISSET(ef_west, EF_CLIMB))
+        {
+            glEnable(GL_LINE_STIPPLE);
+            glColor4d(0.7, 0.7, 0.7, 0.0);
+            glCallList(m_wall_west_gllist);
+            qglColor(Qt::black);
+            glDisable(GL_LINE_STIPPLE);
+        }
+        else if (Config().m_drawNoMatchExits && ISSET(ef_west, EF_NO_MATCH))
+        {
+            glEnable(GL_LINE_STIPPLE);
+            qglColor(Qt::blue);
+            glCallList(m_wall_west_gllist);
+            qglColor(Qt::black);
+            glDisable(GL_LINE_STIPPLE);
+        }
+        if ( ISSET(ef_west, EF_FLOW))
         {
             drawFlow(room, rooms, ED_WEST);
         }
@@ -2251,10 +2316,42 @@ void MapCanvas::drawRoom(const Room *room, const std::vector<Room *> & rooms, co
         }
         else
         {
-            if ( ISSET(getFlags(room->exit(ED_UP)), EF_CLIMB))
+            if ( ISSET(ef_up, EF_NO_FLEE))
+            {
+                glEnable(GL_LINE_STIPPLE);
+                qglColor(m_noFleeColor);
+                glCallList(m_exit_up_transparent_gllist);
+                glColor4d(0.0, 0.0, 0.0, 0.0);
+                glDisable(GL_LINE_STIPPLE);
+            }
+            else if ( ISSET(ef_up, EF_RANDOM))
+            {
+                glEnable(GL_LINE_STIPPLE);
+                glColor4d(1.0, 0.0, 0.0, 0.0);
+                glCallList(m_exit_up_transparent_gllist);
+                glColor4d(0.0, 0.0, 0.0, 0.0);
+                glDisable(GL_LINE_STIPPLE);
+            }
+            else if ( ISSET(ef_up, EF_SPECIAL))
+            {
+                glEnable(GL_LINE_STIPPLE);
+                glColor4d(0.8, 0.1, 0.8, 0.0);
+                glCallList(m_exit_up_transparent_gllist);
+                glColor4d(0.0, 0.0, 0.0, 0.0);
+                glDisable(GL_LINE_STIPPLE);
+            }
+            else if ( ISSET(ef_up, EF_CLIMB))
             {
                 glEnable(GL_LINE_STIPPLE);
                 glColor4d(0.5, 0.5, 0.5, 0.0);
+                glCallList(m_exit_up_transparent_gllist);
+                glColor4d(0.0, 0.0, 0.0, 0.0);
+                glDisable(GL_LINE_STIPPLE);
+            }
+            else if (Config().m_drawNoMatchExits && ISSET(ef_up, EF_NO_MATCH))
+            {
+                glEnable(GL_LINE_STIPPLE);
+                qglColor(Qt::blue);
                 glCallList(m_exit_up_transparent_gllist);
                 glColor4d(0.0, 0.0, 0.0, 0.0);
                 glDisable(GL_LINE_STIPPLE);
@@ -2268,7 +2365,7 @@ void MapCanvas::drawRoom(const Room *room, const std::vector<Room *> & rooms, co
             if (ISSET(ef_up, EF_DOOR))
                 glCallList(m_door_up_gllist);
 
-            if ( ISSET(getFlags(room->exit(ED_UP)), EF_FLOW))
+            if ( ISSET(ef_up, EF_FLOW))
             {
                 drawFlow(room, rooms, ED_UP);
             }
@@ -2289,10 +2386,42 @@ void MapCanvas::drawRoom(const Room *room, const std::vector<Room *> & rooms, co
         }
         else
         {
-            if ( ISSET(getFlags(room->exit(ED_DOWN)), EF_CLIMB))
+            if (ISSET(ef_down, EF_NO_FLEE))
+            {
+                glEnable(GL_LINE_STIPPLE);
+                qglColor(m_noFleeColor);
+                glCallList(m_exit_down_transparent_gllist);
+                glColor4d(0.0, 0.0, 0.0, 0.0);
+                glDisable(GL_LINE_STIPPLE);
+            }
+            else if ( ISSET(ef_down, EF_RANDOM))
+            {
+                glEnable(GL_LINE_STIPPLE);
+                glColor4d(1.0, 0.0, 0.0, 0.0);
+                glCallList(m_exit_down_transparent_gllist);
+                glColor4d(0.0, 0.0, 0.0, 0.0);
+                glDisable(GL_LINE_STIPPLE);
+            }
+            else if ( ISSET(ef_down, EF_SPECIAL))
+            {
+                glEnable(GL_LINE_STIPPLE);
+                glColor4d(0.8, 0.1, 0.8, 0.0);
+                glCallList(m_exit_down_transparent_gllist);
+                glColor4d(0.0, 0.0, 0.0, 0.0);
+                glDisable(GL_LINE_STIPPLE);
+            }
+            else if ( ISSET(ef_down, EF_CLIMB))
             {
                 glEnable(GL_LINE_STIPPLE);
                 glColor4d(0.5, 0.5, 0.5, 0.0);
+                glCallList(m_exit_down_transparent_gllist);
+                glColor4d(0.0, 0.0, 0.0, 0.0);
+                glDisable(GL_LINE_STIPPLE);
+            }
+            else if (Config().m_drawNoMatchExits && ISSET(ef_down, EF_NO_MATCH))
+            {
+                glEnable(GL_LINE_STIPPLE);
+                qglColor(Qt::blue);
                 glCallList(m_exit_down_transparent_gllist);
                 glColor4d(0.0, 0.0, 0.0, 0.0);
                 glDisable(GL_LINE_STIPPLE);
@@ -2306,7 +2435,7 @@ void MapCanvas::drawRoom(const Room *room, const std::vector<Room *> & rooms, co
             if (ISSET(ef_down, EF_DOOR))
                 glCallList(m_door_down_gllist);
 
-            if ( ISSET(getFlags(room->exit(ED_DOWN)), EF_FLOW))
+            if ( ISSET(ef_down, EF_FLOW))
             {
                 drawFlow(room, rooms, ED_DOWN);
             }
@@ -3330,14 +3459,6 @@ float MapCanvas::getDW() const {
 
 float MapCanvas::getDH() const {
     return ((float)(((float)height() / ((float)BASESIZEY / 12.0f)) ) / (float)m_scaleFactor);
-}
-
-void MapCanvas::qglColor(QColor color) {
-    glColor4f(color.redF(), color.greenF(), color.blueF(), color.alphaF());
-}
-
-void MapCanvas::qglClearColor(QColor clearColor) {
-    glClearColor(clearColor.redF(), clearColor.greenF(), clearColor.blueF(), clearColor.alphaF());
 }
 
 void MapCanvas::renderText(double x, double y, const QString &text, QColor color, uint fontFormatFlag, double rotationAngle) {

--- a/src/display/mapcanvas.h
+++ b/src/display/mapcanvas.h
@@ -140,13 +140,14 @@ class MapCanvas : public QOpenGLWidget, protected QOpenGLFunctions
     void drawPathEnd(double dx, double dy, double dz);
     void drawFlow( const Room *room, const std::vector<Room *> & rooms, ExitDirection exitDirection);
 
-    // QGLWidget backwards compatability
-    void qglColor(QColor color);
-    void qglClearColor(QColor color);
-
+    // QGLWidget backwards comptability
+    void inline qglColor(QColor c) { glColor4f(c.redF(), c.greenF(), c.blueF(), c.alphaF()); }
+    void inline qglClearColor(QColor c) { glClearColor(c.redF(), c.greenF(), c.blueF(), c.alphaF()); }
     enum FontFormatFlags {FFF_NONE = 0, FFF_ITALICS = 1, FFF_UNDERLINE = 2};
     void renderText(double x, double y, const QString & str, QColor color = Qt::white, uint fontFormatFlags = FFF_NONE, double rotationAngle = 0.0f);
+
   private:
+    static QColor m_noFleeColor;
 
     GLint    m_viewport[4];
     GLdouble m_modelview[16];

--- a/src/mainwindow/roomeditattrdlg.cpp
+++ b/src/mainwindow/roomeditattrdlg.cpp
@@ -129,8 +129,8 @@ RoomEditAttrDlg::RoomEditAttrDlg(QWidget *parent)
 	exitListItems[4] = (QListWidgetItem*) new QListWidgetItem("Random");
 	exitListItems[5] = (QListWidgetItem*) new QListWidgetItem("Special");
 	exitListItems[6] = (QListWidgetItem*) new QListWidgetItem("No match");
-	exitListItems[7] = (QListWidgetItem*) new QListWidgetItem("Flow dir"); // Added in schema 040
-    exitListItems[8] = NULL;
+    exitListItems[7] = (QListWidgetItem*) new QListWidgetItem("Flow dir");
+    exitListItems[8] = (QListWidgetItem*) new QListWidgetItem("No flee");
     exitListItems[9] = NULL;
     exitListItems[10] = NULL;
     exitListItems[11] = NULL;
@@ -139,7 +139,7 @@ RoomEditAttrDlg::RoomEditAttrDlg(QWidget *parent)
     exitListItems[14] = NULL;
     exitListItems[15] = NULL;
 	exitFlagsListWidget->clear();
-    for (int i=0; i<8; i++)
+    for (int i=0; i<9; i++)
 	{
 		exitListItems[i]->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled);
 		exitFlagsListWidget->addItem(exitListItems[i]);
@@ -151,16 +151,16 @@ RoomEditAttrDlg::RoomEditAttrDlg(QWidget *parent)
 	doorListItems[3] = (QListWidgetItem*) new QListWidgetItem("No break");
 	doorListItems[4] = (QListWidgetItem*) new QListWidgetItem("No pick");
 	doorListItems[5] = (QListWidgetItem*) new QListWidgetItem("Delayed");
-	doorListItems[6] = (QListWidgetItem*) new QListWidgetItem("Callable"); // Added in schema 040
-  doorListItems[7] = (QListWidgetItem*) new QListWidgetItem("Knockable"); // Added in schema 040
-  doorListItems[8] = (QListWidgetItem*) new QListWidgetItem("Magic"); // Added in schema 040
-  doorListItems[9] = (QListWidgetItem*) new QListWidgetItem("Action-controlled"); // Added in schema 040
-  doorListItems[10] = NULL;
-  doorListItems[11] = NULL;
-  doorListItems[12] = NULL;
-  doorListItems[13] = NULL;
-  doorListItems[14] = NULL;
-  doorListItems[15] = NULL;
+    doorListItems[6] = (QListWidgetItem*) new QListWidgetItem("Callable");
+    doorListItems[7] = (QListWidgetItem*) new QListWidgetItem("Knockable");
+    doorListItems[8] = (QListWidgetItem*) new QListWidgetItem("Magic");
+    doorListItems[9] = (QListWidgetItem*) new QListWidgetItem("Action-controlled");
+    doorListItems[10] = NULL;
+    doorListItems[11] = NULL;
+    doorListItems[12] = NULL;
+    doorListItems[13] = NULL;
+    doorListItems[14] = NULL;
+    doorListItems[15] = NULL;
 
 	doorFlagsListWidget->clear();
 	for (int i=0; i<10; i++)
@@ -532,13 +532,18 @@ void RoomEditAttrDlg::updateDialog(const Room *r)
 		else
 			exitListItems[6]->setCheckState(Qt::Unchecked);
 
-    if (ISSET(ef, EF_FLOW))
-			exitListItems[7]->setCheckState(Qt::Checked);
-		else
-			exitListItems[7]->setCheckState(Qt::Unchecked);
+        if (ISSET(ef, EF_FLOW))
+            exitListItems[7]->setCheckState(Qt::Checked);
+        else
+            exitListItems[7]->setCheckState(Qt::Unchecked);
 
-        roomNoteTextEdit->clear();
-        roomNoteTextEdit->setEnabled(false);
+        if (ISSET(ef, EF_NO_FLEE))
+            exitListItems[8]->setCheckState(Qt::Checked);
+        else
+            exitListItems[8]->setCheckState(Qt::Unchecked);
+
+		roomNoteTextEdit->clear();
+		roomNoteTextEdit->setEnabled(false);
 
 		int index = 0;
 		while(loadListItems[index]!=NULL)

--- a/src/mapdata/mmapper2exit.h
+++ b/src/mapdata/mmapper2exit.h
@@ -52,6 +52,7 @@ typedef class QString DoorName;
 #define EF_SPECIAL    bit6
 #define EF_NO_MATCH   bit7
 #define EF_FLOW       bit8
+#define EF_NO_FLEE    bit9
 
 #define DF_HIDDEN     bit1
 #define DF_NEEDKEY    bit2

--- a/src/mapstorage/mapstorage.cpp
+++ b/src/mapstorage/mapstorage.cpp
@@ -376,6 +376,7 @@ void MapStorage::loadExits(Room * room, QDataStream & stream, qint32 version)
     }
     else
     {
+        // Exit flags were stored with 8 bits in version < 041
         stream >> vquint8;
         if (ISSET(vquint8, EF_DOOR)) SET(vquint8, EF_EXIT);
         e[E_FLAGS] = vquint8;

--- a/src/preferences/generalpage.cpp
+++ b/src/preferences/generalpage.cpp
@@ -45,6 +45,7 @@ GeneralPage::GeneralPage(QWidget *parent)
   connect ( emulatedExits, SIGNAL(stateChanged(int)),SLOT(emulatedExitsStateChanged(int)));
   connect ( updated, SIGNAL(stateChanged(int)),SLOT(updatedStateChanged(int)));
   connect ( drawNotMappedExits, SIGNAL(stateChanged(int)),SLOT(drawNotMappedExitsStateChanged(int)));
+  connect ( drawNoMatchExits, SIGNAL(stateChanged(int)),SLOT(drawNoMatchExitsStateChanged(int)));
   connect ( drawDoorNames, SIGNAL(stateChanged(int)),SLOT(drawDoorNamesStateChanged(int)));
   connect ( drawUpperLayersTextured, SIGNAL(stateChanged(int)),SLOT(drawUpperLayersTexturedStateChanged(int)));
 
@@ -69,6 +70,7 @@ GeneralPage::GeneralPage(QWidget *parent)
   emulatedExits->setChecked( Config().m_emulatedExits );
   updated->setChecked( Config().m_showUpdated );
   drawNotMappedExits->setChecked( Config().m_drawNotMappedExits );
+  drawNoMatchExits->setChecked( Config().m_drawNoMatchExits );
   drawUpperLayersTextured->setChecked( Config().m_drawUpperLayersTextured );
   drawDoorNames->setChecked( Config().m_drawDoorNames );
 
@@ -138,6 +140,11 @@ void GeneralPage::updatedStateChanged(int)
 void GeneralPage::drawNotMappedExitsStateChanged(int)
 {
   Config().m_drawNotMappedExits = drawNotMappedExits->isChecked();
+}
+
+void GeneralPage::drawNoMatchExitsStateChanged(int)
+{
+  Config().m_drawNoMatchExits = drawNoMatchExits->isChecked();
 }
 
 void GeneralPage::drawDoorNamesStateChanged(int)

--- a/src/preferences/generalpage.h
+++ b/src/preferences/generalpage.h
@@ -47,6 +47,7 @@ public slots:
 	void emulatedExitsStateChanged(int);
 	void updatedStateChanged(int);
 	void drawNotMappedExitsStateChanged(int);
+    void drawNoMatchExitsStateChanged(int);
     void drawDoorNamesStateChanged(int);
 	void drawUpperLayersTexturedStateChanged(int);
 

--- a/src/preferences/generalpage.ui
+++ b/src/preferences/generalpage.ui
@@ -298,15 +298,19 @@
         <property name="text">
          <string>Draw not mapped exits</string>
         </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
        </widget>
       </item>
       <item row="1" column="0">
        <widget class="QCheckBox" name="updated">
         <property name="text">
          <string>Show non updated rooms</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QCheckBox" name="drawNoMatchExits">
+        <property name="text">
+         <string>Draw &quot;no match&quot; exits</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Adds support for #41 and #40

No match exits are a bit spammy on the default map so I've added a configuration item to disable their rendering.