### PR TITLE
Fix segfault in _dirs when map has buggy connections.

### DIFF
--- a/src/display/Connections.cpp
+++ b/src/display/Connections.cpp
@@ -241,7 +241,8 @@ void ConnectionDrawer::drawRoomConnectionsAndDoors(const Room *const room, const
             for (const auto &outTargetId : sourceExit.outRange()) {
                 const SharedConstRoom &sharedTargetRoom = rooms[outTargetId];
                 if (!sharedTargetRoom) {
-                    qWarning() << "Source room" << sourceId.asUint32() << "has target room"
+                    qWarning() << "Source room" << sourceId.asUint32() << "("
+                               << room->getName().toQString() << ") has target room"
                                << outTargetId.asUint32() << "which does not exist!";
                     continue;
                 }
@@ -288,7 +289,8 @@ void ConnectionDrawer::drawRoomConnectionsAndDoors(const Room *const room, const
         for (const auto &inTargetId : sourceExit.inRange()) {
             const SharedConstRoom &sharedTargetRoom = rooms[inTargetId];
             if (!sharedTargetRoom) {
-                qWarning() << "Source room" << sourceId.asUint32() << "has target room"
+                qWarning() << "Source room" << sourceId.asUint32() << "("
+                           << room->getName().toQString() << ") has target room"
                            << inTargetId.asUint32() << "which does not exist!";
                 continue;
             }

--- a/src/mapdata/shortestpath.cpp
+++ b/src/mapdata/shortestpath.cpp
@@ -137,6 +137,12 @@ void MapData::shortestPathSearch(const Room *origin,
                 continue;
             }
             const SharedConstRoom &nextr = roomIndex[e.outFirst()];
+            if (!nextr) {
+                qWarning() << "Source room" << thisr->getId().asUint32() << "("
+                           << thisr->getName().toQString() << ") has target room"
+                           << e.outFirst().asUint32() << "which does not exist!";
+                continue;
+            }
             if (visited.contains(nextr->getId())) {
                 continue;
             }


### PR DESCRIPTION
Faine's current map has a room connected to a non-existent room, causing a segfault in _dirs.  I don't know how that buggy connection was introduced, but this commit:

 - Fixes the segfault.

 - Adjusts the warning on map load so it's possible to find the bugged room.