### PR TITLE
Deathtraps, oneways, and sundeath are now in Exits/emulated

### DIFF
--- a/src/configuration/configuration.cpp
+++ b/src/configuration/configuration.cpp
@@ -103,6 +103,7 @@ void Configuration::read()
 
     conf.beginGroup("Mume native");
     m_emulatedExits = conf.value("Emulated Exits", true).toBool();
+    m_showHiddenExitFlags = conf.value("Show hidden exit flags", true).toBool();
     conf.endGroup();
 
     if (m_moveForcePatternsList.isEmpty()) {
@@ -200,6 +201,7 @@ void Configuration::write() const
 
     conf.beginGroup("Mume native");
     conf.setValue("Emulated Exits", m_emulatedExits);
+    conf.setValue("Show hidden exit flags", m_showHiddenExitFlags);
     conf.endGroup();
 
     conf.beginGroup("Path Machine");

--- a/src/configuration/configuration.h
+++ b/src/configuration/configuration.h
@@ -89,7 +89,10 @@ public:
 
     QString m_roomNameColor; // ANSI room name color
     QString m_roomDescColor; // ANSI room descriptions color
+
     bool m_emulatedExits;
+    bool m_showHiddenExitFlags;
+
     bool m_showUpdated;
     bool m_drawNotMappedExits;
     bool m_drawNoMatchExits;

--- a/src/parser/abstractparser.h
+++ b/src/parser/abstractparser.h
@@ -104,6 +104,7 @@ protected:
     void printRoomInfo(uint fieldset);
 
     void emulateExits();
+    QByteArray enhanceExits(const Room *);
 
     void parseExits(QString &str);
     void parsePrompt(QString &prompt);

--- a/src/preferences/configdialog.cpp
+++ b/src/preferences/configdialog.cpp
@@ -46,7 +46,7 @@ ConfigDialog::ConfigDialog(Mmapper2Group *gm)
 
     pagesWidget = new QStackedWidget;
     pagesWidget->setMinimumWidth(400);
-    pagesWidget->setMinimumHeight(640);
+    pagesWidget->setMinimumHeight(400);
 
     QPushButton *closeButton = new QPushButton(tr("Close"));
 

--- a/src/preferences/generalpage.cpp
+++ b/src/preferences/generalpage.cpp
@@ -45,7 +45,10 @@ GeneralPage::GeneralPage(QWidget *parent)
     connect( trilinearFilteringCheckBox, SIGNAL(stateChanged(int)),
              SLOT(trilinearFilteringStateChanged(int)));
 
-    connect ( emulatedExits, SIGNAL(stateChanged(int)), SLOT(emulatedExitsStateChanged(int)));
+    connect ( emulatedExitsCheckBox, SIGNAL(stateChanged(int)), SLOT(emulatedExitsStateChanged(int)));
+    connect ( showHiddenExitFlagsCheckBox, SIGNAL(stateChanged(int)),
+              SLOT(showHiddenExitFlagsStateChanged(int)));
+
     connect ( updated, SIGNAL(stateChanged(int)), SLOT(updatedStateChanged(int)));
     connect ( drawNotMappedExits, SIGNAL(stateChanged(int)), SLOT(drawNotMappedExitsStateChanged(int)));
     connect ( drawNoMatchExits, SIGNAL(stateChanged(int)), SLOT(drawNoMatchExitsStateChanged(int)));
@@ -73,7 +76,9 @@ GeneralPage::GeneralPage(QWidget *parent)
     antialiasingSamplesComboBox->setCurrentIndex(index);
     trilinearFilteringCheckBox->setChecked(Config().m_trilinearFiltering);
 
-    emulatedExits->setChecked( Config().m_emulatedExits );
+    emulatedExitsCheckBox->setChecked( Config().m_emulatedExits );
+    showHiddenExitFlagsCheckBox->setChecked( Config().m_showHiddenExitFlags );
+
     updated->setChecked( Config().m_showUpdated );
     drawNotMappedExits->setChecked( Config().m_drawNotMappedExits );
     drawNoMatchExits->setChecked( Config().m_drawNoMatchExits );
@@ -135,7 +140,12 @@ void GeneralPage::localPortValueChanged(int)
 
 void GeneralPage::emulatedExitsStateChanged(int)
 {
-    Config().m_emulatedExits = emulatedExits->isChecked();
+    Config().m_emulatedExits = emulatedExitsCheckBox->isChecked();
+}
+
+void GeneralPage::showHiddenExitFlagsStateChanged(int)
+{
+    Config().m_showHiddenExitFlags = showHiddenExitFlagsCheckBox->isChecked();
 }
 
 void GeneralPage::updatedStateChanged(int)

--- a/src/preferences/generalpage.h
+++ b/src/preferences/generalpage.h
@@ -45,6 +45,8 @@ public slots:
     void trilinearFilteringStateChanged(int);
 
     void emulatedExitsStateChanged(int);
+    void showHiddenExitFlagsStateChanged(int);
+
     void updatedStateChanged(int);
     void drawNotMappedExitsStateChanged(int);
     void drawNoMatchExitsStateChanged(int);

--- a/src/preferences/generalpage.ui
+++ b/src/preferences/generalpage.ui
@@ -279,10 +279,10 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="QCheckBox" name="emulatedExits">
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="updated">
         <property name="text">
-         <string>Show emulated exits</string>
+         <string>Draw outdated room hint</string>
         </property>
        </widget>
       </item>
@@ -296,21 +296,55 @@
       <item row="0" column="0">
        <widget class="QCheckBox" name="drawNotMappedExits">
         <property name="text">
-         <string>Draw not mapped exits</string>
+         <string>Draw unmapped exits</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="updated">
-        <property name="text">
-         <string>Show non updated rooms</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
+      <item row="1" column="1">
        <widget class="QCheckBox" name="drawNoMatchExits">
         <property name="text">
          <string>Draw &quot;no match&quot; exits</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="frame_5">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Sunken</enum>
+     </property>
+     <layout class="QGridLayout">
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
+      <property name="topMargin">
+       <number>9</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
+      <property name="bottomMargin">
+       <number>9</number>
+      </property>
+      <property name="spacing">
+       <number>6</number>
+      </property>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="emulatedExitsCheckBox">
+        <property name="text">
+         <string>Show emulated exits</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QCheckBox" name="showHiddenExitFlagsCheckBox">
+        <property name="text">
+         <string>Show hidden exit flags</string>
         </property>
        </widget>
       </item>

--- a/src/preferences/parserpage.ui
+++ b/src/preferences/parserpage.ui
@@ -260,7 +260,7 @@
       <item row="4" column="0" colspan="5">
        <widget class="QCheckBox" name="IACPromptCheckBox">
         <property name="text">
-         <string>IAC-GA prompt recognition (changes needs reconnect with client!!!)</string>
+         <string>IAC-GA prompts (reconnect required)</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
@nstockton let me know if there is anything else I should port that is very useful.

This code was inspired by https://github.com/MUME/mushclient-mume/blob/6268ab944f23fec61500ee4f532b140330709ec4/mapperproxy/mapper/emulation.py#L64-L67