### PR TITLE
Changes to RoomUpdated flag

### DIFF
--- a/src/expandoracommon/room.cpp
+++ b/src/expandoracommon/room.cpp
@@ -17,7 +17,8 @@
 static constexpr const auto default_updateFlags = RoomUpdateFlags{}; /* none */
 static constexpr const auto mesh_updateFlags = RoomUpdateFlags{RoomUpdateEnum::Mesh};
 static constexpr const auto key_updateFlags = RoomUpdateFlags{RoomUpdateEnum::NodeLookupKey};
-static constexpr const auto borked_updateFlags = RoomUpdateFlags{RoomUpdateEnum::Borked};
+static constexpr const auto borked_updateFlags = RoomUpdateFlags{RoomUpdateEnum::Borked}
+                                                 | RoomUpdateEnum::Mesh;
 
 static constexpr auto RoomName_updateFlags = key_updateFlags | RoomUpdateEnum::Name;
 static constexpr auto RoomStaticDesc_updateFlags = RoomUpdateFlags{RoomUpdateEnum::NodeLookupKey}

--- a/src/mainwindow/roomeditattrdlg.cpp
+++ b/src/mainwindow/roomeditattrdlg.cpp
@@ -577,8 +577,8 @@ void RoomEditAttrDlg::updateDialog(const Room *r)
         roomDescriptionTextEdit->clear();
         roomDescriptionTextEdit->setEnabled(false);
 
-        updatedCheckBox->setCheckable(false);
-        updatedCheckBox->setText("");
+        updatedCheckBox->setCheckable(true);
+        updatedCheckBox->setText("Online update status has not been changed.");
 
         roomNoteTextEdit->clear();
         roomNoteTextEdit->setEnabled(false);


### PR DESCRIPTION
This pull request has two commits, related to the room updated flag.

 (1) Prior to this, when the flag changes (if you walk into a room or update it manually), the display does not refresh.  This makes it refresh.
 (2) When you select multiple rooms, the checkbox is enabled so you can modify the room updated flag en masse.

The second feature is useful when TPing -- I can mark a whole region as non-updated, and see where I haven't been.