### PR TITLE
Add feature "Export MMapper2 XML Map As..." 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Makefile
 **/.DS_Store
 .idea
 .vs
+.vscode
 CMakeSettings.json
 
 # snapcraft

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -186,6 +186,8 @@ set(mmapper_SRCS
     mapstorage/progresscounter.h
     mapstorage/roomsaver.cpp
     mapstorage/roomsaver.h
+    mapstorage/XmlMapStorage.cpp
+    mapstorage/XmlMapStorage.h
     mpi/mpifilter.cpp
     mpi/mpifilter.h
     mpi/remoteedit.cpp

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -545,11 +545,11 @@ void MainWindow::createActions()
     saveAsAct->setStatusTip(tr("Save the document under a new name"));
     connect(saveAsAct, &QAction::triggered, this, &MainWindow::slot_saveAs);
 
-    exportBaseMapAct = new QAction(tr("Export &Base Map As..."), this);
+    exportBaseMapAct = new QAction(tr("Export MMapper2 &Base Map As..."), this);
     exportBaseMapAct->setStatusTip(tr("Save a copy of the map with no secrets"));
     connect(exportBaseMapAct, &QAction::triggered, this, &MainWindow::slot_exportBaseMap);
 
-    exportMm2xmlMapAct = new QAction(tr("Export MM2&XML Map As..."), this);
+    exportMm2xmlMapAct = new QAction(tr("Export MMapper2 &XML Map As..."), this);
     exportMm2xmlMapAct->setStatusTip(tr("Save a copy of the map in the MM2XML format"));
     connect(exportMm2xmlMapAct, &QAction::triggered, this, &MainWindow::slot_exportMm2xmlMap);
 

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -50,6 +50,7 @@
 #include "../mapfrontend/mapfrontend.h"
 #include "../mapstorage/MmpMapStorage.h"
 #include "../mapstorage/PandoraMapStorage.h"
+#include "../mapstorage/XmlMapStorage.h"
 #include "../mapstorage/abstractmapstorage.h"
 #include "../mapstorage/filesaver.h"
 #include "../mapstorage/jsonmapstorage.h"
@@ -547,6 +548,10 @@ void MainWindow::createActions()
     exportBaseMapAct = new QAction(tr("Export &Base Map As..."), this);
     exportBaseMapAct->setStatusTip(tr("Save a copy of the map with no secrets"));
     connect(exportBaseMapAct, &QAction::triggered, this, &MainWindow::slot_exportBaseMap);
+
+    exportMm2xmlMapAct = new QAction(tr("Export MM2&XML Map As..."), this);
+    exportMm2xmlMapAct->setStatusTip(tr("Save a copy of the map in the MM2XML format"));
+    connect(exportMm2xmlMapAct, &QAction::triggered, this, &MainWindow::slot_exportMm2xmlMap);
 
     exportWebMapAct = new QAction(tr("Export &Web Map As..."), this);
     exportWebMapAct->setStatusTip(tr("Save a copy of the map for webclients"));
@@ -1062,6 +1067,7 @@ void MainWindow::disableActions(bool value)
     reloadAct->setDisabled(value);
     saveAsAct->setDisabled(value);
     exportBaseMapAct->setDisabled(value);
+    exportMm2xmlMapAct->setDisabled(value);
     exportWebMapAct->setDisabled(value);
     exportMmpMapAct->setDisabled(value);
     exitAct->setDisabled(value);
@@ -1111,6 +1117,7 @@ void MainWindow::setupMenuBar()
     fileMenu->addSeparator();
     QMenu *exportMenu = fileMenu->addMenu(QIcon::fromTheme("document-send"), tr("&Export"));
     exportMenu->addAction(exportBaseMapAct);
+    exportMenu->addAction(exportMm2xmlMapAct);
     exportMenu->addAction(exportWebMapAct);
     exportMenu->addAction(exportMmpMapAct);
     fileMenu->addAction(mergeAct);
@@ -1662,6 +1669,33 @@ bool MainWindow::slot_exportBaseMap()
     return saveFile(fileNames[0], SaveModeEnum::BASEMAP, SaveFormatEnum::MM2);
 }
 
+bool MainWindow::slot_exportMm2xmlMap()
+{
+    const auto makeSaveDialog = [this]() {
+        // FIXME: code duplication
+        auto save = std::make_unique<QFileDialog>(this,
+                                                  "Choose map file name ...",
+                                                  QDir::current().absolutePath());
+        save->setFileMode(QFileDialog::AnyFile);
+        save->setDirectory(QDir(getConfig().autoLoad.lastMapDirectory));
+        save->setNameFilter("MM2XML Maps (*.mm2xml)");
+        save->setDefaultSuffix("mm2xml");
+        save->setAcceptMode(QFileDialog::AcceptSave);
+        save->selectFile(QFileInfo(m_mapData->getFileName())
+                             .fileName()
+                             .replace(QRegularExpression(R"(\.mm2$)"), ".mm2xml"));
+
+        return save;
+    };
+
+    const auto fileNames = getSaveFileNames(makeSaveDialog());
+    if (fileNames.isEmpty()) {
+        statusBar()->showMessage(tr("No filename provided"), 2000);
+        return false;
+    }
+    return saveFile(fileNames[0], SaveModeEnum::FULL, SaveFormatEnum::MM2XML);
+}
+
 bool MainWindow::slot_exportWebMap()
 {
     const auto makeSaveDialog = [this]() {
@@ -1861,6 +1895,8 @@ bool MainWindow::saveFile(const QString &fileName,
         switch (format) {
         case SaveFormatEnum::MM2:
             return std::make_unique<MapStorage>(*m_mapData, fileName, &saver.file(), this);
+        case SaveFormatEnum::MM2XML:
+            return std::make_unique<XmlMapStorage>(*m_mapData, fileName, &saver.file(), this);
         case SaveFormatEnum::MMP:
             return std::make_unique<MmpMapStorage>(*m_mapData, fileName, &saver.file(), this);
         case SaveFormatEnum::WEB:

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -63,7 +63,7 @@ public:
     ~MainWindow() final;
 
     enum class NODISCARD SaveModeEnum { FULL, BASEMAP };
-    enum class NODISCARD SaveFormatEnum { MM2, WEB, MMP };
+    enum class NODISCARD SaveFormatEnum { MM2, MM2XML, WEB, MMP };
     bool saveFile(const QString &fileName, SaveModeEnum mode, SaveFormatEnum format);
     void loadFile(const QString &fileName);
     void setCurrentFile(const QString &fileName);
@@ -81,6 +81,7 @@ public slots:
     bool slot_save();
     bool slot_saveAs();
     bool slot_exportBaseMap();
+    bool slot_exportMm2xmlMap();
     bool slot_exportWebMap();
     bool slot_exportMmpMap();
     void slot_about();
@@ -209,6 +210,7 @@ private:
     QAction *saveAct = nullptr;
     QAction *saveAsAct = nullptr;
     QAction *exportBaseMapAct = nullptr;
+    QAction *exportMm2xmlMapAct = nullptr;
     QAction *exportWebMapAct = nullptr;
     QAction *exportMmpMapAct = nullptr;
     QAction *exitAct = nullptr;

--- a/src/mapstorage/XmlMapStorage.cpp
+++ b/src/mapstorage/XmlMapStorage.cpp
@@ -242,45 +242,6 @@ void XmlMapStorage::log(const QString &msg)
     emit sig_log("XmlMapStorage", msg);
 }
 
-#define DECL(X, ...) #X,
-static const char *const alignNames[] = {
-    X_FOREACH_RoomAlignEnum(DECL) //
-};
-static const char *const doorFlagNames[] = {
-    X_FOREACH_DOOR_FLAG(DECL) //
-};
-static const char *const exitFlagNames[] = {
-    X_FOREACH_EXIT_FLAG(DECL) //
-};
-static const char *const lightNames[] = {
-    X_FOREACH_RoomLightEnum(DECL) //
-};
-static const char *const loadFlagNames[] = {
-    X_FOREACH_ROOM_LOAD_FLAG(DECL) //
-};
-static const char *const markClassNames[] = {
-    X_FOREACH_INFOMARK_CLASS(DECL) //
-};
-static const char *const markTypeNames[] = {
-    X_FOREACH_INFOMARK_TYPE(DECL) //
-};
-static const char *const mobFlagNames[] = {
-    X_FOREACH_ROOM_MOB_FLAG(DECL) //
-};
-static const char *const portableNames[] = {
-    X_FOREACH_RoomPortableEnum(DECL) //
-};
-static const char *const ridableNames[] = {
-    X_FOREACH_RoomRidableEnum(DECL) //
-};
-static const char *const sundeathNames[] = {
-    X_FOREACH_RoomSundeathEnum(DECL) //
-};
-static const char *const terrainNames[] = {
-    X_FOREACH_RoomTerrainEnum(DECL) //
-};
-#undef DECL
-
 void XmlMapStorage::saveDoorFlags(QXmlStreamWriter &stream, DoorFlags fl)
 {
     if (fl.isEmpty()) {
@@ -288,11 +249,11 @@ void XmlMapStorage::saveDoorFlags(QXmlStreamWriter &stream, DoorFlags fl)
     }
     QString list;
     const char *separator = "";
-    for (uint x = 0; x < sizeof(doorFlagNames) / sizeof(doorFlagNames[0]); x++) {
+    for (uint x = 0; x < NUM_DOOR_FLAGS; x++) {
         if (fl.contains(DoorFlagEnum(x))) {
             list += separator;
             separator = ",";
-            list += doorFlagNames[x];
+            list += doorFlagName(DoorFlagEnum(x));
         }
     }
     saveXmlAttribute(stream, "doorflags", list);
@@ -306,11 +267,11 @@ void XmlMapStorage::saveExitFlags(QXmlStreamWriter &stream, ExitFlags fl)
     }
     QString list;
     const char *separator = "";
-    for (uint x = 0; x < sizeof(exitFlagNames) / sizeof(exitFlagNames[0]); x++) {
+    for (uint x = 0; x < NUM_EXIT_FLAGS; x++) {
         if (fl.contains(ExitFlagEnum(x))) {
             list += separator;
             separator = ",";
-            list += exitFlagNames[x];
+            list += exitFlagName(ExitFlagEnum(x));
         }
     }
     saveXmlAttribute(stream, "flags", list);
@@ -323,13 +284,13 @@ void XmlMapStorage::saveRoomLoadFlags(QXmlStreamWriter &stream, RoomLoadFlags fl
     }
     stream.writeStartElement("flags");
     QString separator;
-    for (uint x = 0; x < sizeof(loadFlagNames) / sizeof(loadFlagNames[0]); x++) {
+    for (uint x = 0; x < NUM_ROOM_LOAD_FLAGS; x++) {
         if (fl.contains(RoomLoadFlagEnum(x))) {
             stream.writeCharacters(separator);
             if (separator.isEmpty()) {
                 separator = ",";
             }
-            stream.writeCharacters(loadFlagNames[x]);
+            stream.writeCharacters(loadFlagName(RoomLoadFlagEnum(x)));
         }
     }
     stream.writeEndElement();
@@ -342,79 +303,182 @@ void XmlMapStorage::saveRoomMobFlags(QXmlStreamWriter &stream, RoomMobFlags fl)
     }
     stream.writeStartElement("mobflags");
     QString separator;
-    for (uint x = 0; x < sizeof(mobFlagNames) / sizeof(mobFlagNames[0]); x++) {
+    for (uint x = 0; x < NUM_ROOM_MOB_FLAGS; x++) {
         if (fl.contains(RoomMobFlagEnum(x))) {
             stream.writeCharacters(separator);
             if (separator.isEmpty()) {
                 separator = ",";
             }
-            stream.writeCharacters(mobFlagNames[x]);
+            stream.writeCharacters(mobFlagName(RoomMobFlagEnum(x)));
         }
     }
     stream.writeEndElement();
 }
 
-NODISCARD QString XmlMapStorage::alignName(const RoomAlignEnum x)
+NODISCARD const char *XmlMapStorage::alignName(const RoomAlignEnum e)
 {
-    return enumName(uint(x), alignNames, sizeof(alignNames) / sizeof(alignNames[0]));
-}
-
-NODISCARD QString XmlMapStorage::lightName(const RoomLightEnum x)
-{
-    return enumName(uint(x), lightNames, sizeof(lightNames) / sizeof(lightNames[0]));
-}
-
-NODISCARD QString XmlMapStorage::markClassName(const InfoMarkClassEnum e)
-{
-    const uint x = uint(e);
-    const uint count = sizeof(markClassNames) / sizeof(markClassNames[0]);
-    if (x < count) {
-        return QString(markClassNames[x]);
-    } else {
-        return QString("%1").arg(x);
+    if (e != RoomAlignEnum::UNDEFINED) {
+#define CASE(X) \
+    case RoomAlignEnum::X: \
+        return #X;
+        switch (e) {
+            X_FOREACH_RoomAlignEnum(CASE)
+        }
+#undef CASE
+        assert(false); // reachable only on invalid RoomAlignEnum
     }
+    return "";
 }
 
-NODISCARD QString XmlMapStorage::markTypeName(const InfoMarkTypeEnum e)
+NODISCARD const char *XmlMapStorage::doorFlagName(const DoorFlagEnum e)
 {
-    const uint x = uint(e);
-    const uint count = sizeof(markTypeNames) / sizeof(markTypeNames[0]);
-    if (x < count) {
-        return QString(markTypeNames[x]);
-    } else {
-        return QString("%1").arg(x);
+#define CASE(UPPER_CASE, lower_case, CamelCase, friendly) \
+    case DoorFlagEnum::UPPER_CASE: \
+        return #UPPER_CASE;
+    switch (e) {
+        X_FOREACH_DOOR_FLAG(CASE)
     }
+#undef CASE
+    assert(false); // reachable only on invalid DoorFlagEnum
+    return "";
 }
 
-NODISCARD QString XmlMapStorage::portableName(const RoomPortableEnum x)
+NODISCARD const char *XmlMapStorage::exitFlagName(const ExitFlagEnum e)
 {
-    return enumName(uint(x), portableNames, sizeof(portableNames) / sizeof(portableNames[0]));
-}
-
-NODISCARD QString XmlMapStorage::ridableName(const RoomRidableEnum x)
-{
-    return enumName(uint(x), ridableNames, sizeof(ridableNames) / sizeof(ridableNames[0]));
-}
-
-NODISCARD QString XmlMapStorage::sundeathName(const RoomSundeathEnum x)
-{
-    return enumName(uint(x), sundeathNames, sizeof(sundeathNames) / sizeof(sundeathNames[0]));
-}
-
-NODISCARD QString XmlMapStorage::terrainName(const RoomTerrainEnum x)
-{
-    return enumName(uint(x), terrainNames, sizeof(terrainNames) / sizeof(terrainNames[0]));
-}
-
-NODISCARD QString XmlMapStorage::enumName(const uint x,
-                                          const char *const names[],
-                                          const size_t count)
-{
-    if (x == 0) {
-        return QString();
-    } else if (x < count) {
-        return QString(names[x]);
-    } else {
-        return QString("%1").arg(x);
+#define CASE(UPPER_CASE, lower_case, CamelCase, friendly) \
+    case ExitFlagEnum::UPPER_CASE: \
+        return #UPPER_CASE;
+    switch (e) {
+        X_FOREACH_EXIT_FLAG(CASE)
     }
+#undef CASE
+    assert(false); // reachable only on invalid DoorFlagEnum
+    return "";
+}
+
+NODISCARD const char *XmlMapStorage::lightName(const RoomLightEnum e)
+{
+    if (e != RoomLightEnum::UNDEFINED) {
+#define CASE(X) \
+    case RoomLightEnum::X: \
+        return #X;
+        switch (e) {
+            X_FOREACH_RoomLightEnum(CASE)
+        }
+#undef CASE
+        assert(false); // reachable only on invalid RoomLightEnum
+    }
+    return "";
+}
+
+NODISCARD const char *XmlMapStorage::loadFlagName(const RoomLoadFlagEnum e)
+{
+#define CASE(X) \
+    case RoomLoadFlagEnum::X: \
+        return #X;
+    switch (e) {
+        X_FOREACH_ROOM_LOAD_FLAG(CASE)
+    }
+#undef CASE
+    assert(false); // reachable only on invalid RoomLoadFlagEnum
+    return "";
+}
+
+NODISCARD const char *XmlMapStorage::markClassName(const InfoMarkClassEnum e)
+{
+#define CASE(X) \
+    case InfoMarkClassEnum::X: \
+        return #X;
+    switch (e) {
+        X_FOREACH_INFOMARK_CLASS(CASE)
+    }
+#undef CASE
+    assert(false); // reachable only on invalid InfoMarkClassEnum
+    return "";
+}
+
+NODISCARD const char *XmlMapStorage::markTypeName(const InfoMarkTypeEnum e)
+{
+#define CASE(X) \
+    case InfoMarkTypeEnum::X: \
+        return #X;
+    switch (e) {
+        X_FOREACH_INFOMARK_TYPE(CASE)
+    }
+#undef CASE
+    assert(false); // reachable only on invalid InfoMarkTypeEnum
+    return "";
+}
+
+NODISCARD const char *XmlMapStorage::mobFlagName(const RoomMobFlagEnum e)
+{
+#define CASE(X) \
+    case RoomMobFlagEnum::X: \
+        return #X;
+    switch (e) {
+        X_FOREACH_ROOM_MOB_FLAG(CASE)
+    }
+#undef CASE
+    assert(false); // reachable only on invalid RoomMobFlagEnum
+    return "";
+}
+
+NODISCARD const char *XmlMapStorage::portableName(const RoomPortableEnum e)
+{
+    if (e != RoomPortableEnum::UNDEFINED) {
+#define CASE(X) \
+    case RoomPortableEnum::X: \
+        return #X;
+        switch (e) {
+            X_FOREACH_RoomPortableEnum(CASE)
+        }
+#undef CASE
+        assert(false); // reachable only on invalid RoomPortableEnum
+    }
+    return "";
+}
+
+NODISCARD const char *XmlMapStorage::ridableName(const RoomRidableEnum e)
+{
+    if (e != RoomRidableEnum::UNDEFINED) {
+#define CASE(X) \
+    case RoomRidableEnum::X: \
+        return #X;
+        switch (e) {
+            X_FOREACH_RoomRidableEnum(CASE)
+        }
+#undef CASE
+        assert(false); // reachable only on invalid RoomRidableEnum
+    }
+    return "";
+}
+
+NODISCARD const char *XmlMapStorage::sundeathName(const RoomSundeathEnum e)
+{
+    if (e != RoomSundeathEnum::UNDEFINED) {
+#define CASE(X) \
+    case RoomSundeathEnum::X: \
+        return #X;
+        switch (e) {
+            X_FOREACH_RoomSundeathEnum(CASE)
+        }
+#undef CASE
+        assert(false); // reachable only on invalid RoomSundeathEnum
+    }
+    return "";
+}
+
+NODISCARD const char *XmlMapStorage::terrainName(const RoomTerrainEnum e)
+{
+    if (e != RoomTerrainEnum::UNDEFINED) {
+#define CASE(X) \
+    case RoomTerrainEnum::X: \
+        return #X;
+        switch (e) {
+            X_FOREACH_RoomTerrainEnum(CASE)
+        }
+#undef CASE
+        assert(false); // reachable only on invalid RoomTerrainEnum
+    }
+    return "";
 }

--- a/src/mapstorage/XmlMapStorage.cpp
+++ b/src/mapstorage/XmlMapStorage.cpp
@@ -80,8 +80,8 @@ bool XmlMapStorage::saveData(bool baseMapOnly)
     stream.writeStartDocument();
 
     stream.writeStartElement("map");
-    stream.writeAttribute("type", "mmapper2xml");
-    stream.writeAttribute("version", "1.0.0");
+    saveXmlAttribute(stream, "type", "mmapper2xml");
+    saveXmlAttribute(stream, "version", "1.0.0");
 
     saveRooms(stream, baseMapOnly, roomList);
     saveMarkers(stream, markerList);
@@ -120,10 +120,10 @@ void XmlMapStorage::saveRoom(QXmlStreamWriter &stream, const Room &room)
 {
     stream.writeStartElement("room");
 
-    stream.writeAttribute("id", QString("%1").arg(room.getId().asUint32()));
-    stream.writeAttribute("name", room.getName().toQString());
+    saveXmlAttribute(stream, "id", QString("%1").arg(room.getId().asUint32()));
+    saveXmlAttribute(stream, "name", room.getName().toQString());
     if (!room.isUpToDate()) {
-        stream.writeAttribute("uptodate", "false");
+        saveXmlAttribute(stream, "uptodate", "false");
     }
     saveXmlElement(stream, "align", alignName(room.getAlignType()));
     saveXmlElement(stream, "light", lightName(room.getLightType()));
@@ -150,9 +150,9 @@ void XmlMapStorage::saveCoordinate(QXmlStreamWriter &stream,
                                    const Coordinate &pos)
 {
     stream.writeStartElement(name);
-    stream.writeAttribute("x", QString("%1").arg(pos.x));
-    stream.writeAttribute("y", QString("%1").arg(pos.y));
-    stream.writeAttribute("z", QString("%1").arg(pos.z));
+    saveXmlAttribute(stream, "x", QString("%1").arg(pos.x));
+    saveXmlAttribute(stream, "y", QString("%1").arg(pos.y));
+    saveXmlAttribute(stream, "z", QString("%1").arg(pos.z));
     stream.writeEndElement(); // end coordinate
 }
 
@@ -162,7 +162,7 @@ void XmlMapStorage::saveExit(QXmlStreamWriter &stream, const Exit &e, ExitDirEnu
         return;
     }
     stream.writeStartElement("exit");
-    stream.writeAttribute("dir", lowercaseDirection(dir));
+    saveXmlAttribute(stream, "dir", lowercaseDirection(dir));
     saveXmlAttribute(stream, "doorname", e.getDoorName().toQString());
     saveExitTo(stream, e);
     saveDoorFlags(stream, e.getDoorFlags());
@@ -173,7 +173,7 @@ void XmlMapStorage::saveExit(QXmlStreamWriter &stream, const Exit &e, ExitDirEnu
 void XmlMapStorage::saveExitTo(QXmlStreamWriter &stream, const Exit &e)
 {
     for (const RoomId id : e.outRange()) {
-        stream.writeTextElement("to", QString("%1").arg(id.asUint32()));
+        saveXmlElement(stream, "to", QString("%1").arg(id.asUint32()));
     }
 }
 
@@ -190,18 +190,19 @@ void XmlMapStorage::saveMarker(QXmlStreamWriter &stream, const InfoMark &marker)
 {
     const InfoMarkTypeEnum type = marker.getType();
     stream.writeStartElement("marker");
-    stream.writeAttribute("type", markTypeName(type));
-    stream.writeAttribute("class", markClassName(marker.getClass()));
+    saveXmlAttribute(stream, "type", markTypeName(type));
+    saveXmlAttribute(stream, "class", markClassName(marker.getClass()));
     // REVISIT: round to 45 degrees?
     if (marker.getRotationAngle() != 0) {
-        stream.writeAttribute("angle",
-                              QString("%1").arg(static_cast<qint32>(marker.getRotationAngle())));
+        saveXmlAttribute(stream,
+                         "angle",
+                         QString("%1").arg(static_cast<qint32>(marker.getRotationAngle())));
     }
     saveCoordinate(stream, "pos1", marker.getPosition1());
     saveCoordinate(stream, "pos2", marker.getPosition2());
 
     if (type == InfoMarkTypeEnum::TEXT) {
-        stream.writeTextElement("text", marker.getText().toQString());
+        saveXmlElement(stream, "text", marker.getText().toQString());
     }
 
     stream.writeEndElement(); // end marker

--- a/src/mapstorage/XmlMapStorage.cpp
+++ b/src/mapstorage/XmlMapStorage.cpp
@@ -129,11 +129,11 @@ void XmlMapStorage::saveRoom(QXmlStreamWriter &stream, const Room &room)
     saveXmlElement(stream, "ridable", ridableName(room.getRidableType()));
     saveXmlElement(stream, "sundeath", sundeathName(room.getSundeathType()));
     saveXmlElement(stream, "terrain", terrainName(room.getTerrainType()));
+    saveCoordinate(stream, "coord", room.getPosition());
     saveRoomLoadFlags(stream, room.getLoadFlags());
     saveRoomMobFlags(stream, room.getMobFlags());
-    saveCoordinate(stream, "coord", room.getPosition());
 
-    for (const ExitDirEnum dir : ALL_EXITS_NESWUD) {
+    for (const ExitDirEnum dir : ALL_EXITS7) {
         saveExit(stream, room.exit(dir), dir);
     }
     saveXmlElement(stream, "description", room.getDescription().toQString());
@@ -162,11 +162,9 @@ void XmlMapStorage::saveExit(QXmlStreamWriter &stream, const Exit &e, ExitDirEnu
     stream.writeStartElement("exit");
     stream.writeAttribute("dir", lowercaseDirection(dir));
     saveExitTo(stream, e);
-    saveExitFlags(stream, e.getExitFlags());
+    saveXmlAttribute("doorname", e.getDoorName().toQString());
     saveDoorFlags(stream, e.getDoorFlags());
-    if (e.hasDoorName()) {
-        stream.writeAttribute("doorname", e.getDoorName().toQString());
-    }
+    saveExitFlags(stream, e.getExitFlags());
     stream.writeEndElement(); // end exit
 }
 
@@ -247,16 +245,12 @@ void XmlMapStorage::saveDoorFlags(QXmlStreamWriter &stream, DoorFlags fl)
     if (fl.isEmpty()) {
         return;
     }
-    QString list;
-    const char *separator = "";
     for (uint x = 0; x < NUM_DOOR_FLAGS; x++) {
-        if (fl.contains(DoorFlagEnum(x))) {
-            list += separator;
-            separator = ",";
-            list += doorFlagName(DoorFlagEnum(x));
+        const DoorFlagEnum e = DoorFlagEnum(x);
+        if (fl.contains(e)) {
+            saveXmlElement(stream, "doorflag", doorFlagName(e));
         }
     }
-    saveXmlAttribute(stream, "doorflags", list);
 }
 
 void XmlMapStorage::saveExitFlags(QXmlStreamWriter &stream, ExitFlags fl)
@@ -265,16 +259,12 @@ void XmlMapStorage::saveExitFlags(QXmlStreamWriter &stream, ExitFlags fl)
     if (fl.isEmpty()) {
         return;
     }
-    QString list;
-    const char *separator = "";
     for (uint x = 0; x < NUM_EXIT_FLAGS; x++) {
-        if (fl.contains(ExitFlagEnum(x))) {
-            list += separator;
-            separator = ",";
-            list += exitFlagName(ExitFlagEnum(x));
+        const ExitFlagEnum e = ExitFlagEnum(x);
+        if (fl.contains(e)) {
+            saveXmlElement(stream, "exitflag", exitFlagName(e));
         }
     }
-    saveXmlAttribute(stream, "flags", list);
 }
 
 void XmlMapStorage::saveRoomLoadFlags(QXmlStreamWriter &stream, RoomLoadFlags fl)
@@ -282,18 +272,12 @@ void XmlMapStorage::saveRoomLoadFlags(QXmlStreamWriter &stream, RoomLoadFlags fl
     if (fl.isEmpty()) {
         return;
     }
-    stream.writeStartElement("flags");
-    QString separator;
     for (uint x = 0; x < NUM_ROOM_LOAD_FLAGS; x++) {
-        if (fl.contains(RoomLoadFlagEnum(x))) {
-            stream.writeCharacters(separator);
-            if (separator.isEmpty()) {
-                separator = ",";
-            }
-            stream.writeCharacters(loadFlagName(RoomLoadFlagEnum(x)));
+        const RoomLoadFlagEnum e = RoomLoadFlagEnum(x);
+        if (fl.contains(e)) {
+            saveXmlElement(stream, "loadflag", loadFlagName(e));
         }
     }
-    stream.writeEndElement();
 }
 
 void XmlMapStorage::saveRoomMobFlags(QXmlStreamWriter &stream, RoomMobFlags fl)
@@ -301,18 +285,12 @@ void XmlMapStorage::saveRoomMobFlags(QXmlStreamWriter &stream, RoomMobFlags fl)
     if (fl.isEmpty()) {
         return;
     }
-    stream.writeStartElement("mobflags");
-    QString separator;
-    for (uint x = 0; x < NUM_ROOM_MOB_FLAGS; x++) {
-        if (fl.contains(RoomMobFlagEnum(x))) {
-            stream.writeCharacters(separator);
-            if (separator.isEmpty()) {
-                separator = ",";
-            }
-            stream.writeCharacters(mobFlagName(RoomMobFlagEnum(x)));
+    for (uint x = 0; x < NUM_ROOM_LOAD_FLAGS; x++) {
+        const RoomMobFlagEnum e = RoomMobFlagEnum(x);
+        if (fl.contains(e)) {
+            saveXmlElement(stream, "mobflag", mobFlagName(e));
         }
     }
-    stream.writeEndElement();
 }
 
 NODISCARD const char *XmlMapStorage::alignName(const RoomAlignEnum e)

--- a/src/mapstorage/XmlMapStorage.cpp
+++ b/src/mapstorage/XmlMapStorage.cpp
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2021 The MMapper Authors
+// Author: Massimiliano Ghilardi <massimiliano.ghilardi@gmail.com> (Cosmos)
+// Author: Nils Schimmelmann <nschimme@gmail.com> (Jahara)
+
+#include "XmlMapStorage.h"
+
+#include <cassert>
+#include <cstddef>
+#include <stdexcept>
+#include <QString>
+#include <QXmlStreamWriter>
+
+#include "../expandoracommon/coordinate.h"
+#include "../expandoracommon/exit.h"
+#include "../expandoracommon/room.h"
+#include "../global/roomid.h"
+#include "../global/utils.h"
+#include "../mapdata/DoorFlags.h"
+#include "../mapdata/ExitDirection.h"
+#include "../mapdata/ExitFlags.h"
+#include "../mapdata/enums.h"
+#include "../mapdata/mapdata.h"
+#include "../mapdata/mmapper2room.h"
+#include "abstractmapstorage.h"
+#include "basemapsavefilter.h"
+#include "progresscounter.h"
+#include "roomsaver.h"
+
+XmlMapStorage::XmlMapStorage(MapData &mapdata,
+                             const QString &filename,
+                             QFile *const file,
+                             QObject *parent)
+    : AbstractMapStorage(mapdata, filename, file, parent)
+{}
+
+XmlMapStorage::~XmlMapStorage() = default;
+
+void XmlMapStorage::newData()
+{
+    qWarning() << "XmlMapStorage does not implement newData()";
+}
+
+bool XmlMapStorage::loadData()
+{
+    return false;
+}
+
+bool XmlMapStorage::mergeData()
+{
+    return false;
+}
+
+bool XmlMapStorage::saveData(bool baseMapOnly)
+{
+    log("Writing data to file ...");
+
+    // Collect the room and marker lists. The room list can't be acquired
+    // directly apparently and we have to go through a RoomSaver which receives
+    // them from a sort of callback function.
+    // The RoomSaver acts as a lock on the rooms.
+    ConstRoomList roomList;
+    roomList.reserve(m_mapData.getRoomsCount());
+
+    RoomSaver saver(m_mapData, roomList);
+    for (uint i = 0; i < m_mapData.getRoomsCount(); ++i) {
+        m_mapData.lookingForRooms(saver, RoomId{i});
+    }
+
+    uint roomsCount = saver.getRoomsCount();
+
+    auto &progressCounter = getProgressCounter();
+    progressCounter.reset();
+    progressCounter.increaseTotalStepsBy(roomsCount + 3);
+
+    BaseMapSaveFilter filter;
+    if (baseMapOnly) {
+        filter.setMapData(&m_mapData);
+        progressCounter.increaseTotalStepsBy(filter.prepareCount());
+        filter.prepare(progressCounter);
+    }
+
+    QXmlStreamWriter stream(m_file);
+    stream.setAutoFormatting(true);
+    stream.writeStartDocument();
+
+    // save map
+    stream.writeStartElement("map");
+    stream.writeAttribute("type", "mmapper2xml");
+    stream.writeAttribute("version", "1");
+
+    // save rooms
+    stream.writeStartElement("rooms");
+    auto saveOne = [&stream](const Room &room) { saveRoom(stream, room); };
+
+    for (const auto &pRoom : roomList) {
+        filter.visitRoom(deref(pRoom), baseMapOnly, saveOne);
+        progressCounter.step();
+    }
+    stream.writeEndElement(); // end rooms
+
+    progressCounter.step();
+
+    stream.writeEndElement(); // end map
+    progressCounter.step();
+
+    log("Writing data finished.");
+
+    m_mapData.unsetDataChanged();
+    emit sig_onDataSaved();
+
+    return true;
+}
+
+void XmlMapStorage::saveRoom(QXmlStreamWriter &stream, const Room &room)
+{
+    stream.writeStartElement("room");
+    stream.writeAttribute("id", QString("%1").arg(room.getId().asUint32()));
+    stream.writeAttribute("name", room.getName().toQString());
+    saveXmlElement(stream, "terrain", terrainName(room.getTerrainType()));
+    saveXmlElement(stream, "light", lightName(room.getLightType()));
+    saveXmlElement(stream, "ridable", ridableName(room.getRidableType()));
+    saveXmlElement(stream, "sundeath", sundeathName(room.getSundeathType()));
+    saveXmlElement(stream, "align", alignName(room.getAlignType()));
+    saveRoomFlags(stream, room.getLoadFlags());
+
+    stream.writeStartElement("coord");
+    const Coordinate &pos = room.getPosition();
+    stream.writeAttribute("x", QString("%1").arg(pos.x));
+    stream.writeAttribute("y", QString("%1").arg(pos.y));
+    stream.writeAttribute("z", QString("%1").arg(pos.z));
+    stream.writeEndElement(); // end coord
+
+    for (const ExitDirEnum dir : ALL_EXITS_NESWUD) {
+        const Exit &e = room.exit(dir);
+        if (e.exitIsExit() && !e.outIsEmpty()) {
+            stream.writeStartElement("exit");
+            stream.writeAttribute("direction", lowercaseDirection(dir));
+            // REVISIT: Can MMP handle multiple exits in the same direction?
+            stream.writeAttribute("target", QString("%1").arg(e.outFirst().asUint32()));
+            if (e.isHiddenExit())
+                stream.writeAttribute("hidden", "true");
+            if (e.exitIsDoor()) {
+                stream.writeAttribute("door", "true");
+            }
+            stream.writeEndElement(); // end exit
+        }
+    }
+    saveXmlElement(stream, "description", room.getDescription().toQString());
+    saveXmlElement(stream, "contents", room.getContents().toQString());
+    saveXmlElement(stream, "note", room.getNote().toQString());
+
+    stream.writeEndElement(); // end room
+}
+
+void XmlMapStorage::saveXmlAttribute(QXmlStreamWriter &stream,
+                                     const QString &name,
+                                     const QString &value)
+{
+    if (!value.isEmpty()) {
+        stream.writeAttribute(name, value);
+    }
+}
+
+void XmlMapStorage::saveXmlElement(QXmlStreamWriter &stream,
+                                   const QString &name,
+                                   const QString &value)
+{
+    if (!value.isEmpty()) {
+        stream.writeStartElement(name);
+        stream.writeCharacters(value);
+        stream.writeEndElement(); // end description
+    }
+}
+
+#define DECL(X) #X,
+static const char *const flagNames[] = {
+    X_FOREACH_ROOM_LOAD_FLAG(DECL) //
+};
+static const char *const terrainNames[] = {
+    X_FOREACH_RoomTerrainEnum(DECL) //
+};
+static const char *const lightNames[] = {
+    X_FOREACH_RoomLightEnum(DECL) //
+};
+static const char *const portableNames[] = {
+    X_FOREACH_RoomPortableEnum(DECL) //
+};
+static const char *const ridableNames[] = {
+    X_FOREACH_RoomRidableEnum(DECL) //
+};
+static const char *const sundeathNames[] = {
+    X_FOREACH_RoomSundeathEnum(DECL) //
+};
+static const char *const alignNames[] = {
+    X_FOREACH_RoomAlignEnum(DECL) //
+};
+
+#undef DECL
+
+void XmlMapStorage::saveRoomFlags(QXmlStreamWriter &stream, RoomLoadFlags fl)
+{
+    if (fl.isEmpty()) {
+        return;
+    }
+    stream.writeStartElement("flags");
+    QString separator;
+    for (uint x = 0; x < sizeof(flagNames) / sizeof(flagNames[0]); x++) {
+        if (fl.contains(RoomLoadFlagEnum(x))) {
+            stream.writeCharacters(separator);
+            if (separator.isEmpty()) {
+                separator = ",";
+            }
+            stream.writeCharacters(flagNames[x]);
+        }
+    }
+    stream.writeEndElement();
+}
+
+NODISCARD QString XmlMapStorage::terrainName(const RoomTerrainEnum x)
+{
+    if (x == RoomTerrainEnum::UNDEFINED) {
+        return QString();
+    }
+    if (uint(x) > 0 && uint(x) < sizeof(terrainNames) / sizeof(terrainNames[0])) {
+        return QString{terrainNames[uint(x)]};
+    }
+    return QString("%1").arg(uint(x));
+}
+
+NODISCARD QString XmlMapStorage::lightName(const RoomLightEnum x)
+{
+    if (x == RoomLightEnum::UNDEFINED) {
+        return QString();
+    }
+    if (uint(x) > 0 && uint(x) < sizeof(lightNames) / sizeof(lightNames[0])) {
+        return QString{lightNames[uint(x)]};
+    }
+    return QString("%1").arg(uint(x));
+}
+
+NODISCARD QString XmlMapStorage::ridableName(const RoomRidableEnum x)
+{
+    if (x == RoomRidableEnum::UNDEFINED) {
+        return QString();
+    }
+    if (uint(x) > 0 && uint(x) < sizeof(ridableNames) / sizeof(ridableNames[0])) {
+        return QString{ridableNames[uint(x)]};
+    }
+    return QString("%1").arg(uint(x));
+}
+
+NODISCARD QString XmlMapStorage::sundeathName(const RoomSundeathEnum x)
+{
+    if (x == RoomSundeathEnum::UNDEFINED) {
+        return QString();
+    }
+    if (uint(x) > 0 && uint(x) < sizeof(sundeathNames) / sizeof(sundeathNames[0])) {
+        return QString{sundeathNames[uint(x)]};
+    }
+    return QString("%1").arg(uint(x));
+}
+
+NODISCARD QString XmlMapStorage::alignName(const RoomAlignEnum x)
+{
+    if (x == RoomAlignEnum::UNDEFINED) {
+        return QString();
+    }
+    if (uint(x) > 0 && uint(x) < sizeof(alignNames) / sizeof(alignNames[0])) {
+        return QString{alignNames[uint(x)]};
+    }
+    return QString("%1").arg(uint(x));
+}

--- a/src/mapstorage/XmlMapStorage.cpp
+++ b/src/mapstorage/XmlMapStorage.cpp
@@ -59,11 +59,13 @@ bool XmlMapStorage::saveData(bool baseMapOnly)
     // directly apparently and we have to go through a RoomSaver which receives
     // them from a sort of callback function.
     // The RoomSaver acts as a lock on the rooms.
+    const quint32 roomsCount = m_mapData.getRoomsCount();
+
     ConstRoomList roomList;
-    roomList.reserve(m_mapData.getRoomsCount());
+    roomList.reserve(roomsCount);
 
     RoomSaver saver(m_mapData, roomList);
-    for (uint i = 0, n = m_mapData.getRoomsCount(); i < n; ++i) {
+    for (quint32 i = 0; i < roomsCount; ++i) {
         m_mapData.lookingForRooms(saver, RoomId{i});
     }
     const MarkerList &markerList = m_mapData.getMarkersList();

--- a/src/mapstorage/XmlMapStorage.cpp
+++ b/src/mapstorage/XmlMapStorage.cpp
@@ -79,7 +79,7 @@ bool XmlMapStorage::saveData(bool baseMapOnly)
 
     stream.writeStartElement("map");
     stream.writeAttribute("type", "mmapper2xml");
-    stream.writeAttribute("version", "1");
+    stream.writeAttribute("version", "1.0.0");
 
     saveRooms(stream, baseMapOnly, roomList);
     saveMarkers(stream, markerList);

--- a/src/mapstorage/XmlMapStorage.cpp
+++ b/src/mapstorage/XmlMapStorage.cpp
@@ -153,7 +153,7 @@ void XmlMapStorage::saveCoordinate(QXmlStreamWriter &stream,
     stream.writeAttribute("x", QString("%1").arg(pos.x));
     stream.writeAttribute("y", QString("%1").arg(pos.y));
     stream.writeAttribute("z", QString("%1").arg(pos.z));
-    stream.writeEndElement(); // end coord
+    stream.writeEndElement(); // end coordinate
 }
 
 void XmlMapStorage::saveExit(QXmlStreamWriter &stream, const Exit &e, ExitDirEnum dir)
@@ -163,8 +163,8 @@ void XmlMapStorage::saveExit(QXmlStreamWriter &stream, const Exit &e, ExitDirEnu
     }
     stream.writeStartElement("exit");
     stream.writeAttribute("dir", lowercaseDirection(dir));
-    saveExitTo(stream, e);
     saveXmlAttribute(stream, "doorname", e.getDoorName().toQString());
+    saveExitTo(stream, e);
     saveDoorFlags(stream, e.getDoorFlags());
     saveExitFlags(stream, e.getExitFlags());
     stream.writeEndElement(); // end exit
@@ -172,17 +172,9 @@ void XmlMapStorage::saveExit(QXmlStreamWriter &stream, const Exit &e, ExitDirEnu
 
 void XmlMapStorage::saveExitTo(QXmlStreamWriter &stream, const Exit &e)
 {
-    QString idlist;
-    const char *separator = nullptr;
     for (const RoomId id : e.outRange()) {
-        if (separator == nullptr) {
-            separator = ",";
-        } else {
-            idlist += separator;
-        }
-        idlist += QString("%1").arg(id.asUint32());
+        stream.writeTextElement("to", QString("%1").arg(id.asUint32()));
     }
-    stream.writeAttribute("to", idlist);
 }
 
 void XmlMapStorage::saveMarkers(QXmlStreamWriter &stream, const MarkerList &markerList)
@@ -209,9 +201,7 @@ void XmlMapStorage::saveMarker(QXmlStreamWriter &stream, const InfoMark &marker)
     saveCoordinate(stream, "pos2", marker.getPosition2());
 
     if (type == InfoMarkTypeEnum::TEXT) {
-        stream.writeStartElement("text");
-        stream.writeCharacters(marker.getText().toQString());
-        stream.writeEndElement(); // end text
+        stream.writeTextElement("text", marker.getText().toQString());
     }
 
     stream.writeEndElement(); // end marker
@@ -222,9 +212,7 @@ void XmlMapStorage::saveXmlElement(QXmlStreamWriter &stream,
                                    const QString &value)
 {
     if (!value.isEmpty()) {
-        stream.writeStartElement(name);
-        stream.writeCharacters(value);
-        stream.writeEndElement(); // end description
+        stream.writeTextElement(name, value);
     }
 }
 

--- a/src/mapstorage/XmlMapStorage.cpp
+++ b/src/mapstorage/XmlMapStorage.cpp
@@ -235,8 +235,7 @@ void XmlMapStorage::saveDoorFlags(QXmlStreamWriter &stream, DoorFlags fl)
     if (fl.isEmpty()) {
         return;
     }
-    for (uint x = 0; x < NUM_DOOR_FLAGS; x++) {
-        const DoorFlagEnum e = DoorFlagEnum(x);
+    for (const DoorFlagEnum e : ALL_DOOR_FLAGS) {
         if (fl.contains(e)) {
             saveXmlElement(stream, "doorflag", doorFlagName(e));
         }
@@ -249,8 +248,7 @@ void XmlMapStorage::saveExitFlags(QXmlStreamWriter &stream, ExitFlags fl)
     if (fl.isEmpty()) {
         return;
     }
-    for (uint x = 0; x < NUM_EXIT_FLAGS; x++) {
-        const ExitFlagEnum e = ExitFlagEnum(x);
+    for (const ExitFlagEnum e : ALL_EXIT_FLAGS) {
         if (fl.contains(e)) {
             saveXmlElement(stream, "exitflag", exitFlagName(e));
         }
@@ -262,8 +260,7 @@ void XmlMapStorage::saveRoomLoadFlags(QXmlStreamWriter &stream, RoomLoadFlags fl
     if (fl.isEmpty()) {
         return;
     }
-    for (uint x = 0; x < NUM_ROOM_LOAD_FLAGS; x++) {
-        const RoomLoadFlagEnum e = RoomLoadFlagEnum(x);
+    for (const RoomLoadFlagEnum e : ALL_LOAD_FLAGS) {
         if (fl.contains(e)) {
             saveXmlElement(stream, "loadflag", loadFlagName(e));
         }
@@ -275,8 +272,7 @@ void XmlMapStorage::saveRoomMobFlags(QXmlStreamWriter &stream, RoomMobFlags fl)
     if (fl.isEmpty()) {
         return;
     }
-    for (uint x = 0; x < NUM_ROOM_LOAD_FLAGS; x++) {
-        const RoomMobFlagEnum e = RoomMobFlagEnum(x);
+    for (const RoomMobFlagEnum e : ALL_MOB_FLAGS) {
         if (fl.contains(e)) {
             saveXmlElement(stream, "mobflag", mobFlagName(e));
         }

--- a/src/mapstorage/XmlMapStorage.cpp
+++ b/src/mapstorage/XmlMapStorage.cpp
@@ -162,7 +162,7 @@ void XmlMapStorage::saveExit(QXmlStreamWriter &stream, const Exit &e, ExitDirEnu
     stream.writeStartElement("exit");
     stream.writeAttribute("dir", lowercaseDirection(dir));
     saveExitTo(stream, e);
-    saveXmlAttribute("doorname", e.getDoorName().toQString());
+    saveXmlAttribute(stream, "doorname", e.getDoorName().toQString());
     saveDoorFlags(stream, e.getDoorFlags());
     saveExitFlags(stream, e.getExitFlags());
     stream.writeEndElement(); // end exit

--- a/src/mapstorage/XmlMapStorage.h
+++ b/src/mapstorage/XmlMapStorage.h
@@ -1,6 +1,7 @@
 #pragma once
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (C) 2019 The MMapper Authors
+// Copyright (C) 2021 The MMapper Authors
+// Author: Massimiliano Ghilardi <massimiliano.ghilardi@gmail.com> (Cosmos)
 // Author: Nils Schimmelmann <nschimme@gmail.com> (Jahara)
 
 #include <QString>

--- a/src/mapstorage/XmlMapStorage.h
+++ b/src/mapstorage/XmlMapStorage.h
@@ -38,11 +38,13 @@ private:
 
 private:
     static void saveRoom(QXmlStreamWriter &stream, const Room &room);
-    static void saveRoomExit(QXmlStreamWriter &stream, const Exit &e, ExitDirEnum dir);
-    static void saveRoomExitTo(QXmlStreamWriter &stream, const Exit &e);
-    static void saveRoomExitFlags(QXmlStreamWriter &stream, ExitFlags fl);
     static void saveRoomLoadFlags(QXmlStreamWriter &stream, RoomLoadFlags fl);
     static void saveRoomMobFlags(QXmlStreamWriter &stream, RoomMobFlags fl);
+
+    static void saveExit(QXmlStreamWriter &stream, const Exit &e, ExitDirEnum dir);
+    static void saveExitTo(QXmlStreamWriter &stream, const Exit &e);
+    static void saveExitFlags(QXmlStreamWriter &stream, ExitFlags fl);
+    static void saveDoorFlags(QXmlStreamWriter &stream, DoorFlags fl);
 
     static void saveXmlElement(QXmlStreamWriter &stream, const QString &name, const QString &value);
     static void saveXmlAttribute(QXmlStreamWriter &stream,

--- a/src/mapstorage/XmlMapStorage.h
+++ b/src/mapstorage/XmlMapStorage.h
@@ -8,9 +8,9 @@
 #include <QtCore>
 
 #include "../global/macros.h"
+#include "../mapdata/mapdata.h"
 #include "abstractmapstorage.h"
 
-class MapData;
 class QObject;
 class QXmlStreamWriter;
 

--- a/src/mapstorage/XmlMapStorage.h
+++ b/src/mapstorage/XmlMapStorage.h
@@ -37,14 +37,19 @@ private:
     NODISCARD bool mergeData() override;
 
 private:
+    void saveRooms(QXmlStreamWriter &stream, bool baseMapOnly, const ConstRoomList &roomList);
     static void saveRoom(QXmlStreamWriter &stream, const Room &room);
     static void saveRoomLoadFlags(QXmlStreamWriter &stream, RoomLoadFlags fl);
     static void saveRoomMobFlags(QXmlStreamWriter &stream, RoomMobFlags fl);
 
+    static void saveCoordinate(QXmlStreamWriter &stream, const QString &name, const Coordinate &pos);
     static void saveExit(QXmlStreamWriter &stream, const Exit &e, ExitDirEnum dir);
     static void saveExitTo(QXmlStreamWriter &stream, const Exit &e);
     static void saveExitFlags(QXmlStreamWriter &stream, ExitFlags fl);
     static void saveDoorFlags(QXmlStreamWriter &stream, DoorFlags fl);
+
+    void saveMarkers(QXmlStreamWriter &stream, const MarkerList &markerList);
+    static void saveMarker(QXmlStreamWriter &stream, const InfoMark &marker);
 
     static void saveXmlElement(QXmlStreamWriter &stream, const QString &name, const QString &value);
     static void saveXmlAttribute(QXmlStreamWriter &stream,
@@ -53,6 +58,8 @@ private:
 
     NODISCARD static QString alignName(const RoomAlignEnum x);
     NODISCARD static QString lightName(const RoomLightEnum x);
+    NODISCARD static QString markClassName(const InfoMarkClassEnum x);
+    NODISCARD static QString markTypeName(const InfoMarkTypeEnum x);
     NODISCARD static QString portableName(const RoomPortableEnum x);
     NODISCARD static QString ridableName(const RoomRidableEnum x);
     NODISCARD static QString sundeathName(const RoomSundeathEnum x);

--- a/src/mapstorage/XmlMapStorage.h
+++ b/src/mapstorage/XmlMapStorage.h
@@ -14,7 +14,7 @@ class MapData;
 class QObject;
 class QXmlStreamWriter;
 
-/*! \brief MM2 export in text (actually XML) format
+/*! \brief MM2 export in XML format
  */
 class XmlMapStorage final : public AbstractMapStorage
 {
@@ -37,17 +37,25 @@ private:
     NODISCARD bool mergeData() override;
 
 private:
+    static void saveRoom(QXmlStreamWriter &stream, const Room &room);
+    static void saveRoomExit(QXmlStreamWriter &stream, const Exit &e, ExitDirEnum dir);
+    static void saveRoomExitTo(QXmlStreamWriter &stream, const Exit &e);
+    static void saveRoomExitFlags(QXmlStreamWriter &stream, ExitFlags fl);
+    static void saveRoomLoadFlags(QXmlStreamWriter &stream, RoomLoadFlags fl);
+    static void saveRoomMobFlags(QXmlStreamWriter &stream, RoomMobFlags fl);
+
+    static void saveXmlElement(QXmlStreamWriter &stream, const QString &name, const QString &value);
     static void saveXmlAttribute(QXmlStreamWriter &stream,
                                  const QString &name,
                                  const QString &value);
-    static void saveXmlElement(QXmlStreamWriter &stream, const QString &name, const QString &value);
-    static void saveRoom(QXmlStreamWriter &stream, const Room &room);
-    static void saveRoomFlags(QXmlStreamWriter &stream, RoomLoadFlags fl);
-    NODISCARD static QString terrainName(const RoomTerrainEnum x);
+
+    NODISCARD static QString alignName(const RoomAlignEnum x);
     NODISCARD static QString lightName(const RoomLightEnum x);
+    NODISCARD static QString portableName(const RoomPortableEnum x);
     NODISCARD static QString ridableName(const RoomRidableEnum x);
     NODISCARD static QString sundeathName(const RoomSundeathEnum x);
-    NODISCARD static QString alignName(const RoomAlignEnum x);
+    NODISCARD static QString terrainName(const RoomTerrainEnum x);
+    NODISCARD static QString enumName(const uint x, const char *const names[], const size_t count);
 
-    void log(const QString &msg) { emit sig_log("XmlMapStorage", msg); }
+    void log(const QString &msg);
 };

--- a/src/mapstorage/XmlMapStorage.h
+++ b/src/mapstorage/XmlMapStorage.h
@@ -1,0 +1,52 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2019 The MMapper Authors
+// Author: Nils Schimmelmann <nschimme@gmail.com> (Jahara)
+
+#include <QString>
+#include <QtCore>
+
+#include "../global/macros.h"
+#include "abstractmapstorage.h"
+
+class MapData;
+class QObject;
+class QXmlStreamWriter;
+
+/*! \brief MM2 export in text (actually XML) format
+ */
+class XmlMapStorage final : public AbstractMapStorage
+{
+    Q_OBJECT
+
+public:
+    explicit XmlMapStorage(MapData &, const QString &, QFile *, QObject *parent);
+    ~XmlMapStorage() final;
+
+public:
+    XmlMapStorage() = delete;
+
+private:
+    NODISCARD bool canLoad() const override { return false; }
+    NODISCARD bool canSave() const override { return true; }
+
+    void newData() override;
+    NODISCARD bool loadData() override;
+    NODISCARD bool saveData(bool baseMapOnly) override;
+    NODISCARD bool mergeData() override;
+
+private:
+    static void saveXmlAttribute(QXmlStreamWriter &stream,
+                                 const QString &name,
+                                 const QString &value);
+    static void saveXmlElement(QXmlStreamWriter &stream, const QString &name, const QString &value);
+    static void saveRoom(QXmlStreamWriter &stream, const Room &room);
+    static void saveRoomFlags(QXmlStreamWriter &stream, RoomLoadFlags fl);
+    NODISCARD static QString terrainName(const RoomTerrainEnum x);
+    NODISCARD static QString lightName(const RoomLightEnum x);
+    NODISCARD static QString ridableName(const RoomRidableEnum x);
+    NODISCARD static QString sundeathName(const RoomSundeathEnum x);
+    NODISCARD static QString alignName(const RoomAlignEnum x);
+
+    void log(const QString &msg) { emit sig_log("XmlMapStorage", msg); }
+};

--- a/src/mapstorage/XmlMapStorage.h
+++ b/src/mapstorage/XmlMapStorage.h
@@ -56,15 +56,18 @@ private:
                                  const QString &name,
                                  const QString &value);
 
-    NODISCARD static QString alignName(const RoomAlignEnum x);
-    NODISCARD static QString lightName(const RoomLightEnum x);
-    NODISCARD static QString markClassName(const InfoMarkClassEnum x);
-    NODISCARD static QString markTypeName(const InfoMarkTypeEnum x);
-    NODISCARD static QString portableName(const RoomPortableEnum x);
-    NODISCARD static QString ridableName(const RoomRidableEnum x);
-    NODISCARD static QString sundeathName(const RoomSundeathEnum x);
-    NODISCARD static QString terrainName(const RoomTerrainEnum x);
-    NODISCARD static QString enumName(const uint x, const char *const names[], const size_t count);
+    NODISCARD static const char *alignName(const RoomAlignEnum e);
+    NODISCARD static const char *doorFlagName(const DoorFlagEnum e);
+    NODISCARD static const char *exitFlagName(const ExitFlagEnum e);
+    NODISCARD static const char *lightName(const RoomLightEnum e);
+    NODISCARD static const char *loadFlagName(const RoomLoadFlagEnum e);
+    NODISCARD static const char *markClassName(const InfoMarkClassEnum e);
+    NODISCARD static const char *markTypeName(const InfoMarkTypeEnum e);
+    NODISCARD static const char *mobFlagName(const RoomMobFlagEnum e);
+    NODISCARD static const char *portableName(const RoomPortableEnum e);
+    NODISCARD static const char *ridableName(const RoomRidableEnum e);
+    NODISCARD static const char *sundeathName(const RoomSundeathEnum e);
+    NODISCARD static const char *terrainName(const RoomTerrainEnum e);
 
     void log(const QString &msg);
 };


### PR DESCRIPTION
As discussed on Discord chat,
MMapper2 currently lacks a mechanism to merge two maps that are derived from the same one,
and which differ only for some (relatively minor) modifications.

A typical use case is: a player has added some information (which he may not want to share,
or may not be relevant to other players, or simply have not been integrated yet into the upstream map)
to an upstream map, but in the meantime a new upstream map was published,
and he wants to merge his personal changes into a copy of the new upstream map.

This is a classical 3-way merge, with a base map and two other maps derived from it.

MMapper2 currently has no support for such a use case, and it may contain conflicts between the two derived maps,
which may be difficult or impossible to resolve without user input.

**This pull request adds the following feature: allow exporting a map to human-readable, text (actually XML) format,**
named ".mm2xml", which empowers users to use text editing tools on MMapper2 maps, such as `diff(1)`, `patch(1)` or even plain text editors.

It also allows maintaining patches on top of an existing map, for example using `diff(1)`

A subsequent pull request will add the ability to **import** (i.e. load) maps saved in the ".mm2xml" format.