### PR TITLE
Fix ExitFlags bits offset

### DIFF
--- a/src/mapdata/roomfactory.cpp
+++ b/src/mapdata/roomfactory.cpp
@@ -50,7 +50,7 @@ ParseEvent *RoomFactory::getEvent(const Room *room) const
         const Exit &e = room->exit(dir);
 
         ExitFlags eFlags = Mmapper2Exit::getFlags(e);
-        exitFlags |= (eFlags << (dir * 3));
+        exitFlags |= (eFlags << (dir * 4));
     }
 
     exitFlags |= EXITS_FLAGS_VALID;


### PR DESCRIPTION
Climb exits introduced in commit https://github.com/MUME/MMapper/commit/5005e3727993a61caf5d1b92668cf76e87b3214b#diff-79e49887935fd1521dbb826cc9556ab1 added 4th ExitFlags bit and a bug.

This bug most likely explains the proliferation of NO_MATCH exits on older maps. We'll need to clean that up in another PR.