### PR TITLE
Include missing header to fix the build with gcc 10

### DIFF
--- a/src/global/enums.h
+++ b/src/global/enums.h
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cstddef>
+#include <stdexcept>
 
 namespace enums {
 


### PR DESCRIPTION
src/mapdata/../global/enums.h:55:24: error: 'runtime_error' is not a member of 'std'