### PR TITLE
Add StartupWMClass to desktop file

### DIFF
--- a/src/org.mume.MMapper.desktop
+++ b/src/org.mume.MMapper.desktop
@@ -3,6 +3,7 @@ Name=MMapper
 GenericName=MUME Mapper
 Exec=mmapper
 Icon=org.mume.MMapper
+StartupWMClass=mmapper
 Terminal=false
 Type=Application
 Categories=Qt;Game;RolePlaying;


### PR DESCRIPTION
This helps gnome-shell map the app window to the desktop file (so that
correct icon and name are shown).