### PR TITLE
Character encoding auto detection for the built in client

### DIFF
--- a/src/client/ctelnet.h
+++ b/src/client/ctelnet.h
@@ -72,6 +72,7 @@ a) FULLY SUPPORTED COMMANDS:
 b) PARTIALLY SUPPORTED COMMANDS
 - SUPPRESS-GO-AHEAD (cmd 3, RFC 858) - we try to suppress GA's if possible.
   If we fail, we just ignore all GA's, hoping for no problems...
+- CHARSET (cmd 42, RFC 2066) - mechanism for passing character set
 
 c) COMMANDS THAT ARE NOT SUPPORTED
 The following commands are not supported at all - they are all disabled,
@@ -144,10 +145,18 @@ else does it ;))
 #define OPT_TIMING_MARK (unsigned char) 6
 #define OPT_TERMINAL_TYPE (unsigned char) 24
 #define OPT_NAWS (unsigned char) 31
+#define OPT_CHARSET (unsigned char) 42
 
 //telnet SB suboption types
 #define TNSB_IS (char) 0
 #define TNSB_SEND (unsigned char) 1
+#define TNSB_REQUEST (char) 1
+#define TNSB_ACCEPTED (char) 2
+#define TNSB_REJECTED (char) 3
+#define TNSB_TTABLE_IS (char) 4
+#define TNSB_TTABLE_REJECTED (char) 5
+#define TNSB_TTABLE_ACK (char) 6
+#define TNSB_TTABLE_NAK (char) 7
 
 class QTextCodec;
 class QTextDecoder;
@@ -230,14 +239,11 @@ private:
     bool announcedState[256]{};
     /** whether the server has already announced his WILL/WON'T */
     bool heAnnouncedState[256]{};
-    /** whether we have tried to enable this option */
-    bool triedToEnable[256]{};
     /** amount of bytes sent up to now */
     int sentbytes;
     /** have we received the GA signal? */
     bool recvdGA{};
     bool echoMode{};
-    bool startupneg;
     /** current dimensions */
     int curX, curY;
 

--- a/src/client/stackedinputwidget.cpp
+++ b/src/client/stackedinputwidget.cpp
@@ -85,6 +85,7 @@ bool StackedInputWidget::eventFilter(QObject *obj, QEvent *event)
 void StackedInputWidget::toggleEchoMode(bool localEcho)
 {
     m_localEcho = localEcho;
+    m_passwordWidget->clear();
     if (m_localEcho) {
         setFocusProxy(m_inputWidget);
         setCurrentWidget(m_inputWidget);

--- a/src/proxy/mumesocket.cpp
+++ b/src/proxy/mumesocket.cpp
@@ -113,7 +113,7 @@ void MumeSslSocket::onConnect()
 
 void MumeSslSocket::onError(QAbstractSocket::SocketError e)
 {
-    qWarning() << m_socket->errorString();
+    qWarning() << "MumeSslSocket error:" << m_socket->errorString();
     MumeSocket::onError(e);
 }
 

--- a/src/proxy/proxy.cpp
+++ b/src/proxy/proxy.cpp
@@ -312,7 +312,7 @@ void Proxy::onMudError(QAbstractSocket::SocketError socketError)
 {
     m_serverConnected = false;
 
-    qWarning() << socketError;
+    qWarning() << "Mud socket error" << socketError;
     QByteArray errorStr = "MUME is not responding!";
 
     switch (socketError) {
@@ -378,8 +378,10 @@ void Proxy::processUserStream()
 
 void Proxy::sendToMud(const QByteArray &ba)
 {
-    if ((m_mudSocket != nullptr) && m_serverConnected) {
+    if (m_mudSocket != nullptr) {
         m_mudSocket->sendToMud(ba);
+    } else {
+        qWarning() << "Mud socket not available";
     }
 }
 
@@ -388,5 +390,7 @@ void Proxy::sendToUser(const QByteArray &ba)
     if (m_userSocket != nullptr) {
         m_userSocket->write(ba.data(), ba.size());
         m_userSocket->flush();
+    } else {
+        qWarning() << "User socket not available";
     }
 }


### PR DESCRIPTION
This PR provides minimal [RFC 2066](https://tools.ietf.org/html/rfc2066) support for MMapper's built in client. Once MUME supports this standard it should be easier for the clients and mappers to know what the character encoding that is currently in use is.

On connection start for all clients:
-
MUME sends:  `IAC DO CHARSET`
Client sends either: 

- `IAC WILL CHARSET` if it supports RFC 2066
- `IAC WONT CHARSET` if it does not (or will not respond)

MUME sends:  `IAC SB CHARSET REQUEST DELIM NAMES IAC SE`

- DELIM is any character that does not appear in the charset name or IAC (eg. comma, space)
- NAME:  the [IANA character set](https://www.iana.org/assignments/character-sets/character-sets.xml) string (eg. `UTF-8`, `LATIN1`, `US-ASCII`)

Client sends:  `IAC SB CHARSET ACCEPTED NAME IAC SE`

On `change charset <NAME>`
-
MUME sends: `IAC SB CHARSET REQUEST DELIM NAME`
Client sends either:

- `IAC SB CHARSET ACCEPTED NAME IAC SE` if it understands any IANA NAMES (eg. `UTF-8` etc)
- `IAC SB CHARSET REJECTED IAC SE` if it does not understand (but whatever, player requested this, so MUME should keep using `change charset <NAME>`)