### PR TITLE
Rename appdata, desktop file and icons to use reverse-DNS name

### DIFF
--- a/.snapcraft.yaml
+++ b/.snapcraft.yaml
@@ -17,7 +17,7 @@ base: core18
 apps:
   mmapper-desktop:
     command: desktop-launch mmapper
-    desktop: usr/share/applications/mmapper.desktop
+    desktop: usr/share/applications/org.mume.MMapper.desktop
     plugs:
       - home
       - gsettings
@@ -53,7 +53,7 @@ parts:
       - libminiupnpc10
     override-build: |
       snapcraftctl build
-      sed -i 's|Icon=mmapper|Icon=${SNAP}/usr/share/icons/hicolor/256x256/apps/mmapper.png|g' $SNAPCRAFT_PART_INSTALL/usr/share/applications/mmapper.desktop
+      sed -i 's|Icon=org.mume.MMapper|Icon=${SNAP}/usr/share/icons/hicolor/256x256/apps/org.mume.MMapper.png|g' $SNAPCRAFT_PART_INSTALL/usr/share/applications/org.mume.MMapper.desktop
     after: [desktop-qt5]
   desktop-qt5:
     source: https://github.com/ubuntu/snapcraft-desktop-helpers.git

--- a/appdata/CMakeLists.txt
+++ b/appdata/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Linux Install Settings
 if(UNIX AND NOT APPLE)
-    install(FILES mmapper.appdata.xml
+    install(FILES org.mume.MMapper.appdata.xml
             DESTINATION share/metainfo
             COMPONENT desktopintegration
     )

--- a/appdata/org.mume.MMapper.appdata.xml
+++ b/appdata/org.mume.MMapper.appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-  <id>mmapper.desktop</id>
+  <id>org.mume.MMapper</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0+</project_license>
   <name>MMapper</name>
@@ -31,6 +31,10 @@
       <image height="675" width="1200">https://raw.githubusercontent.com/MUME/MMapper/master/appdata/screenshot1.png</image>
     </screenshot>
   </screenshots>
+  <provides>
+    <id>mmapper.desktop</id>
+  </provides>
+  <launchable type="desktop-id">org.mume.MMapper.desktop</launchable>
   <url type="bugtracker">https://github.com/MUME/MMapper/issues</url>
   <url type="homepage">https://github.com/MUME/MMapper</url>
 </component>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -359,7 +359,7 @@ if(CHECK_MISSING_INCLUDES)
 endif()
 
 set(mmapper_DATA
-    mmapper.desktop
+    org.mume.MMapper.desktop
     MacOSXBundleInfo.plist.in
     display/OpenGL.cpp)
 
@@ -520,7 +520,7 @@ if(UNIX AND NOT APPLE)
     )
 
     # Linux Desktop Integration
-    install(FILES mmapper.desktop
+    install(FILES org.mume.MMapper.desktop
             DESTINATION share/applications
             COMPONENT desktopintegration
     )
@@ -531,7 +531,7 @@ if(UNIX AND NOT APPLE)
             FILES resources/icons/hi${RES}-app-mmapper.png
             DESTINATION share/icons/hicolor/${RES}x${RES}/apps/
             COMPONENT desktopintegration
-            RENAME mmapper.png
+            RENAME org.mume.MMapper.png
         )
     endforeach(RES)
 
@@ -539,7 +539,7 @@ if(UNIX AND NOT APPLE)
         FILES resources/icons/m.png
         DESTINATION share/icons/hicolor/256x256/apps/
         COMPONENT desktopintegration
-        RENAME mmapper.png
+        RENAME org.mume.MMapper.png
     )
 
     set(CPACK_GENERATOR "DEB;TGZ") # Others: RPM, STGZ

--- a/src/org.mume.MMapper.desktop
+++ b/src/org.mume.MMapper.desktop
@@ -2,7 +2,7 @@
 Name=MMapper
 GenericName=MUME Mapper
 Exec=mmapper
-Icon=mmapper
+Icon=org.mume.MMapper
 Terminal=false
 Type=Application
 Categories=Qt;Game;RolePlaying;


### PR DESCRIPTION
This is necessary for flatpak packaging that requires all applications
to use a unique reverse-DNS based identifier.

http://docs.flatpak.org/en/latest/conventions.html#application-ids