### PR TITLE
Minimal <snoop> tag support

### DIFF
--- a/src/parser/mumexmlparser.h
+++ b/src/parser/mumexmlparser.h
@@ -77,6 +77,7 @@ protected:
     bool m_readingTag;
     bool m_readStatusTag;
     bool m_readWeatherTag;
+    bool m_readSnoopTag;
     bool m_gratuitous;
     CommandIdType m_move;
 


### PR DESCRIPTION
Mw+ can now `/snoop` characters and watch them on MMapper with only some slight hiccups.