### PR TITLE
return GmcpMessage fields by const reference

### DIFF
--- a/src/proxy/GmcpMessage.h
+++ b/src/proxy/GmcpMessage.h
@@ -84,8 +84,8 @@ public:
 #undef DECL_GETTERS_AND_SETTERS
 
 public:
-    NODISCARD GmcpMessageName getName() const { return name; }
-    NODISCARD std::optional<GmcpJson> getJson() const { return json; }
+    NODISCARD const GmcpMessageName &getName() const { return name; }
+    NODISCARD const std::optional<GmcpJson> &getJson() const { return json; }
 
 public:
     NODISCARD QByteArray toRawBytes() const;


### PR DESCRIPTION
because returning them by value breaks the idiom
```C++
  const std::string &str = msg.getJson()->getStdString();
```
which creates a temporary `std::optional<GmcpJson>` object, then extracts a `const std::string &` from it,
which in turn is dutifully destroyed at the `;`