### PR TITLE
Do not normalize all strings from MUME

### DIFF
--- a/src/parser/abstractparser.h
+++ b/src/parser/abstractparser.h
@@ -90,9 +90,10 @@ private:
     char prefixChar = '_';
 
 protected:
-    QString m_roomName{};
-    QString m_staticRoomDesc{};
-    QString m_dynamicRoomDesc{};
+    QString m_roomName = nullString;
+    QString m_staticRoomDesc = nullString;
+    QString m_dynamicRoomDesc = nullString;
+    QString m_exits = nullString;
     ExitsFlagsType m_exitsFlags{};
     PromptFlagsType m_promptFlags{};
     ConnectedRoomFlagsType m_connectedRoomFlags{};
@@ -201,9 +202,10 @@ protected:
     void emulateExits();
     QByteArray enhanceExits(const Room *);
 
-    void parseExits(const QString &str);
+    void parseExits();
     void parsePrompt(const QString &prompt);
     virtual bool parseUserCommands(const QString &command);
+    QString& normalizeString(QString &str);
 
     void searchCommand(const RoomFilter &f);
     void dirsCommand(const RoomFilter &f);

--- a/src/parser/mumexmlparser.h
+++ b/src/parser/mumexmlparser.h
@@ -73,13 +73,10 @@ protected:
     static const QByteArray ampersand;
     static const QByteArray ampersandTemplate;
 
-    void parseMudCommands(QString &str);
+    void parseMudCommands(const QString &str);
 
     QByteArray characters(QByteArray &ch);
     bool element(const QByteArray &);
-
-    quint32 m_roomDescLines = 0u;
-    bool m_readingStaticDescLines = false;
 
     CommandIdType m_move = CommandIdType::LOOK;
     XmlMode m_xmlMode = XmlMode::NONE;


### PR DESCRIPTION
Normalize strings by removing Latin-1 characters or stripping ANSI only for room names, static descriptions, and dynamic descriptions.

As a side effect, exits now preserve their color from MUME.

https://github.com/MUME/MMapper/issues/122