### PR TITLE
Updating time and clock strings

### DIFF
--- a/src/clock/mumeclock.cpp
+++ b/src/clock/mumeclock.cpp
@@ -110,8 +110,8 @@ void MumeClock::parseMumeTime(const QString &mumeTime, int secsSinceEpoch)
     int year = MUME_START_YEAR;
 
     if (mumeTime.at(0).isDigit()) {
-        // 3pm on Highday, the 18th of Halimath, Year 3030 of the Third Age.
-        QRegExp rx("(\\d+)(am|pm) on \\w+, the (\\d+).{2} of (\\w+), Year (\\d+) of the Third Age.");
+        // 3pm on Highday, the 18th of Halimath, year 3030 of the Third Age.
+        QRegExp rx("(\\d+)(am|pm) on \\w+, the (\\d+).{2} of (\\w+), year (\\d+) of the Third Age.");
         if (rx.indexIn(mumeTime) != -1) {
             hour = rx.cap(1).toInt();
             if (rx.cap(2).at(0) == 'p') {
@@ -134,8 +134,8 @@ void MumeClock::parseMumeTime(const QString &mumeTime, int secsSinceEpoch)
                 m_precision = MUMECLOCK_HOUR;
         }
     } else {
-        // "Highday, the 18th of Halimath, Year 3030 of the Third Age."
-        QRegExp rx("\\w+, the (\\d+).{2} of (\\w+), Year (\\d+) of the Third Age.");
+        // "Highday, the 18th of Halimath, year 3030 of the Third Age."
+        QRegExp rx("\\w+, the (\\d+).{2} of (\\w+), year (\\d+) of the Third Age.");
         if (rx.indexIn(mumeTime) != -1) {
             day = rx.cap(1).toInt() - 1;
             month = s_westronMonthNames.keyToValue(rx.cap(2).toLatin1().data());
@@ -241,8 +241,8 @@ void MumeClock::parseClockTime(const QString &clockTime)
 
 void MumeClock::parseClockTime(const QString &clockTime, int secsSinceEpoch)
 {
-    // The current time is 5:23 pm.
-    QRegExp rx("The current time is (\\d+):(\\d+) (am|pm).");
+    // The current time is 5:23pm.
+    QRegExp rx("The current time is (\\d+):(\\d+)(am|pm).");
     if (rx.indexIn(clockTime) != -1) {
         int hour = rx.cap(1).toInt();
         int minute = rx.cap(2).toInt();
@@ -308,7 +308,7 @@ const QString MumeClock::toMumeTime(const MumeMoment &moment)
 
     // TODO: Figure out how to reverse engineer the day of the week
     QString monthName = MumeClock::s_westronMonthNames.valueToKey((WestronMonthNames)moment.m_month);
-    return QString("%1%2%3 of %4, Year %5 of the Third Age.")
+    return QString("%1%2%3 of %4, year %5 of the Third Age.")
            .arg(time)
            .arg(day)
            .arg(daySuffix)

--- a/tests/testclock.cpp
+++ b/tests/testclock.cpp
@@ -24,27 +24,27 @@ void TestClock::mumeClockTest()
     MumeClock clock;
     clock.setPrecision(MUMECLOCK_HOUR);
 
-    QString zeroTime = "12am on the 1st of Afteryule, Year 2850 of the Third Age.";
+    QString zeroTime = "12am on the 1st of Afteryule, year 2850 of the Third Age.";
     QString actualTime = testMumeStartEpochTime(clock, 0);
     QCOMPARE(actualTime, zeroTime);
 
-    QString oneSecond = "12am on the 1st of Afteryule, Year 2850 of the Third Age.";
+    QString oneSecond = "12am on the 1st of Afteryule, year 2850 of the Third Age.";
     actualTime = testMumeStartEpochTime(clock, 1);
     QCOMPARE(actualTime, oneSecond);
 
-    QString oneTick = "1am on the 1st of Afteryule, Year 2850 of the Third Age.";
+    QString oneTick = "1am on the 1st of Afteryule, year 2850 of the Third Age.";
     actualTime = testMumeStartEpochTime(clock, 60);
     QCOMPARE(actualTime, oneTick);
 
-    QString oneDay = "12am on the 2nd of Afteryule, Year 2850 of the Third Age.";
+    QString oneDay = "12am on the 2nd of Afteryule, year 2850 of the Third Age.";
     actualTime = testMumeStartEpochTime(clock, 60 * 24);
     QCOMPARE(actualTime, oneDay);
 
-    QString oneMonth = "12am on the 1st of Solmath, Year 2850 of the Third Age.";
+    QString oneMonth = "12am on the 1st of Solmath, year 2850 of the Third Age.";
     actualTime = testMumeStartEpochTime(clock, 60 * 24 * 30);
     QCOMPARE(actualTime, oneMonth);
 
-    QString oneYear = "12am on the 1st of Afteryule, Year 2851 of the Third Age.";
+    QString oneYear = "12am on the 1st of Afteryule, year 2851 of the Third Age.";
     actualTime = testMumeStartEpochTime(clock, 60 * 24 * 30 * 12);
     QCOMPARE(actualTime, oneYear);
 }
@@ -54,35 +54,35 @@ void TestClock::parseMumeTimeTest()
     MumeClock clock;
 
     // Defaults to epoch time of zero
-    QString expectedZeroEpoch = "1st of Afteryule, Year 2850 of the Third Age.";
+    QString expectedZeroEpoch = "1st of Afteryule, year 2850 of the Third Age.";
     QCOMPARE(testMumeStartEpochTime(clock, 0), expectedZeroEpoch);
 
     // Real time is Wed Dec 20 07:03:27 2017 UTC.
-    QString snapShot1 = "3pm on Highday, the 18th of Halimath, Year 3030 of the Third Age.";
-    QString expected1 = "3pm on the 18th of Halimath, Year 3030 of the Third Age.";
+    QString snapShot1 = "3pm on Highday, the 18th of Halimath, year 3030 of the Third Age.";
+    QString expected1 = "3pm on the 18th of Halimath, year 3030 of the Third Age.";
     clock.parseMumeTime(snapShot1);
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), expected1);
 
     // Real time is Wed Dec 20 07:18:02 2017 UTC.
-    QString snapShot2 = "5am on Sterday, the 19th of Halimath, Year 3030 of the Third Age.";
-    QString expected2 = "5am on the 19th of Halimath, Year 3030 of the Third Age.";
+    QString snapShot2 = "5am on Sterday, the 19th of Halimath, year 3030 of the Third Age.";
+    QString expected2 = "5am on the 19th of Halimath, year 3030 of the Third Age.";
     clock.parseMumeTime(snapShot2);
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), expected2);
 
     // Real time is Wed Dec 20 07:38:44 2017 UTC.
-    QString snapShot3 = "2am on Sunday, the 20th of Halimath, Year 3030 of the Third Age.";
-    QString expected3 = "2am on the 20th of Halimath, Year 3030 of the Third Age.";
+    QString snapShot3 = "2am on Sunday, the 20th of Halimath, year 3030 of the Third Age.";
+    QString expected3 = "2am on the 20th of Halimath, year 3030 of the Third Age.";
     clock.parseMumeTime(snapShot3);
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), expected3);
 
     // Real time is Thu Dec 21 05:27:35 2017 UTC.
-    QString snapShot4 = "3pm on Highday, the 14th of Blotmath, Year 3030 of the Third Age.";
-    QString expected4 = "3pm on the 14th of Blotmath, Year 3030 of the Third Age.";
+    QString snapShot4 = "3pm on Highday, the 14th of Blotmath, year 3030 of the Third Age.";
+    QString expected4 = "3pm on the 14th of Blotmath, year 3030 of the Third Age.";
     clock.parseMumeTime(snapShot4);
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), expected4);
 
     // Sindarin Calendar
-    QString sindarin = "3pm on Oraearon, the 14th of Hithui, Year 3030 of the Third Age.";
+    QString sindarin = "3pm on Oraearon, the 14th of Hithui, year 3030 of the Third Age.";
     QString expectedSindarin = expected4;
     clock.parseMumeTime(sindarin);
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), expectedSindarin);
@@ -92,8 +92,8 @@ void TestClock::parseWeatherClockSkewTest()
 {
     MumeClock clock;
 
-    QString snapShot1 = "3pm on Highday, the 18th of Halimath, Year 3030 of the Third Age.";
-    QString expected1 = "3pm on the 18th of Halimath, Year 3030 of the Third Age.";
+    QString snapShot1 = "3pm on Highday, the 18th of Halimath, year 3030 of the Third Age.";
+    QString expected1 = "3pm on the 18th of Halimath, year 3030 of the Third Age.";
     // Real time is Wed Dec 20 07:03:27 2017 UTC.
     int realTime1 = 1513753407;
     clock.parseMumeTime(snapShot1, realTime1);
@@ -101,31 +101,31 @@ void TestClock::parseWeatherClockSkewTest()
 
     // First sync
     int timeOccuredAt = 1;
-    QString expectedTime = "6:00am on the 18th of Halimath, Year 3030 of the Third Age.";
+    QString expectedTime = "6:00am on the 18th of Halimath, year 3030 of the Third Age.";
     clock.parseWeather("The day has begun.", realTime1 + timeOccuredAt);
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment(realTime1 + timeOccuredAt)), expectedTime);
 
     // Mume running on time
     timeOccuredAt = 1 + 60;
-    expectedTime = "7:00am on the 18th of Halimath, Year 3030 of the Third Age.";
+    expectedTime = "7:00am on the 18th of Halimath, year 3030 of the Third Age.";
     clock.parseWeather("The evil power begins to regress...", realTime1 + timeOccuredAt);
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment(realTime1 + timeOccuredAt)), expectedTime);
 
     // Mume running fast
     timeOccuredAt = 1 + 60 + 58;
-    expectedTime = "8:00am on the 18th of Halimath, Year 3030 of the Third Age.";
+    expectedTime = "8:00am on the 18th of Halimath, year 3030 of the Third Age.";
     clock.parseWeather("The evil power begins to regress...", realTime1 + timeOccuredAt);
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment(realTime1 + timeOccuredAt)), expectedTime);
 
     // Mume running on time
     timeOccuredAt = 1 + 60 + 58 + 60;
-    expectedTime = "9:00am on the 18th of Halimath, Year 3030 of the Third Age.";
+    expectedTime = "9:00am on the 18th of Halimath, year 3030 of the Third Age.";
     clock.parseWeather("The evil power begins to regress...", realTime1 + timeOccuredAt);
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment(realTime1 + timeOccuredAt)), expectedTime);
 
     // Mume running slow
     timeOccuredAt = 1 + 60 + 58 + 60 + 65;
-    expectedTime = "10:00am on the 18th of Halimath, Year 3030 of the Third Age.";
+    expectedTime = "10:00am on the 18th of Halimath, year 3030 of the Third Age.";
     clock.parseWeather("The evil power begins to regress...", realTime1 + timeOccuredAt);
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment(realTime1 + timeOccuredAt)), expectedTime);
 }
@@ -134,24 +134,24 @@ void TestClock::parseWeatherTest()
 {
     MumeClock clock;
 
-    QString snapShot1 = "3pm on Highday, the 18th of Halimath, Year 3030 of the Third Age.";
-    QString expectedTime = "3pm on the 18th of Halimath, Year 3030 of the Third Age.";
+    QString snapShot1 = "3pm on Highday, the 18th of Halimath, year 3030 of the Third Age.";
+    QString expectedTime = "3pm on the 18th of Halimath, year 3030 of the Third Age.";
     clock.parseMumeTime(snapShot1);
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), expectedTime);
 
-    expectedTime = "5:00am on the 18th of Halimath, Year 3030 of the Third Age.";
+    expectedTime = "5:00am on the 18th of Halimath, year 3030 of the Third Age.";
     clock.parseWeather("Light gradually filters in, proclaiming a new sunrise outside.");
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), expectedTime);
 
-    expectedTime = "6:00am on the 18th of Halimath, Year 3030 of the Third Age.";
+    expectedTime = "6:00am on the 18th of Halimath, year 3030 of the Third Age.";
     clock.parseWeather("It seems as if the day has begun.");
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), expectedTime);
 
-    expectedTime = "9:00pm on the 18th of Halimath, Year 3030 of the Third Age.";
+    expectedTime = "9:00pm on the 18th of Halimath, year 3030 of the Third Age.";
     clock.parseWeather("The deepening gloom announces another sunset outside.");
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), expectedTime);
 
-    expectedTime = "10:00pm on the 18th of Halimath, Year 3030 of the Third Age.";
+    expectedTime = "10:00pm on the 18th of Halimath, year 3030 of the Third Age.";
     clock.parseWeather("It seems as if the night has begun.");
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), expectedTime);
 }
@@ -162,17 +162,17 @@ void TestClock::parseClockTimeTest()
 
     // Clock set to coarse
     // Real time is Wed Dec 20 07:03:27 2017 UTC.
-    QString snapShot1 = "3pm on Highday, the 18th of Halimath, Year 3030 of the Third Age.";
-    QString expected1 = "3pm on the 18th of Halimath, Year 3030 of the Third Age.";
+    QString snapShot1 = "3pm on Highday, the 18th of Halimath, year 3030 of the Third Age.";
+    QString expected1 = "3pm on the 18th of Halimath, year 3030 of the Third Age.";
     clock.parseMumeTime(snapShot1);
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), expected1);
 
-    QString afternoon = "12:34pm on the 18th of Halimath, Year 3030 of the Third Age.";
-    clock.parseClockTime("The current time is 12:34 pm.");
+    QString afternoon = "12:34pm on the 18th of Halimath, year 3030 of the Third Age.";
+    clock.parseClockTime("The current time is 12:34pm.");
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), afternoon);
 
-    QString midnight = "12:51am on the 18th of Halimath, Year 3030 of the Third Age.";
-    clock.parseClockTime("The current time is 12:51 am.");
+    QString midnight = "12:51am on the 18th of Halimath, year 3030 of the Third Age.";
+    clock.parseClockTime("The current time is 12:51am.");
     QCOMPARE(clock.toMumeTime(clock.getMumeMoment()), midnight);
 
 }


### PR DESCRIPTION
MUME updated the `time` and `look clock` output and we need to update the regular expressions to match.