### PR TITLE
MumeClock syncs only on known weather

### DIFF
--- a/src/clock/mumeclock.h
+++ b/src/clock/mumeclock.h
@@ -30,6 +30,7 @@ enum MumeClockPrecision { MUMECLOCK_UNSET = -1, MUMECLOCK_DAY, MUMECLOCK_HOUR, M
 #include <QObject>
 #include <QList>
 #include <QMetaEnum>
+#include <QHash>
 
 #include "mumemoment.h"
 
@@ -60,10 +61,11 @@ public:
     enum SindarinMonthNames { UnknownSindarinMonth = -1, Narwain, Ninui, Gwaeron, Gwirith, Lothron, Norui, Cerveth, Urui, Ivanneth, Narbeleth, Hithui, Girithron };
     Q_ENUM(SindarinMonthNames)
 
-    static QList<int> m_dawnHour;
-    static QList<int> m_duskHour;
-    static QMetaEnum m_westronMonthNames;
-    static QMetaEnum m_sindarinMonthNames;
+    static const QList<int> m_dawnHour;
+    static const QList<int> m_duskHour;
+    static const QMetaEnum m_westronMonthNames;
+    static const QMetaEnum m_sindarinMonthNames;
+    static const QHash<QString, MumeTime> m_stringTimeHash;
 
 signals:
     void log(const QString &, const QString &);
@@ -71,7 +73,7 @@ signals:
 public slots:
     void parseMumeTime(const QString &mumeTime);
     void parseClockTime(const QString &clockTime);
-    void tickSync(MumeTime time = TIME_UNKNOWN);
+    void parseWeather(const QString &str);
 
 protected:
     void setPrecision(MumeClockPrecision state)
@@ -80,9 +82,11 @@ protected:
     }
     void parseMumeTime(const QString &mumeString, int secsSinceUnixEpoch);
     void parseClockTime(const QString &clockTime, int secsSinceUnixEpoch);
-    void tickSync(int secsSinceEpoch);
+    void parseWeather(const QString &str, int secsSinceEpoch);
 
 private:
+    MumeMoment &unknownTimeTick(MumeMoment &time);
+
     int m_mumeStartEpoch;
     int m_clockTolerance;
     MumeClockPrecision m_precision;

--- a/src/parser/abstractparser.cpp
+++ b/src/parser/abstractparser.cpp
@@ -167,8 +167,7 @@ void AbstractParser::parseExits(QString &str)
     bool directSun = false;
     DirectionType dir = UNKNOWN;
 
-    if (str.at(6).toLatin1() != ':')
-    {
+    if (str.at(6).toLatin1() != ':') {
         // Ainur exits
         emit sendToUser(str.toLatin1() + "\r\n");
         return ;

--- a/src/parser/mumexmlparser.cpp
+++ b/src/parser/mumexmlparser.cpp
@@ -485,35 +485,10 @@ void MumeXmlParser::parseMudCommands(QString &str)
         m_mumeClock->parseMumeTime(str);
     }
 
-    // Weather events happen on ticks
+    // Certain weather events happen on ticks
     if (m_readWeatherTag) {
         m_readWeatherTag = false;
-        if (str.at(0) == 'T') {
-            if (str.startsWith("The day has begun.")) {
-                m_mumeClock->tickSync(TIME_DAY);
-            } else if (str.startsWith("The night has begun.")) {
-                m_mumeClock->tickSync(TIME_NIGHT);
-            } else if (str.startsWith("The deepening gloom announces another sunset outside.")) {
-                // Indoors
-                m_mumeClock->tickSync(TIME_DUSK);
-            } else if (str.startsWith("The last ray of light fades, and all is swallowed up in darkness.")) {
-                // Indoors
-                m_mumeClock->tickSync(TIME_NIGHT);
-            }
-        } else if (str.at(0) == 'I') {
-            if (str.startsWith("It seems as if the night has begun.")) {
-                m_mumeClock->tickSync(TIME_NIGHT);
-            } else if (str.startsWith("It seems as if the day has begun.")) {
-                m_mumeClock->tickSync(TIME_DAY);
-            }
-        } else if (str.at(0) == 'L') {
-            if (str.startsWith("Light gradually filters in, proclaiming a new sunrise outside.")) {
-                // Indoors
-                m_mumeClock->tickSync(TIME_DAWN);
-            }
-        } else {
-            m_mumeClock->tickSync();
-        }
+        m_mumeClock->parseWeather(str);
     }
 
     // parse regexps which force new char move

--- a/src/parser/patterns.cpp
+++ b/src/parser/patterns.cpp
@@ -31,7 +31,7 @@ QRegExp Patterns::m_rx;
 const QRegExp Patterns::m_score("\\d+/\\d+ hits(?:, \\d+/\\d+ mana,)? and \\d+/\\d+ moves.");
 
 // Used for oldRoom loading only
-QStringList Patterns::m_dynamicDescriptionPatternsList(
+const QStringList Patterns::m_dynamicDescriptionPatternsList(
     QStringList()
     << "#!(?:A|An|The)[^.]*\\."
     << "#![^.]*(?:sit(?:s|ting)?|rest(?:s|ing)?|stand(?:s|ing)|sleep(?:s|ing)?|swim(?:s|ming)?|walk(?:s|ing)?|wander(?:s|ing)?|grow(?:s|ing)?|lies?|lying)[^.]*"
@@ -43,7 +43,8 @@ QStringList Patterns::m_dynamicDescriptionPatternsList(
     << "#>whip all around you."
     << "#<Clusters of"
     << "#<Prickly"
-    << "#!.*arrived from.*\\.");
+    << "#!.*arrived from.*\\."
+);
 
 bool Patterns::matchPattern(QString pattern, QString &str)
 {
@@ -113,7 +114,6 @@ bool Patterns::matchScore(QString &str)
     return m_score.exactMatch(str);
 }
 
-
 bool Patterns::matchMoveForcePatterns(QString &str)
 {
     for ( QStringList::iterator it = Config().m_moveForcePatternsList.begin();
@@ -132,8 +132,8 @@ bool Patterns::matchNoDescriptionPatterns(QString &str)
 
 bool Patterns::matchDynamicDescriptionPatterns(QString &str)
 {
-    for (QStringList::iterator it = m_dynamicDescriptionPatternsList.begin();
-            it != m_dynamicDescriptionPatternsList.end(); ++it )
+    for (QStringList::const_iterator it = m_dynamicDescriptionPatternsList.constBegin();
+            it != m_dynamicDescriptionPatternsList.constEnd(); ++it )
         if (matchPattern(*it, str)) return true;
     return false;
 }

--- a/src/parser/patterns.h
+++ b/src/parser/patterns.h
@@ -37,7 +37,7 @@ class Patterns
 {
 
     static QRegExp m_rx;
-    static QStringList m_dynamicDescriptionPatternsList;
+    static const QStringList m_dynamicDescriptionPatternsList;
     static const QRegExp m_score;
 
 public:

--- a/src/tests/testclock.cpp
+++ b/src/tests/testclock.cpp
@@ -96,7 +96,7 @@ void TestClock::parseMumeTimeTest()
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), expectedSindarin);
 }
 
-void TestClock::tickSyncTest()
+void TestClock::parseWeatherClockSkewTest()
 {
     MumeClock clock;
 
@@ -108,36 +108,36 @@ void TestClock::tickSyncTest()
 
     // First sync
     int timeOccuredAt = 1;
-    QString expectedTime = "4:00pm on the 18th of Halimath, Year 3030 of the Third Age.";
-    clock.tickSync(realTime1 + timeOccuredAt);
+    QString expectedTime = "6:00am on the 18th of Halimath, Year 3030 of the Third Age.";
+    clock.parseWeather("The day has begun.", realTime1 + timeOccuredAt);
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment(realTime1 + timeOccuredAt)), expectedTime);
 
     // Mume running on time
     timeOccuredAt = 1 + 60;
-    expectedTime = "5:00pm on the 18th of Halimath, Year 3030 of the Third Age.";
-    clock.tickSync(realTime1 + timeOccuredAt);
+    expectedTime = "7:00am on the 18th of Halimath, Year 3030 of the Third Age.";
+    clock.parseWeather("The evil power begins to regress...", realTime1 + timeOccuredAt);
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment(realTime1 + timeOccuredAt)), expectedTime);
 
     // Mume running fast
     timeOccuredAt = 1 + 60 + 58;
-    expectedTime = "6:00pm on the 18th of Halimath, Year 3030 of the Third Age.";
-    clock.tickSync(realTime1 + timeOccuredAt);
+    expectedTime = "8:00am on the 18th of Halimath, Year 3030 of the Third Age.";
+    clock.parseWeather("The evil power begins to regress...", realTime1 + timeOccuredAt);
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment(realTime1 + timeOccuredAt)), expectedTime);
 
     // Mume running on time
     timeOccuredAt = 1 + 60 + 58 + 60;
-    expectedTime = "7:00pm on the 18th of Halimath, Year 3030 of the Third Age.";
-    clock.tickSync(realTime1 + timeOccuredAt);
+    expectedTime = "9:00am on the 18th of Halimath, Year 3030 of the Third Age.";
+    clock.parseWeather("The evil power begins to regress...", realTime1 + timeOccuredAt);
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment(realTime1 + timeOccuredAt)), expectedTime);
 
     // Mume running slow
     timeOccuredAt = 1 + 60 + 58 + 60 + 65;
-    expectedTime = "8:00pm on the 18th of Halimath, Year 3030 of the Third Age.";
-    clock.tickSync(realTime1 + timeOccuredAt);
+    expectedTime = "10:00am on the 18th of Halimath, Year 3030 of the Third Age.";
+    clock.parseWeather("The evil power begins to regress...", realTime1 + timeOccuredAt);
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment(realTime1 + timeOccuredAt)), expectedTime);
 }
 
-void TestClock::partOfDayTickSyncTest()
+void TestClock::parseWeatherTest()
 {
     MumeClock clock;
 
@@ -147,19 +147,19 @@ void TestClock::partOfDayTickSyncTest()
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), expectedTime);
 
     expectedTime = "5:00am on the 18th of Halimath, Year 3030 of the Third Age.";
-    clock.tickSync(TIME_DAWN);
+    clock.parseWeather("Light gradually filters in, proclaiming a new sunrise outside.");
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), expectedTime);
 
     expectedTime = "6:00am on the 18th of Halimath, Year 3030 of the Third Age.";
-    clock.tickSync(TIME_DAY);
+    clock.parseWeather("It seems as if the day has begun.");
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), expectedTime);
 
     expectedTime = "9:00pm on the 18th of Halimath, Year 3030 of the Third Age.";
-    clock.tickSync(TIME_DUSK);
+    clock.parseWeather("The deepening gloom announces another sunset outside.");
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), expectedTime);
 
     expectedTime = "10:00pm on the 18th of Halimath, Year 3030 of the Third Age.";
-    clock.tickSync(TIME_NIGHT);
+    clock.parseWeather("It seems as if the night has begun.");
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), expectedTime);
 }
 
@@ -174,8 +174,8 @@ void TestClock::parseClockTimeTest()
     clock.parseMumeTime(snapShot1);
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), expected1);
 
-    QString afternoon = "3:34pm on the 18th of Halimath, Year 3030 of the Third Age.";
-    clock.parseClockTime("The current time is 3:34 pm.");
+    QString afternoon = "12:34pm on the 18th of Halimath, Year 3030 of the Third Age.";
+    clock.parseClockTime("The current time is 12:34 pm.");
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), afternoon);
 
     QString midnight = "12:51am on the 18th of Halimath, Year 3030 of the Third Age.";

--- a/src/tests/testclock.h
+++ b/src/tests/testclock.h
@@ -40,8 +40,8 @@ private Q_SLOTS:
     // MumeClock
     void mumeClockTest();
     void parseMumeTimeTest();
-    void tickSyncTest();
-    void partOfDayTickSyncTest();
+    void parseWeatherTest();
+    void parseWeatherClockSkewTest();
     void parseClockTimeTest();
 };
 


### PR DESCRIPTION
I noticed that the clock would unsync when it saw snow on the ground or if the clouds cleared up. I'm going to limit the sync to only known weather strings now.