### PR TITLE
Switch deb from Ubuntu 18.04 to Debian Buster

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -158,9 +158,9 @@ for:
 
     init:
       - sh: echo _NPROCESSORS_ONLN=$(getconf _NPROCESSORS_ONLN)
-      - sh: if [[ $ARCH == x86 ]]; then export DOCKER_IMAGE=i386/ubuntu:18.04 ; fi
+      - sh: if [[ $ARCH == x86 ]]; then export DOCKER_IMAGE=multiarch/debian-debootstrap:i386-buster ; fi
       - sh: if [[ $ARCH == x86 ]]; then export TARGET_ARCHITECTURE=i386 ; fi
-      - sh: if [[ $ARCH == x64 ]]; then export DOCKER_IMAGE=amd64/ubuntu:18.04 ; fi
+      - sh: if [[ $ARCH == x64 ]]; then export DOCKER_IMAGE=multiarch/debian-debootstrap:amd64-buster ; fi
       - sh: if [[ $ARCH == x64 ]]; then export TARGET_ARCHITECTURE=amd64 ; fi
       - sh: if [[ $ARCH == arm ]]; then export DOCKER_IMAGE=multiarch/debian-debootstrap:armhf-buster ; fi
       - sh: if [[ $ARCH == arm ]]; then export TARGET_ARCHITECTURE=armhf ; fi


### PR DESCRIPTION
Ubuntu 20.04 is unable to install 18.04 .debs due to miniupnpc