### PR TITLE
total: in _dirs had n/s switched

### DIFF
--- a/src/parser/abstractparser.cpp
+++ b/src/parser/abstractparser.cpp
@@ -742,7 +742,7 @@ static QString compressDirections(QString original)
         } else {
             ans += " (total:";
             addNumber(delta.x, 'e', 'w');
-            addNumber(delta.y, 's', 'n');
+            addNumber(delta.y, 'n', 's');
             addNumber(delta.z, 'u', 'd');
             ans += ")";
         }


### PR DESCRIPTION
_dirs gives  a summary of directions, like so:

```
*.>_dirs Pasture-Land
Distance 1.5: Rolling Pasture-Land
dirs: s (total: n)
Distance 4.5: Pasture-Land
dirs: 2ws (total: 2w n)
```

The n/s summary is flipped.  This fixes it.