### PR TITLE
Migrate away from QtIOCompressor for new saves

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ IF(WITH_QTIOCOMPRESSOR)
         ENDIF()
 
         # Add QtIOCommpressor sources
+        OPTION(SKIP_INSTALL_ALL "Do not install QtIOCompressor libraries or headers" TRUE)
         CONFIGURE_FILE(CMakeLists.QtIOCompressor.in QtIOCompressor-download/CMakeLists.txt)
         EXECUTE_PROCESS(COMMAND "${CMAKE_COMMAND}" -G "${CMAKE_GENERATOR}" .
             WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/QtIOCompressor-download" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ FILE(STRINGS "MMAPPER_VERSION" MMAPPER_VERSION)
 ADD_DEFINITIONS(-DMMAPPER_VERSION="${MMAPPER_VERSION}" -DWITH_SPLASH)
 MESSAGE(STATUS "MMapper version ${MMAPPER_VERSION} (${CMAKE_BUILD_TYPE} distribution)")
 
+# Options
+OPTION(WITH_QTIOCOMPRESSOR "QtIOCompressor old save backwards compatability" ON)
+
 # Apple users are most likely using brew
 IF(APPLE)
    SET(CMAKE_PREFIX_PATH /usr/local/opt/qt5/)
@@ -29,38 +32,48 @@ SET(CMAKE_AUTOUIC ON)
 SET(CMAKE_AUTORCC ON)
 
 # Try to find the system copy of QtIOCompressor
-FIND_PATH(QTIOCOMPRESSOR_INCLUDE_DIRS qtiocompressor.h PATH_SUFFIXES QtSolutions)
-FIND_LIBRARY(QTIOCOMPRESSOR_LIBRARIES QtSolutions_IOCompressor-2.3)
-IF(QTIOCOMPRESSOR_INCLUDE_DIRS AND QTIOCOMPRESSOR_LIBRARIES)
-    SET(QTIOCOMPRESSOR_FOUND 1)
-    MESSAGE(STATUS "Found QtIOCompressor: ${QTIOCOMPRESSOR_LIBRARIES}")
-ELSE()
-    SET(QTIOCOMPRESSOR_FOUND 0)
-
-    # QtIOCompressor requires zlib
-    FIND_PACKAGE(ZLIB QUIET)
-    IF(ZLIB_FOUND)
-        MESSAGE(STATUS "Found ZLIB: ${ZLIB_LIBRARIES} ${ZLIB_INCLUDE_DIRS}")
+IF(WITH_QTIOCOMPRESSOR)
+    FIND_PATH(QTIOCOMPRESSOR_INCLUDE_DIRS qtiocompressor.h PATH_SUFFIXES QtSolutions)
+    FIND_LIBRARY(QTIOCOMPRESSOR_LIBRARIES QtSolutions_IOCompressor-2.3)
+    IF(QTIOCOMPRESSOR_INCLUDE_DIRS AND QTIOCOMPRESSOR_LIBRARIES)
+        SET(QTIOCOMPRESSOR_FOUND 1)
+        SET(QTIOCOMPRESSOR_INTERNAL "")
+        MESSAGE(STATUS "Found QtIOCompressor: ${QTIOCOMPRESSOR_LIBRARIES}")
     ELSE()
-        # QtIOCompressor will build a static zlib under zlib-build
-        IF(WIN32)
-            SET(ZLIB_STATIC_LIBRARY_NAME zlibstatic)
-        ELSE()
-            SET(ZLIB_STATIC_LIBRARY_NAME z)
-        ENDIF()
-        SET(ZLIB_STATIC_LIBRARY ${CMAKE_BINARY_DIR}/zlib-build/${CMAKE_STATIC_LIBRARY_PREFIX}${ZLIB_STATIC_LIBRARY_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX})
-        SET(ZLIB_LIBRARIES ${ZLIB_STATIC_LIBRARY})
-        SET(ZLIB_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/zlib-src ${CMAKE_BINARY_DIR}/zlib-build)
-    ENDIF()
+        SET(QTIOCOMPRESSOR_FOUND 0)
+        MESSAGE(STATUS "QtIOCompressor not found: use `-DWITH_QTIOCOMPRESSOR=OFF` to build without old map backwards compatability")
+        MESSAGE(STATUS "Building QtIOCompressor as an object library...")
 
-    # Add QtIOCommpressor sources
-    CONFIGURE_FILE(CMakeLists.QtIOCompressor.in QtIOCompressor-download/CMakeLists.txt)
-    EXECUTE_PROCESS(COMMAND "${CMAKE_COMMAND}" -G "${CMAKE_GENERATOR}" .
-        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/QtIOCompressor-download" )
-    EXECUTE_PROCESS(COMMAND "${CMAKE_COMMAND}" --build .
-        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/QtIOCompressor-download" )
-    ADD_SUBDIRECTORY("${CMAKE_BINARY_DIR}/QtIOCompressor-src" "${CMAKE_BINARY_DIR}/QtIOCompressor-build")
-    SET(QTIOCOMPRESSOR_INCLUDE_DIRS "${CMAKE_BINARY_DIR}/QtIOCompressor-src/src")
+        # QtIOCompressor requires zlib
+        FIND_PACKAGE(ZLIB QUIET)
+        IF(ZLIB_FOUND)
+            MESSAGE(STATUS "Found ZLIB: ${ZLIB_LIBRARIES} ${ZLIB_INCLUDE_DIRS}")
+        ELSE()
+            # QtIOCompressor will build a static zlib under zlib-build
+            IF(WIN32)
+                SET(ZLIB_STATIC_LIBRARY_NAME zlibstatic)
+            ELSE()
+                SET(ZLIB_STATIC_LIBRARY_NAME z)
+            ENDIF()
+            SET(ZLIB_STATIC_LIBRARY ${CMAKE_BINARY_DIR}/zlib-build/${CMAKE_STATIC_LIBRARY_PREFIX}${ZLIB_STATIC_LIBRARY_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX})
+            SET(ZLIB_LIBRARIES ${ZLIB_STATIC_LIBRARY})
+            SET(ZLIB_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/zlib-src ${CMAKE_BINARY_DIR}/zlib-build)
+        ENDIF()
+
+        # Add QtIOCommpressor sources
+        CONFIGURE_FILE(CMakeLists.QtIOCompressor.in QtIOCompressor-download/CMakeLists.txt)
+        EXECUTE_PROCESS(COMMAND "${CMAKE_COMMAND}" -G "${CMAKE_GENERATOR}" .
+            WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/QtIOCompressor-download" )
+        EXECUTE_PROCESS(COMMAND "${CMAKE_COMMAND}" --build .
+            WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/QtIOCompressor-download" )
+        ADD_SUBDIRECTORY("${CMAKE_BINARY_DIR}/QtIOCompressor-src" "${CMAKE_BINARY_DIR}/QtIOCompressor-build")
+        SET(QTIOCOMPRESSOR_INCLUDE_DIRS "${CMAKE_BINARY_DIR}/QtIOCompressor-src/src")
+
+        SET(QTIOCOMPRESSOR_OBJECTS $<TARGET_OBJECTS:qtiocompressorobj>)
+    ENDIF()
+ELSE()
+    MESSAGE(STATUS "Building without QtIOCompressor which provides old map backwards compatability")
+    ADD_DEFINITIONS(/DMMAPPER_NO_QTIOCOMPRESSOR)
 ENDIF()
 
 # Extract git branch and revision

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -95,9 +95,12 @@ SET(mmapper_UIS
     preferences/pathmachinepage.ui
 )
 
-IF(NOT QTIOCOMPRESSOR_FOUND)
-    # Build QtIOCompressor embedded
-    SET(mmapper_SRCS ${mmapper_SRCS} ${QTIOCOMPRESSOR_INCLUDE_DIRS}/qtiocompressor.cpp)
+IF(WITH_QTIOCOMPRESSOR)
+    IF(NOT QTIOCOMPRESSOR_FOUND)
+        # Build QtIOCompressor as an object library
+        SET(mmapper_SRCS ${mmapper_SRCS} ${QTIOCOMPRESSOR_OBJECTS})
+    ENDIF()
+    INCLUDE_DIRECTORIES(${QTIOCOMPRESSOR_INCLUDE_DIRS})
 ENDIF()
 
 SET(mmapper_DATA
@@ -123,7 +126,6 @@ INCLUDE_DIRECTORIES(
     ${CMAKE_CURRENT_SOURCE_DIR}/proxy
     ${OPENGL_INCLUDE_DIR}
     ${ZLIB_INCLUDE_DIRS}
-    ${QTIOCOMPRESSOR_INCLUDE_DIRS}
 )
 
 # Build the executable
@@ -143,15 +145,17 @@ TARGET_LINK_LIBRARIES(mmapper
     ${OPENGL_gl_LIBRARY}
 )
 
-IF(QTIOCOMPRESSOR_FOUND)
-    TARGET_LINK_LIBRARIES(mmapper ${QTIOCOMPRESSOR_LIBRARIES})
-ELSE()
-    # Build QtIOCompressor embedded
-    IF (NOT ZLIB_FOUND)
-        # Assume we are building a static zlib
-        ADD_DEPENDENCIES(mmapper zlib)
+IF(WITH_QTIOCOMPRESSOR)
+    IF(QTIOCOMPRESSOR_FOUND)
+        TARGET_LINK_LIBRARIES(mmapper ${QTIOCOMPRESSOR_LIBRARIES})
+    ELSE()
+        # Build QtIOCompressor as an object library
+        IF (NOT ZLIB_FOUND)
+            # Assume we are building a static zlib
+            ADD_DEPENDENCIES(mmapper zlib)
+        ENDIF()
+        TARGET_LINK_LIBRARIES(mmapper ${ZLIB_LIBRARIES})
     ENDIF()
-    TARGET_LINK_LIBRARIES(mmapper ${ZLIB_LIBRARIES})
 ENDIF()
 
 # Begin CPack Settings

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -215,7 +215,10 @@ IF(UNIX AND NOT APPLE)
     # Debian
     SET(CPACK_DEBIAN_PACKAGE_MAINTAINER "nschimme@gmail.com")
     SET(CPACK_DEBIAN_PACKAGE_NAME "mmapper")
-    SET(CPACK_DEBIAN_PACKAGE_DEPENDS "libqt5core5a (>= 5.4.0), libqt5gui5 (>= 5.4.0), libqt5opengl5 (>= 5.4.0), libqt5network5 (>= 5.4.0), libqt5xml5 (>= 5.4.0), zlib1g")
+    SET(CPACK_DEBIAN_PACKAGE_DEPENDS "libqt5core5a (>= 5.6.0), libqt5gui5 (>= 5.6.0), libqt5opengl5 (>= 5.6.0), libqt5network5 (>= 5.6.0), libqt5xml5 (>= 5.6.0)")
+    IF(WITH_QTIOCOMPRESSOR)
+        SET(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS}, zlib1g")
+    ENDIF()
 
     SET(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_FILE_NAME}-${CMAKE_SYSTEM_PROCESSOR}")
 ENDIF(UNIX AND NOT APPLE)

--- a/src/mainwindow/aboutdialog.cpp
+++ b/src/mainwindow/aboutdialog.cpp
@@ -41,35 +41,44 @@ AboutDialog::AboutDialog(QWidget *parent)
     pixmapLabel->setAlignment(Qt::AlignCenter);
 
     aboutText->setAlignment(Qt::AlignCenter);
-    aboutText->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    aboutText->setTextFormat(Qt::RichText);
+    aboutText->setOpenExternalLinks(true);
+    aboutText->setTextInteractionFlags(Qt::TextBrowserInteraction);
     aboutText->setText(
         "<p align=\"center\"><b>" + tr("MMapper Version %1").arg(QString(MMAPPER_VERSION))
         + "</b></p>"
         + "<p align=\"center\">"
 #ifdef GIT_BRANCH
-        + tr("Built on branch %1 and revision %2").arg(QString(GIT_BRANCH), QString(GIT_COMMIT_HASH))
+        + tr("Built on branch %1 and revision %2 ").arg(QString(GIT_BRANCH), QString(GIT_COMMIT_HASH))
+#ifdef __clang__
+        + tr("using Clang %1.%2.%3").arg(QString::number(__clang_major__), QString::number(__clang_minor__),
+                                         QString::number(__clang_patchlevel__))
+#elif __GNUC__
+        + tr("using GCC %1.%2.%3").arg(QString::number(__GNUC__), QString::number(__GNUC_MINOR__),
+                                       QString::number(__GNUC_PATCHLEVEL__))
 #endif
         + "<br>"
-        + tr("Based on Qt %1 (%2 bit)").arg(QLatin1String(QT_VERSION_STR),
-                                            QString::number(QSysInfo::WordSize))
+#endif
+#ifndef MMAPPER_NO_QTIOCOMPRESSOR
+        + tr("Built with QtIOCompressor under the <a href=\"https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html\">LGPL 2.1 license</a>.")
         + "<br>"
-        + tr("Built on %1 at %2").arg(QLatin1String(__DATE__),
-                                      QLatin1String(__TIME__))
+#endif
+        + tr("Based on Qt %1 (%2 bit)").arg(QT_VERSION_STR, QString::number(QSysInfo::WordSize))
+        + "<br>"
+        + tr("Built on %1 at %2").arg(QString(__DATE__)).arg(QString(__TIME__))
         + "</p>");
 
     /* Authors tab */
     authorsView->setOpenExternalLinks(true);
     authorsView->setHtml(tr(
-                             "Maintainer: Jahara (nschimme@gmail.com)<br>"
-                             "<br>"
-                             "<u>Special thanks to:</u><br>"
+                             "<p>Maintainer: Jahara (please report bugs <a href=\"https://github.com/MUME/MMapper/issues\">here</a>)</p>"
+                             "<p><u>Special thanks to:</u><br>"
                              "Alve for his great map engine<br>"
                              "Caligor for starting the mmapper project<br>"
-                             "Azazello for his work with the Group Manager protocol<br>"
-                             "<br>"
-                             "<u>Contributors:</u><br>"
-                             "Jahara, Kalev, Azazello, Alve, Caligor, Kovis, Krush, and Korir<br>"
-                             "<br>"
+                             "Azazello for creating the group manager</p>"
+                             "<p><u>Contributors:</u><br>"
+                             "Arfang, Ethorondil, Kalev, Korir, Kovis, Krush, Midoc, Teoli, and Waba"
+                             "</p>"
                          ));
 
     /* License tab */
@@ -81,7 +90,7 @@ AboutDialog::AboutDialog(QWidget *parent)
         licenseView->setText(ts.readAll());
     }
     setFixedFont(licenseView);
-    licenseView->setMinimumWidth(600);
+    licenseView->setMinimumWidth(700);
 
     setMaximumSize(sizeHint());
 }

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -951,7 +951,7 @@ void MainWindow::newFile()
     getCurrentMapWindow()->getCanvas()->clearConnectionSelection();
 
     if (maybeSave()) {
-        AbstractMapStorage *storage = (AbstractMapStorage *) new MapStorage(*m_mapData, "");
+        AbstractMapStorage *storage = (AbstractMapStorage *) new MapStorage(*m_mapData, "", this);
         connect(storage, SIGNAL(onNewData()), getCurrentMapWindow()->getCanvas(), SLOT(dataLoaded()));
         connect(storage, SIGNAL(log(const QString &, const QString &)), this, SLOT(log(const QString &,
                                                                                        const QString &)));
@@ -994,7 +994,7 @@ void MainWindow::merge()
         getCurrentMapWindow()->getCanvas()->clearRoomSelection();
         getCurrentMapWindow()->getCanvas()->clearConnectionSelection();
 
-        AbstractMapStorage *storage = new MapStorage(*m_mapData, fileName, file);
+        AbstractMapStorage *storage = new MapStorage(*m_mapData, fileName, file, this);
         connect(storage, SIGNAL(onDataLoaded()), getCurrentMapWindow()->getCanvas(), SLOT(dataLoaded()));
         connect(storage->progressCounter(), SIGNAL(onPercentageChanged(quint32)), this,
                 SLOT(percentageChanged(quint32)));
@@ -1177,7 +1177,8 @@ void MainWindow::loadFile(const QString &fileName)
     getCurrentMapWindow()->getCanvas()->clearRoomSelection();
     getCurrentMapWindow()->getCanvas()->clearConnectionSelection();
 
-    AbstractMapStorage *storage = (AbstractMapStorage *) new MapStorage(*m_mapData, fileName, file);
+    AbstractMapStorage *storage = (AbstractMapStorage *) new MapStorage(*m_mapData, fileName, file,
+                                                                        this);
     connect(storage, SIGNAL(onDataLoaded()), getCurrentMapWindow()->getCanvas(), SLOT(dataLoaded()));
     connect(storage->progressCounter(), SIGNAL(onPercentageChanged(quint32)), this,
             SLOT(percentageChanged(quint32)));
@@ -1227,9 +1228,9 @@ bool MainWindow::saveFile(const QString &fileName, SaveMode mode, SaveFormat for
 
     std::unique_ptr<AbstractMapStorage> storage;
     if (format == SAVEF_WEB)
-        storage.reset(new JsonMapStorage(*m_mapData, fileName));
+        storage.reset(new JsonMapStorage(*m_mapData, fileName, this));
     else
-        storage.reset(new MapStorage(*m_mapData, fileName, &saver.file()));
+        storage.reset(new MapStorage(*m_mapData, fileName, &saver.file(), this));
 
     if (!storage->canSave())
         return false;

--- a/src/mapstorage/abstractmapstorage.cpp
+++ b/src/mapstorage/abstractmapstorage.cpp
@@ -27,26 +27,26 @@
 #include "abstractmapstorage.h"
 #include "mapdata.h"
 #include "progresscounter.h"
-#include "qtiocompressor.h"
 
 #include <QFile>
 
-AbstractMapStorage::AbstractMapStorage(MapData &mapdata, const QString &filename, QFile *file) :
+AbstractMapStorage::AbstractMapStorage(MapData &mapdata, const QString &filename, QFile *file,
+                                       QObject *parent) :
+    QObject(parent),
     m_file(file),
     m_mapData(mapdata),
     m_fileName(filename),
     m_progressCounter( new ProgressCounter( this ) )
 {
-    m_compressor = new QtIOCompressor(file);
 }
 
-AbstractMapStorage::AbstractMapStorage(MapData &mapdata, const QString &filename) :
+AbstractMapStorage::AbstractMapStorage(MapData &mapdata, const QString &filename, QObject *parent) :
+    QObject(parent),
     m_file(NULL),
     m_mapData(mapdata),
     m_fileName(filename),
     m_progressCounter( new ProgressCounter( this ) )
 {
-    m_compressor = new QtIOCompressor(NULL);
 }
 
 AbstractMapStorage::~AbstractMapStorage()

--- a/src/mapstorage/abstractmapstorage.h
+++ b/src/mapstorage/abstractmapstorage.h
@@ -36,7 +36,6 @@ class MapData;
 class RoomSaveFilter;
 class ProgressCounter;
 class QFile;
-class QtIOCompressor;
 
 class AbstractMapStorage : public QObject
 {
@@ -44,8 +43,8 @@ class AbstractMapStorage : public QObject
     Q_OBJECT
 
 public:
-    AbstractMapStorage(MapData &, const QString &, QFile *);
-    AbstractMapStorage(MapData &, const QString &);
+    AbstractMapStorage(MapData &, const QString &, QFile *, QObject *parent = 0);
+    AbstractMapStorage(MapData &, const QString &, QObject *parent = 0);
     ~AbstractMapStorage();
 
     virtual bool canLoad() = 0;
@@ -65,7 +64,6 @@ signals:
 
 protected:
     QFile *m_file;
-    QtIOCompressor *m_compressor;
     MapData &m_mapData;
     QString m_fileName;
     QPointer<ProgressCounter> m_progressCounter;

--- a/src/mapstorage/jsonmapstorage.cpp
+++ b/src/mapstorage/jsonmapstorage.cpp
@@ -36,7 +36,6 @@
 #include "progresscounter.h"
 #include "basemapsavefilter.h"
 #include "infomark.h"
-#include "qtiocompressor.h"
 #include "olddoor.h"
 #include "parserutils.h"
 
@@ -457,8 +456,8 @@ void JsonWorld::writeZones( const QDir &dir, BaseMapSaveFilter &filter,
 } // ns
 
 
-JsonMapStorage::JsonMapStorage(MapData &mapdata, const QString &filename) :
-    AbstractMapStorage(mapdata, filename)
+JsonMapStorage::JsonMapStorage(MapData &mapdata, const QString &filename, QObject *parent) :
+    AbstractMapStorage(mapdata, filename, parent)
 {}
 
 JsonMapStorage::~JsonMapStorage()

--- a/src/mapstorage/jsonmapstorage.h
+++ b/src/mapstorage/jsonmapstorage.h
@@ -45,7 +45,7 @@ class JsonMapStorage : public AbstractMapStorage
     Q_OBJECT
 
 public:
-    JsonMapStorage(MapData &, const QString &);
+    JsonMapStorage(MapData &, const QString &, QObject *parent = 0);
     ~JsonMapStorage();
 
 private:

--- a/src/mapstorage/mapstorage.h
+++ b/src/mapstorage/mapstorage.h
@@ -38,19 +38,19 @@ class MapStorage : public AbstractMapStorage
     Q_OBJECT
 
 public:
-    MapStorage(MapData &, const QString &, QFile *);
-    MapStorage(MapData &, const QString &);
+    MapStorage(MapData &, const QString &, QFile *, QObject *parent = 0);
+    MapStorage(MapData &, const QString &, QObject *parent = 0);
     bool mergeData();
 
 private:
     virtual bool canLoad()
     {
         return TRUE;
-    };
+    }
     virtual bool canSave()
     {
         return TRUE;
-    };
+    }
 
     virtual void newData ();
     virtual bool loadData();


### PR DESCRIPTION
QtIOCompressor causes a lot of headaches and with Qt6 on the horizon I would rather not have it around if possible.

Let's migrate to the native `qCompress` and `qUncompress` methods which have better support.