### PR TITLE
Avoid QString::fromStdString() and QString::toStdString()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -194,7 +194,22 @@ script:
 
 after_success:
   - '[[ "$CODECOV" == "" ]] || lcov  --zerocounters  --directory .'
-  - '[[ "$BUILD" == "" ]] || ctest -V'
+  - |
+    if [[ "$BUILD" != "" ]]; then
+      ctest -V
+      if  [[ -n $(nm -C src/mmapper | grep -w 'QString::\(to\|from\)StdString') ]]; then
+        nm -C src/mmapper | grep -w 'QString::\(to\|from\)StdString'
+        echo
+        echo
+        echo "Please avoid using QString::fromStdString() and QString::toStdString()"
+        echo
+        echo "Both functions assume the user wants utf8, but MMapper almost always expects"
+        echo "std::string to have latin1 encoding."
+        echo
+        echo "Convert any uses to corresponding functions in TextUtils e.g. ::toQStringUtf8()"
+        exit -1
+      fi
+    fi
   - |
     if [ "$CODECOV" != "" ]; then
       lcov --remove coverage.info '/usr/*' "${HOME}"'/.cache/*' --output-file coverage.info

--- a/src/display/Connections.cpp
+++ b/src/display/Connections.cpp
@@ -139,6 +139,7 @@ void ConnectionDrawer::drawRoomDoorName(const Room *const sourceRoom,
         return;
     }
 
+    // consider converting this to std::string
     QString name;
     bool together = false;
 
@@ -216,8 +217,11 @@ void ConnectionDrawer::drawRoomDoorName(const Room *const sourceRoom,
 
     static const auto bg = Colors::black.withAlpha(0.4f);
     const glm::vec3 pos{xy, m_currentLayer};
-    m_roomNameBatch.emplace_back(
-        GLText{pos, name, Colors::white, bg, FontFormatFlags{FontFormatFlagEnum::HALIGN_CENTER}});
+    m_roomNameBatch.emplace_back(GLText{pos,
+                                        ::toStdStringLatin1(name),
+                                        Colors::white,
+                                        bg,
+                                        FontFormatFlags{FontFormatFlagEnum::HALIGN_CENTER}});
 }
 
 void ConnectionDrawer::drawRoomConnectionsAndDoors(const Room *const room, const RoomIndex &rooms)

--- a/src/display/Textures.cpp
+++ b/src/display/Textures.cpp
@@ -42,7 +42,7 @@ static SharedMMTexture loadTexture(const QString &name)
         texture->create();
 
         if (!texture->isCreated())
-            throw std::runtime_error(("failed to create: " + name).toStdString());
+            throw std::runtime_error(::toStdStringUtf8("failed to create: " + name));
     }
 
     texture->setWrapMode(QOpenGLTexture::WrapMode::MirroredRepeat);

--- a/src/display/mapcanvas_gl.cpp
+++ b/src/display/mapcanvas_gl.cpp
@@ -585,7 +585,7 @@ void MapCanvas::paintGL()
     float y = lineHeight;
     const auto print = [lineHeight, rightMargin, &text, &y](const QString &msg) {
         text.emplace_back(glm::vec3(rightMargin, y, 0),
-                          msg,
+                          ::toStdStringLatin1(msg),
                           Colors::white,
                           Colors::black.withAlpha(0.4f),
                           FontFormatFlags{FontFormatFlagEnum::HALIGN_RIGHT});

--- a/src/expandoracommon/parseevent.cpp
+++ b/src/expandoracommon/parseevent.cpp
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <memory>
 
+#include "../global/TextUtils.h"
 #include "../global/utils.h"
 #include "../mapdata/ExitDirection.h"
 #include "../parser/CommandId.h"
@@ -80,7 +81,7 @@ QString ParseEvent::toQString() const
     }
     QString promptStr;
     if (m_promptFlags.isValid()) {
-        promptStr.append(QString::fromStdString(getPromptBytes(m_promptFlags)));
+        promptStr.append(::toQStringLatin1(getPromptBytes(m_promptFlags)));
         if (m_promptFlags.isLit())
             promptStr.append("*");
         else if (m_promptFlags.isDark())

--- a/src/expandoracommon/room.cpp
+++ b/src/expandoracommon/room.cpp
@@ -714,7 +714,7 @@ void Room::update(Room *const target, const Room *const source)
 std::string Room::toStdString() const
 {
     std::stringstream ss;
-    ss << getName() + "\n"
+    ss << getName().getStdString() << "\n"
        << getStaticDescription().getStdString() << getDynamicDescription().getStdString();
 
     ss << "Exits:";

--- a/src/expandoracommon/room.h
+++ b/src/expandoracommon/room.h
@@ -13,6 +13,7 @@
 #include "../global/EnumIndexedArray.h"
 #include "../global/Flags.h"
 #include "../global/RuleOf5.h"
+#include "../global/TextUtils.h"
 #include "../global/roomid.h"
 #include "../mapdata/mmapper2exit.h"
 #include "../mapdata/mmapper2room.h"
@@ -215,7 +216,7 @@ public:
 
 public:
     std::string toStdString() const;
-    QString toQString() const { return QString::fromStdString(toStdString()); }
+    QString toQString() const { return ::toQStringLatin1(toStdString()); }
     explicit operator QString() const { return toQString(); }
     friend QDebug operator<<(QDebug os, const Room &r) { return os << r.toQString(); }
 

--- a/src/global/StringView.cpp
+++ b/src/global/StringView.cpp
@@ -33,12 +33,12 @@ std::string StringView::toStdString() const noexcept(false)
 
 QString StringView::toQString() const noexcept(false)
 {
-    return QString::fromStdString(toStdString());
+    return ::toQStringLatin1(m_sv);
 }
 
 QByteArray StringView::toQByteArray() const noexcept(false)
 {
-    return QByteArray(m_sv.data(), static_cast<int>(m_sv.size()));
+    return ::toQByteArrayLatin1(m_sv);
 }
 
 void StringView::eatFirst()

--- a/src/global/TaggedString.h
+++ b/src/global/TaggedString.h
@@ -11,6 +11,7 @@
 #include <QString>
 
 #include "RuleOf5.h"
+#include "TextUtils.h"
 
 // Latin1
 template<typename T>
@@ -37,7 +38,7 @@ public:
         : m_str(std::move(s))
     {}
     explicit TaggedString(const QString &s)
-        : m_str(s.toLatin1().toStdString())
+        : m_str(::toStdStringLatin1(s))
     {}
     DEFAULT_RULE_OF_5(TaggedString);
 
@@ -45,6 +46,7 @@ public:
     bool operator==(const TaggedString &rhs) const { return m_str == rhs.m_str; }
     bool operator!=(const TaggedString &rhs) const { return !(rhs == *this); }
 
+#if 0
 public:
     template<typename U>
     friend auto operator+(const TaggedString &taggedString, const U &x)
@@ -56,27 +58,22 @@ public:
     {
         return x + taggedString.getStdString();
     }
+#endif
 
 public:
-    friend auto operator+(const TaggedString &taggedString, const QString &x)
+    friend auto operator+(const TaggedString &taggedString, const QString &qs)
     {
-        return taggedString.getStdString().c_str() + x;
+        return taggedString.toQString() + qs;
     }
-    friend auto operator+(const QString &x, const TaggedString &taggedString)
+    friend auto operator+(const QString &qs, const TaggedString &taggedString)
     {
-        return x + taggedString.getStdString().c_str();
+        return qs + taggedString.toQString();
     }
 
 public:
     const std::string &getStdString() const { return m_str; }
-    QByteArray toQByteArray() const
-    {
-        return QByteArray{m_str.data(), static_cast<int>(m_str.size())};
-    }
-    QString toQString() const
-    {
-        return QString::fromLatin1(m_str.data(), static_cast<int>(m_str.size()));
-    }
+    QByteArray toQByteArray() const { return ::toQByteArrayLatin1(m_str); }
+    QString toQString() const { return ::toQStringLatin1(m_str); }
 
 public:
     bool empty() const { return m_str.empty(); }

--- a/src/global/TextUtils.cpp
+++ b/src/global/TextUtils.cpp
@@ -1118,3 +1118,28 @@ std::ostream &print_string_smartquote(std::ostream &os, const std::string_view &
     }
     return print_string_quoted(os, sv);
 }
+
+QString toQStringLatin1(const std::string_view &sv)
+{
+    return QString::fromLatin1(sv.data(), static_cast<int>(sv.size()));
+}
+
+QString toQStringUtf8(const std::string_view &sv)
+{
+    return QString::fromUtf8(sv.data(), static_cast<int>(sv.size()));
+}
+
+QByteArray toQByteArrayLatin1(const std::string_view &sv)
+{
+    return QByteArray::fromRawData(sv.data(), static_cast<int>(sv.size()));
+}
+
+std::string toStdStringLatin1(const QString &qs)
+{
+    return qs.toLatin1().toStdString();
+}
+
+std::string toStdStringUtf8(const QString &qs)
+{
+    return qs.toUtf8().toStdString();
+}

--- a/src/global/TextUtils.h
+++ b/src/global/TextUtils.h
@@ -526,3 +526,10 @@ public:
         return print_string_smartquote(os, smartQuotedString.m_str);
     }
 };
+
+QString toQStringLatin1(const std::string_view &sv);
+QString toQStringUtf8(const std::string_view &sv);
+QByteArray toQByteArrayLatin1(const std::string_view &sv);
+
+std::string toStdStringLatin1(const QString &qs);
+std::string toStdStringUtf8(const QString &qs);

--- a/src/mainwindow/UpdateDialog.cpp
+++ b/src/mainwindow/UpdateDialog.cpp
@@ -88,6 +88,7 @@ void UpdateDialog::managerFinished(QNetworkReply *reply)
     }
     QString answer = reply->readAll();
     QJsonParseError error;
+    // REVISIT: Should this be latin1 or utf8?
     QJsonDocument doc = QJsonDocument::fromJson(answer.toLatin1(), &error);
     if (doc.isNull()) {
         qWarning() << error.errorString();

--- a/src/mainwindow/findroomsdlg.cpp
+++ b/src/mainwindow/findroomsdlg.cpp
@@ -88,9 +88,9 @@ void FindRoomsDlg::findClicked()
 {
     const Qt::CaseSensitivity cs = caseCheckBox->isChecked() ? Qt::CaseSensitive
                                                              : Qt::CaseInsensitive;
-    QString text = lineEdit->text();
+    std::string text = lineEdit->text().toLatin1().toStdString();
     // remove latin1
-    text = ParserUtils::latinToAsciiInPlace(text);
+    text = ParserUtils::latin1ToAsciiInPlace(text);
     resultTable->clear();
     roomsFoundLabel->clear();
 

--- a/src/mainwindow/roomeditattrdlg.cpp
+++ b/src/mainwindow/roomeditattrdlg.cpp
@@ -165,7 +165,7 @@ static QIcon getIcon(T flag)
         QIcon result(filename);
         if (result.isNull())
             throw std::runtime_error(
-                QString("failed to load icon '%1'").arg(filename).toStdString());
+                ::toStdStringUtf8(QString("failed to load icon '%1'").arg(filename)));
         return result;
     } catch (...) {
         qWarning() << "Oops: Unable to create icon:" << filename;

--- a/src/mapdata/roomfilter.h
+++ b/src/mapdata/roomfilter.h
@@ -24,11 +24,11 @@ class RoomFilter final
 {
 public:
     static const char *const parse_help;
-    static std::optional<RoomFilter> parseRoomFilter(const QString &line);
+    static std::optional<RoomFilter> parseRoomFilter(const std::string_view &line);
 
 public:
     RoomFilter() = delete;
-    explicit RoomFilter(QString str, Qt::CaseSensitivity cs, PatternKindsEnum kind);
+    explicit RoomFilter(const std::string_view &str, Qt::CaseSensitivity cs, PatternKindsEnum kind);
 
 public:
     bool filter(const Room *r) const;

--- a/src/mapstorage/filesaver.cpp
+++ b/src/mapstorage/filesaver.cpp
@@ -10,6 +10,7 @@
 #include <QIODevice>
 
 #include "../configuration/configuration.h"
+#include "../global/TextUtils.h"
 #include "../global/io.h"
 
 static constexpr const bool USE_TMP_SUFFIX = CURRENT_PLATFORM != PlatformEnum::Windows;
@@ -48,7 +49,7 @@ void FileSaver::open(const QString &filename) noexcept(false)
     m_file.setFileName(maybe_add_suffix(filename));
 
     if (!m_file.open(QFile::WriteOnly)) {
-        throw std::runtime_error(m_file.errorString().toStdString());
+        throw std::runtime_error(::toStdStringUtf8(m_file.errorString()));
     }
 }
 

--- a/src/mapstorage/jsonmapstorage.cpp
+++ b/src/mapstorage/jsonmapstorage.cpp
@@ -54,14 +54,15 @@ public:
         // This is most likely unnecessary because the parser did it for us...
         // We need plain ASCII so that accentuation changes do not affect the
         // hashes and because MD5 is defined on bytes, not encoded chars.
-        ParserUtils::latinToAsciiInPlace(str);
-        // Roomdescs may see whitespacing fixes over the year (ex: removing double
-        // spaces after periods). MM2 ignores such changes when comparing rooms,
+        ParserUtils::toAsciiInPlace(str);
+        // Roomdescs may see whitespacing fixes over the years (ex: removing double
+        // spaces after periods). MMapper ignores such changes when comparing rooms,
         // but the web mapper may only look up rooms by hash. Normalizing the
-        // whitespaces make the hash resilient.
+        // whitespaces makes the hash more resilient.
         str.replace(QRegularExpression(" +"), " ");
         str.replace(QRegularExpression(" *\r?\n"), "\n");
 
+        // REVISIT: should this be latin1 or utf8?
         m_hash.addData(str.toLatin1());
     }
 
@@ -144,7 +145,7 @@ static void writeJson(const QString &filePath, JsonT &json, const QString &what)
     if (!file.open(QIODevice::WriteOnly)) {
         QString msg(
             QString("error opening %1 to %2: %3").arg(what).arg(filePath).arg(file.errorString()));
-        throw std::runtime_error(msg.toStdString());
+        throw std::runtime_error(::toStdStringUtf8(msg));
     }
 
     QJsonDocument doc(json);
@@ -154,7 +155,7 @@ static void writeJson(const QString &filePath, JsonT &json, const QString &what)
     if (!file.flush() || stream.status() != QTextStream::Ok) {
         QString msg(
             QString("error writing %1 to %2: %3").arg(what).arg(filePath).arg(file.errorString()));
-        throw std::runtime_error(msg.toStdString());
+        throw std::runtime_error(::toStdStringUtf8(msg));
     }
 }
 
@@ -433,7 +434,7 @@ void JsonWorld::writeZones(const QDir &dir,
             progressCounter.step();
         }
 
-        QString filePath = dir.filePath(QString::fromStdString(kv.first + ".json"));
+        QString filePath = dir.filePath(::toQStringUtf8(kv.first + ".json"));
         writeJson(filePath, jRooms, "zone");
     }
 }

--- a/src/mpi/remoteeditprocess.cpp
+++ b/src/mpi/remoteeditprocess.cpp
@@ -50,7 +50,7 @@ RemoteEditProcess::RemoteEditProcess(const bool editSession,
 
     const QString &fileName = m_file.fileName();
     qDebug() << "View session file template" << fileName;
-    m_file.write(m_body.toLatin1());
+    m_file.write(m_body.toLatin1()); // note: MUME expects all remote edit data to be Latin-1.
     m_file.flush();
     io::fsyncNoexcept(m_file);
     m_file.close();

--- a/src/opengl/Font.cpp
+++ b/src/opengl/Font.cpp
@@ -677,20 +677,6 @@ public:
     }
 };
 
-GLText::GLText(const glm::vec3 &pos,
-               const QString &text,
-               const Color &color,
-               std::optional<Color> moved_bgcolor,
-               const FontFormatFlags &fontFormatFlag,
-               const int rotationAngle)
-    : GLText{pos,
-             text.toLatin1().toStdString(),
-             color,
-             std::move(moved_bgcolor),
-             fontFormatFlag,
-             rotationAngle}
-{}
-
 GLFont::GLFont(OpenGL &gl)
     : m_gl(gl)
 {}
@@ -850,7 +836,7 @@ void GLFont::renderTextCentered(const QString &text,
     const auto center = glm::vec2{getScreenCenter()};
     render2dTextImmediate(
         std::vector<GLText>{GLText{glm::vec3{center, 0.f},
-                                   text,
+                                   ::toStdStringLatin1(text),
                                    color,
                                    bgcolor,
                                    FontFormatFlags{FontFormatFlagEnum::HALIGN_CENTER}}});

--- a/src/opengl/Font.h
+++ b/src/opengl/Font.h
@@ -28,13 +28,6 @@ struct NODISCARD GLText final
     int rotationAngle = 0;
 
     explicit GLText(const glm::vec3 &pos,
-                    const QString &text,
-                    const Color &color = {},
-                    std::optional<Color> moved_bgcolor = {},
-                    const FontFormatFlags &fontFormatFlag = {},
-                    int rotationAngle = 0);
-
-    explicit GLText(const glm::vec3 &pos,
                     std::string moved_text,
                     const Color &color = {},
                     std::optional<Color> moved_bgcolor = {},

--- a/src/pandoragroup/CGroupChar.cpp
+++ b/src/pandoragroup/CGroupChar.cpp
@@ -49,13 +49,16 @@ const QVariantMap CGroupChar::toVariantMap() const
     return root;
 }
 
-struct QuotedString final
+struct QuotedQString final
 {
+private:
     QString str;
-    explicit QuotedString(QString input)
+
+public:
+    explicit QuotedQString(QString input)
         : str{std::move(input)}
     {}
-    friend QDebug &operator<<(QDebug &debug, const QuotedString &q)
+    friend QDebug &operator<<(QDebug &debug, const QuotedQString &q)
     {
         debug.quote();
         debug << q.str;
@@ -67,7 +70,7 @@ struct QuotedString final
 bool CGroupChar::updateFromVariantMap(const QVariantMap &data)
 {
     if (!data.contains(playerDataKey) || !data[playerDataKey].canConvert(QMetaType::QVariantMap)) {
-        qWarning() << "Unable to find" << QuotedString(playerDataKey) << "in map" << data;
+        qWarning() << "Unable to find" << QuotedQString(playerDataKey) << "in map" << data;
         return false;
     }
     const QVariantMap &playerData = data[playerDataKey].toMap();
@@ -126,7 +129,7 @@ bool CGroupChar::updateFromVariantMap(const QVariantMap &data)
             updated = true;
             color = QColor(str);
             if (str != color.name())
-                qWarning() << "Round trip error on color" << QuotedString(str) << "vs" << color;
+                qWarning() << "Round trip error on color" << QuotedQString(str) << "vs" << color;
         }
     }
 
@@ -152,13 +155,13 @@ bool CGroupChar::updateFromVariantMap(const QVariantMap &data)
     const auto boundsCheck =
         [&updated](const char *const xname, auto &x, const char *const maxxname, auto &maxx) {
             if (maxx < 0) {
-                qWarning() << "[boundsCheck]" << QuotedString(maxxname) << "(" << maxx
+                qWarning() << "[boundsCheck]" << QuotedQString(maxxname) << "(" << maxx
                            << ") has been raised to 0.";
                 maxx = 0;
                 updated = true;
             }
             if (x > maxx) {
-                qWarning() << "[boundsCheck]" << QuotedString(xname) << "(" << x
+                qWarning() << "[boundsCheck]" << QuotedQString(xname) << "(" << x
                            << ") has been clamped to " << maxxname << "(" << maxx << ").";
                 x = maxx;
                 updated = true;
@@ -216,13 +219,13 @@ bool CGroupChar::updateFromVariantMap(const QVariantMap &data)
 QByteArray CGroupChar::getNameFromUpdateChar(const QVariantMap &data)
 {
     if (!data.contains(playerDataKey) || !data[playerDataKey].canConvert(QMetaType::QVariantMap)) {
-        qWarning() << "Unable to find" << QuotedString(playerDataKey) << "in map" << data;
+        qWarning() << "Unable to find" << QuotedQString(playerDataKey) << "in map" << data;
         return "";
     }
 
     const QVariantMap &playerData = data[playerDataKey].toMap();
     if (!playerData.contains(nameKey) || !playerData[nameKey].canConvert(QMetaType::QByteArray)) {
-        qWarning() << "Unable to find" << QuotedString(nameKey) << "in map" << playerData;
+        qWarning() << "Unable to find" << QuotedQString(nameKey) << "in map" << playerData;
         return "";
     }
 

--- a/src/parser/AbstractParser-Commands.cpp
+++ b/src/parser/AbstractParser-Commands.cpp
@@ -376,7 +376,7 @@ bool AbstractParser::parseUserCommands(const QString &input)
         return false;
 
     if (input.startsWith(prefixChar)) {
-        std::string s = input.toLatin1().toStdString();
+        std::string s = ::toStdStringLatin1(input);
         auto view = StringView{s}.trim();
         if (view.isEmpty() || view.takeFirstLetter() != prefixChar)
             sendToUser("Internal error. Sorry.\r\n");
@@ -391,7 +391,7 @@ bool AbstractParser::parseUserCommands(const QString &input)
 
 bool AbstractParser::parseSimpleCommand(const QString &qstr)
 {
-    const std::string str = qstr.toLatin1().toStdString();
+    const std::string str = ::toStdStringLatin1(qstr);
     const auto isOnline = ::isOnline();
 
     for (const CommandEnum cmd : ALL_COMMANDS) {
@@ -829,8 +829,8 @@ void AbstractParser::initSpecialCommandMap()
         return [this, help](const std::string &name) {
             sendToUser(QString("Help for %1%2:\r\n  %3\r\n\r\n")
                            .arg(prefixChar)
-                           .arg(QString::fromStdString(name))
-                           .arg(QString::fromStdString(help)));
+                           .arg(::toQStringLatin1(name))
+                           .arg(::toQStringLatin1(help)));
         };
     };
 
@@ -1042,8 +1042,8 @@ void AbstractParser::initSpecialCommandMap()
                   "so you cannot do ''', '\\'', \"\"\", or \"\\\"\".";
             sendToUser(QString("Help for %1%2:\r\n%3\r\n\r\n")
                            .arg(prefixChar)
-                           .arg(QString::fromStdString(name))
-                           .arg(QString::fromStdString(help)));
+                           .arg(::toQStringLatin1(name))
+                           .arg(::toQStringLatin1(help)));
         });
     add(cmdTime,
         [this](const std::vector<StringView> & /*s*/, StringView rest) {
@@ -1110,8 +1110,7 @@ void AbstractParser::addSpecialCommand(const char *const s,
         if (it == map.end())
             map.emplace(key, ParserRecord{fullName, callback, help});
         else {
-            qWarning() << ("unable to add " + QString::fromStdString(key) + " for "
-                           + abb.describe());
+            qWarning() << ("unable to add " + ::toQStringLatin1(key) + " for " + abb.describe());
         }
     }
 }

--- a/src/parser/abstractparser.cpp
+++ b/src/parser/abstractparser.cpp
@@ -537,7 +537,7 @@ QString AbstractParser::normalizeStringCopy(QString string)
     // Remove ANSI first, since we don't want Latin1
     // transliterations to accidentally count as ANSI.
     ParserUtils::removeAnsiMarksInPlace(string);
-    ParserUtils::latinToAsciiInPlace(string);
+    ParserUtils::toAsciiInPlace(string);
     return string;
 }
 
@@ -927,8 +927,7 @@ void AbstractParser::toggleTrollMapping()
 
 void AbstractParser::doSearchCommand(StringView view)
 {
-    QString pattern_str = view.toQString();
-    if (std::optional<RoomFilter> optFilter = RoomFilter::parseRoomFilter(pattern_str)) {
+    if (std::optional<RoomFilter> optFilter = RoomFilter::parseRoomFilter(view.getStdStringView())) {
         searchCommand(optFilter.value());
     } else {
         sendToUser(RoomFilter::parse_help);
@@ -937,8 +936,7 @@ void AbstractParser::doSearchCommand(StringView view)
 
 void AbstractParser::doGetDirectionsCommand(StringView view)
 {
-    QString pattern_str = view.toQString();
-    if (std::optional<RoomFilter> optFilter = RoomFilter::parseRoomFilter(pattern_str)) {
+    if (std::optional<RoomFilter> optFilter = RoomFilter::parseRoomFilter(view.getStdStringView())) {
         dirsCommand(optFilter.value());
     } else {
         sendToUser(RoomFilter::parse_help);

--- a/src/parser/abstractparser.h
+++ b/src/parser/abstractparser.h
@@ -18,6 +18,7 @@
 
 #include "../expandoracommon/parseevent.h"
 #include "../global/StringView.h"
+#include "../global/TextUtils.h"
 #include "../mapdata/DoorFlags.h"
 #include "../mapdata/ExitFieldVariant.h"
 #include "../mapdata/RoomFieldVariant.h"
@@ -265,13 +266,9 @@ public:
     }
     inline void sendToUser(const std::string_view &s, bool goAhead = false)
     {
-        sendToUser(QByteArray{s.data(), static_cast<int>(s.length())}, goAhead);
+        sendToUser(::toQByteArrayLatin1(s), goAhead);
     }
     inline void sendToUser(const char *const s, bool goAhead = false)
-    {
-        sendToUser(std::string_view{s}, goAhead);
-    }
-    inline void sendToUser(const std::string &s, bool goAhead = false)
     {
         sendToUser(std::string_view{s}, goAhead);
     }

--- a/src/parser/parserutils.cpp
+++ b/src/parser/parserutils.cpp
@@ -6,13 +6,19 @@
 
 #include "parserutils.h"
 
+#include <array>
+#include <cassert>
+#include <stdexcept>
 #include <QRegularExpression>
 #include <QtCore>
 
 namespace ParserUtils {
-
+static constexpr const size_t IDX_NBSP = 160;
+static constexpr const char LATIN1_UNDEFINED = 'z';
+static constexpr const size_t NUM_ASCII_CODEPOINTS = 128;
+static constexpr const size_t NUM_LATIN1_CODEPOINTS = 256;
 // Taken from MUME's HELP LATIN to convert from Latin-1 to US-ASCII
-static const unsigned char latin1ToAscii[] = {
+static constexpr const std::array g_latin1ToAscii = {
     /*160*/
     ' ', '!', 'c', 'L', '$',  'Y', '|', 'P', '"', 'C', 'a', '<', ',', '-', 'R', '-',
     'd', '+', '2', '3', '\'', 'u', 'P', '*', ',', '1', 'o', '>', '4', '2', '3', '?',
@@ -21,6 +27,41 @@ static const unsigned char latin1ToAscii[] = {
     'a', 'a', 'a', 'a', 'a',  'a', 'a', 'c', 'e', 'e', 'e', 'e', 'i', 'i', 'i', 'i',
     'd', 'n', 'o', 'o', 'o',  'o', 'o', '/', 'o', 'u', 'u', 'u', 'u', 'y', 't', 'y'};
 
+static_assert(
+    std::is_same_v<char, std::remove_const_t<std::remove_reference_t<decltype(g_latin1ToAscii[0])>>>);
+static_assert(std::size(g_latin1ToAscii) == NUM_LATIN1_CODEPOINTS - IDX_NBSP);
+
+static inline constexpr size_t getIndex(const char c) noexcept
+{
+    return static_cast<size_t>(static_cast<uint8_t>(c));
+}
+
+static inline constexpr bool isAscii(const char c) noexcept
+{
+    return getIndex(c) < NUM_ASCII_CODEPOINTS;
+}
+
+static inline constexpr char latin1ToAscii(char c) noexcept
+{
+    if (isAscii(c))
+        return c;
+
+    const auto i = getIndex(c);
+    if (i >= IDX_NBSP && i < NUM_LATIN1_CODEPOINTS) {
+        return g_latin1ToAscii[static_cast<size_t>(i - IDX_NBSP)];
+    } else {
+        return LATIN1_UNDEFINED;
+    }
+}
+
+static_assert(latin1ToAscii('X') == 'X');
+static_assert(latin1ToAscii('x') == 'x');
+static_assert(latin1ToAscii("\x7f"[0]) == '\x7f');
+static_assert(latin1ToAscii("\x80"[0]) == LATIN1_UNDEFINED);
+static_assert(latin1ToAscii("\x9f"[0]) == LATIN1_UNDEFINED);
+static_assert(latin1ToAscii("\xa0"[0]) == ' ');
+static_assert(latin1ToAscii("\xff"[0]) == 'y');
+
 QString &removeAnsiMarksInPlace(QString &str)
 {
     static const QRegularExpression ansi("\x1b\\[[0-9;]*[A-Za-z]");
@@ -28,20 +69,33 @@ QString &removeAnsiMarksInPlace(QString &str)
     return str;
 }
 
-QString &latinToAsciiInPlace(QString &str)
+QString &toAsciiInPlace(QString &str)
 {
-    for (int pos = 0; pos < str.length(); pos++) {
-        auto ch = static_cast<unsigned char>(str.at(pos).toLatin1());
-        if (ch > 128) {
-            if (ch < 160) {
-                ch = 'z';
-            } else {
-                ch = latin1ToAscii[ch - 160];
-            }
-            str[pos] = ch;
+    // NOTE: 128 (0x80) was not converted to 'z' before.
+    for (QChar &qc : str) {
+        // c++17 if statement with initializer
+        if (const char ch = qc.toLatin1(); !isAscii(ch)) {
+            qc = latin1ToAscii(ch);
         }
     }
     return str;
+}
+
+std::string &latin1ToAsciiInPlace(std::string &str)
+{
+    for (char &c : str) {
+        if (!isAscii(c)) {
+            c = latin1ToAscii(c);
+        }
+    }
+    return str;
+}
+
+std::string latin1ToAscii(const std::string_view &sv)
+{
+    std::string tmp{sv};
+    latin1ToAsciiInPlace(tmp);
+    return tmp;
 }
 
 } // namespace ParserUtils

--- a/src/parser/parserutils.h
+++ b/src/parser/parserutils.h
@@ -5,9 +5,15 @@
 // Author: Marek Krejza <krejza@gmail.com> (Caligor)
 // Author: Nils Schimmelmann <nschimme@gmail.com> (Jahara)
 
+#include <string>
+#include <string_view>
+
 class QString;
 
 namespace ParserUtils {
 QString &removeAnsiMarksInPlace(QString &str);
-QString &latinToAsciiInPlace(QString &str);
+QString &toAsciiInPlace(QString &str);
+std::string &latin1ToAsciiInPlace(std::string &str);
+std::string latin1ToAscii(const std::string_view &sv);
+
 } // namespace ParserUtils

--- a/src/proxy/TextCodec.cpp
+++ b/src/proxy/TextCodec.cpp
@@ -59,7 +59,7 @@ QByteArray TextCodec::fromUnicode(const QString &data)
     if (currentEncoding == CharacterEncodingEnum::ASCII) {
         // Simplify Latin-1 characters to US-ASCII
         QString outdata = data;
-        ParserUtils::latinToAsciiInPlace(outdata);
+        ParserUtils::toAsciiInPlace(outdata);
         return textCodec->fromUnicode(outdata);
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,8 @@ file(GLOB_RECURSE expandoracommon_SRCS
     ../src/global/NullPointerException.h
     ../src/global/StringView.cpp
     ../src/global/StringView.h
+    ../src/global/TextUtils.cpp
+    ../src/global/TextUtils.h
     ../src/global/random.cpp
     ../src/global/random.h
     ../src/global/utils.cpp
@@ -53,6 +55,8 @@ set(parser_SRCS
     ../src/mapdata/ExitDirection.h
     ../src/global/NullPointerException.cpp
     ../src/global/NullPointerException.h
+    ../src/global/TextUtils.cpp
+    ../src/global/TextUtils.h
     ../src/global/random.cpp
     ../src/global/random.h
     )

--- a/tests/testparser.cpp
+++ b/tests/testparser.cpp
@@ -10,6 +10,7 @@
 
 #include "../src/expandoracommon/parseevent.h"
 #include "../src/expandoracommon/property.h"
+#include "../src/global/TextUtils.h"
 #include "../src/mapdata/mmapper2room.h"
 #include "../src/parser/parserutils.h"
 
@@ -27,10 +28,10 @@ void TestParser::removeAnsiMarksTest()
 
 void TestParser::latinToAsciiTest()
 {
-    QString latin("Nórui Nínui");
-    QString expectedAscii("Norui Ninui");
-    ParserUtils::latinToAsciiInPlace(latin);
-    QCOMPARE(latin, expectedAscii);
+    QString utf8("Nórui Nínui");
+    const QString expectedAscii("Norui Ninui");
+    ParserUtils::toAsciiInPlace(utf8);
+    QCOMPARE(utf8, expectedAscii);
 }
 
 void TestParser::createParseEventTest()
@@ -65,8 +66,8 @@ void TestParser::createParseEventTest()
     QCOMPARE(e.getNumSkipped(), 0u);
     QCOMPARE(RoomName(e[0].getStdString()), roomName);
     QCOMPARE(RoomStaticDesc(e[1].getStdString()), parsedRoomDescription);
-    QCOMPARE(QString::fromStdString(e[2].getStdString()),
-             QString::fromStdString(std::string(1, static_cast<char>(terrain))));
+    QCOMPARE(::toQStringLatin1(e[2].getStdString()),
+             ::toQStringLatin1(std::string(1, static_cast<char>(terrain))));
 }
 
 QTEST_MAIN(TestParser)


### PR DESCRIPTION
Eliminate GLText's QString ctor

Both QString::fromStdString() and QString::toStdString()
assume the user wants UTF-8, but MMapper almost always expects
std::string to have Latin-1 encoding.

Add CI check