### PR TITLE
Enable hiding both status bar and scroll bars for a more minimal MapWindow

### DIFF
--- a/src/configuration/configuration.cpp
+++ b/src/configuration/configuration.cpp
@@ -194,6 +194,8 @@ ConstString GRP_ROOMEDIT_DIALOG = "RoomEdit Dialog";
 
 ConstString KEY_ABSOLUTE_PATH_ACCEPTANCE = "absolute path acceptance";
 ConstString KEY_ALWAYS_ON_TOP = "Always On Top";
+ConstString KEY_SHOW_STATUS_BAR = "Show Status Bar";
+ConstString KEY_SHOW_SCROLL_BARS = "Show Scroll Bars";
 ConstString KEY_AUTHORIZATION_REQUIRED = "Authorization required";
 ConstString KEY_AUTHORIZED_SECRETS = "Authorized secrets";
 ConstString KEY_AUTO_LOAD = "Auto load";
@@ -540,6 +542,8 @@ void Configuration::GeneralSettings::read(QSettings &conf)
     windowGeometry = conf.value(KEY_WINDOW_GEOMETRY).toByteArray();
     windowState = conf.value(KEY_WINDOW_STATE).toByteArray();
     alwaysOnTop = conf.value(KEY_ALWAYS_ON_TOP, false).toBool();
+    showStatusBar = conf.value(KEY_SHOW_STATUS_BAR, true).toBool();
+    showScrollBars = conf.value(KEY_SHOW_SCROLL_BARS, true).toBool();
     mapMode = sanitizeMapMode(
         conf.value(KEY_MAP_MODE, static_cast<uint32_t>(MapModeEnum::PLAY)).toUInt());
     noSplash = conf.value(KEY_NO_SPLASH, false).toBool();
@@ -756,6 +760,8 @@ void Configuration::GeneralSettings::write(QSettings &conf) const
     conf.setValue(KEY_WINDOW_GEOMETRY, windowGeometry);
     conf.setValue(KEY_WINDOW_STATE, windowState);
     conf.setValue(KEY_ALWAYS_ON_TOP, alwaysOnTop);
+    conf.setValue(KEY_SHOW_STATUS_BAR, showStatusBar);
+    conf.setValue(KEY_SHOW_SCROLL_BARS, showScrollBars);
     conf.setValue(KEY_MAP_MODE, static_cast<uint32_t>(mapMode));
     conf.setValue(KEY_NO_SPLASH, noSplash);
     conf.setValue(KEY_NO_LAUNCH_PANEL, noClientPanel);

--- a/src/configuration/configuration.h
+++ b/src/configuration/configuration.h
@@ -102,6 +102,8 @@ public:
         QByteArray windowGeometry;
         QByteArray windowState;
         bool alwaysOnTop = false;
+        bool showStatusBar = true;
+        bool showScrollBars = true;
         MapModeEnum mapMode = MapModeEnum::PLAY;
         bool noSplash = false;
         bool noClientPanel = false;

--- a/src/display/mapwindow.cpp
+++ b/src/display/mapwindow.cpp
@@ -38,6 +38,8 @@ MapWindow::MapWindow(MapData &mapData, PrespammedPath &pp, Mmapper2Group &gm, QW
 
     m_gridLayout->addWidget(m_horizontalScrollBar.get(), 1, 0, 1, 1);
 
+    m_scrollBarsVisible = true;
+
     m_canvas = std::make_unique<MapCanvas>(mapData, pp, gm, this);
     MapCanvas *const canvas = m_canvas.get();
 
@@ -189,19 +191,29 @@ void MapWindow::slot_setScrollBars(const Coordinate &min, const Coordinate &max)
     updateScrollBars();
 }
 
+void MapWindow::setScrollBarsVisible(const bool visible)
+{
+    qDebug() << "setScrollBarsVisible: " << visible;
+    m_scrollBarsVisible = visible;
+
+    m_horizontalScrollBar->setVisible(visible);
+    m_verticalScrollBar->setVisible(visible);
+
+}
+
 void MapWindow::updateScrollBars()
 {
     const auto dims = m_knownMapSize.size() * MapCanvas::SCROLL_SCALE;
 
     m_horizontalScrollBar->setRange(0, dims.x);
-    if (dims.x > 0) {
+    if (dims.x > 0 && m_scrollBarsVisible) {
         m_horizontalScrollBar->show();
     } else {
         m_horizontalScrollBar->hide();
     }
 
     m_verticalScrollBar->setRange(0, dims.y);
-    if (dims.y > 0) {
+    if (dims.y > 0 && m_scrollBarsVisible) {
         m_verticalScrollBar->show();
     } else {
         m_verticalScrollBar->hide();

--- a/src/display/mapwindow.cpp
+++ b/src/display/mapwindow.cpp
@@ -38,7 +38,7 @@ MapWindow::MapWindow(MapData &mapData, PrespammedPath &pp, Mmapper2Group &gm, QW
 
     m_gridLayout->addWidget(m_horizontalScrollBar.get(), 1, 0, 1, 1);
 
-    m_scrollBarsVisible = std::nullopt;
+    m_showScrollBars = std::nullopt;
 
     m_canvas = std::make_unique<MapCanvas>(mapData, pp, gm, this);
     MapCanvas *const canvas = m_canvas.get();
@@ -191,9 +191,9 @@ void MapWindow::slot_setScrollBars(const Coordinate &min, const Coordinate &max)
     updateScrollBars();
 }
 
-void MapWindow::setScrollBarsVisible(const bool visible)
+void MapWindow::setShowScrollBars(const bool show)
 {
-    m_scrollBarsVisible = visible;
+    m_showScrollBars = show;
     updateScrollBars();
 }
 
@@ -202,14 +202,14 @@ void MapWindow::updateScrollBars()
     const auto dims = m_knownMapSize.size() * MapCanvas::SCROLL_SCALE;
 
     m_horizontalScrollBar->setRange(0, dims.x);
-    if (dims.x > 0 && m_scrollBarsVisible.value_or(true)) {
+    if (dims.x > 0 && m_showScrollBars.value_or(true)) {
         m_horizontalScrollBar->show();
     } else {
         m_horizontalScrollBar->hide();
     }
 
     m_verticalScrollBar->setRange(0, dims.y);
-    if (dims.y > 0 && m_scrollBarsVisible.value_or(true)) {
+    if (dims.y > 0 && m_showScrollBars.value_or(true)) {
         m_verticalScrollBar->show();
     } else {
         m_verticalScrollBar->hide();

--- a/src/display/mapwindow.cpp
+++ b/src/display/mapwindow.cpp
@@ -38,7 +38,7 @@ MapWindow::MapWindow(MapData &mapData, PrespammedPath &pp, Mmapper2Group &gm, QW
 
     m_gridLayout->addWidget(m_horizontalScrollBar.get(), 1, 0, 1, 1);
 
-    m_scrollBarsVisible = true;
+    m_scrollBarsVisible = std::nullopt;
 
     m_canvas = std::make_unique<MapCanvas>(mapData, pp, gm, this);
     MapCanvas *const canvas = m_canvas.get();
@@ -193,12 +193,8 @@ void MapWindow::slot_setScrollBars(const Coordinate &min, const Coordinate &max)
 
 void MapWindow::setScrollBarsVisible(const bool visible)
 {
-    qDebug() << "setScrollBarsVisible: " << visible;
     m_scrollBarsVisible = visible;
-
-    m_horizontalScrollBar->setVisible(visible);
-    m_verticalScrollBar->setVisible(visible);
-
+    updateScrollBars();
 }
 
 void MapWindow::updateScrollBars()
@@ -206,14 +202,14 @@ void MapWindow::updateScrollBars()
     const auto dims = m_knownMapSize.size() * MapCanvas::SCROLL_SCALE;
 
     m_horizontalScrollBar->setRange(0, dims.x);
-    if (dims.x > 0 && m_scrollBarsVisible) {
+    if (dims.x > 0 && m_scrollBarsVisible.value_or(true)) {
         m_horizontalScrollBar->show();
     } else {
         m_horizontalScrollBar->hide();
     }
 
     m_verticalScrollBar->setRange(0, dims.y);
-    if (dims.y > 0 && m_scrollBarsVisible) {
+    if (dims.y > 0 && m_scrollBarsVisible.value_or(true)) {
         m_verticalScrollBar->show();
     } else {
         m_verticalScrollBar->hide();

--- a/src/display/mapwindow.cpp
+++ b/src/display/mapwindow.cpp
@@ -38,8 +38,6 @@ MapWindow::MapWindow(MapData &mapData, PrespammedPath &pp, Mmapper2Group &gm, QW
 
     m_gridLayout->addWidget(m_horizontalScrollBar.get(), 1, 0, 1, 1);
 
-    m_showScrollBars = std::nullopt;
-
     m_canvas = std::make_unique<MapCanvas>(mapData, pp, gm, this);
     MapCanvas *const canvas = m_canvas.get();
 
@@ -191,25 +189,19 @@ void MapWindow::slot_setScrollBars(const Coordinate &min, const Coordinate &max)
     updateScrollBars();
 }
 
-void MapWindow::setShowScrollBars(const bool show)
-{
-    m_showScrollBars = show;
-    updateScrollBars();
-}
-
 void MapWindow::updateScrollBars()
 {
     const auto dims = m_knownMapSize.size() * MapCanvas::SCROLL_SCALE;
-
+    const auto showScrollBars = getConfig().general.showScrollBars;
     m_horizontalScrollBar->setRange(0, dims.x);
-    if (dims.x > 0 && m_showScrollBars.value_or(true)) {
+    if (dims.x > 0 && showScrollBars) {
         m_horizontalScrollBar->show();
     } else {
         m_horizontalScrollBar->hide();
     }
 
     m_verticalScrollBar->setRange(0, dims.y);
-    if (dims.y > 0 && m_showScrollBars.value_or(true)) {
+    if (dims.y > 0 && showScrollBars) {
         m_verticalScrollBar->show();
     } else {
         m_verticalScrollBar->hide();

--- a/src/display/mapwindow.h
+++ b/src/display/mapwindow.h
@@ -69,12 +69,12 @@ protected:
     std::unique_ptr<QGridLayout> m_gridLayout;
     std::unique_ptr<QScrollBar> m_horizontalScrollBar;
     std::unique_ptr<QScrollBar> m_verticalScrollBar;
+    std::optional<bool> m_scrollBarsVisible;
     std::unique_ptr<MapCanvas> m_canvas;
 
 private:
     QPoint mousePressPos;
     QPoint scrollBarValuesOnMousePress;
-    bool m_scrollBarsVisible;
     struct NODISCARD KnownMapSize final
     {
         glm::ivec3 min{0};

--- a/src/display/mapwindow.h
+++ b/src/display/mapwindow.h
@@ -56,6 +56,7 @@ public slots:
     void slot_graphicsSettingsChanged();
 
 public:
+    void setScrollBarsVisible(const bool visible);
     void updateScrollBars();
     void setZoom(float zoom);
     float getZoom() const;
@@ -73,6 +74,7 @@ protected:
 private:
     QPoint mousePressPos;
     QPoint scrollBarValuesOnMousePress;
+    bool m_scrollBarsVisible;
     struct NODISCARD KnownMapSize final
     {
         glm::ivec3 min{0};

--- a/src/display/mapwindow.h
+++ b/src/display/mapwindow.h
@@ -13,7 +13,6 @@
 #include <QtGlobal>
 
 #include "../expandoracommon/coordinate.h"
-#include "../global/utils.h"
 #include "mapcanvas.h"
 
 class MapCanvas;
@@ -56,7 +55,6 @@ public slots:
     void slot_graphicsSettingsChanged();
 
 public:
-    void setShowScrollBars(const bool show);
     void updateScrollBars();
     void setZoom(float zoom);
     float getZoom() const;
@@ -69,7 +67,6 @@ protected:
     std::unique_ptr<QGridLayout> m_gridLayout;
     std::unique_ptr<QScrollBar> m_horizontalScrollBar;
     std::unique_ptr<QScrollBar> m_verticalScrollBar;
-    std::optional<bool> m_showScrollBars;
     std::unique_ptr<MapCanvas> m_canvas;
 
 private:

--- a/src/display/mapwindow.h
+++ b/src/display/mapwindow.h
@@ -56,7 +56,7 @@ public slots:
     void slot_graphicsSettingsChanged();
 
 public:
-    void setScrollBarsVisible(const bool visible);
+    void setShowScrollBars(const bool show);
     void updateScrollBars();
     void setZoom(float zoom);
     float getZoom() const;
@@ -69,7 +69,7 @@ protected:
     std::unique_ptr<QGridLayout> m_gridLayout;
     std::unique_ptr<QScrollBar> m_horizontalScrollBar;
     std::unique_ptr<QScrollBar> m_verticalScrollBar;
-    std::optional<bool> m_scrollBarsVisible;
+    std::optional<bool> m_showScrollBars;
     std::unique_ptr<MapCanvas> m_canvas;
 
 private:

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -309,6 +309,12 @@ MainWindow::MainWindow()
         alwaysOnTopAct->setChecked(true);
         setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
     }
+
+    showStatusBarAct->setChecked(getConfig().general.showStatusBar);
+    slot_setShowStatusBar();
+
+    showScrollBarsAct->setChecked(getConfig().general.showScrollBars);
+    slot_setShowScrollBars();
 }
 
 // depth-first recursively disconnect all children
@@ -647,12 +653,10 @@ void MainWindow::createActions()
 
     showStatusBarAct = new QAction(tr("Status Bar"), this);
     showStatusBarAct->setCheckable(true);
-    showStatusBarAct->setChecked(true);
     connect(showStatusBarAct, &QAction::triggered, this, &MainWindow::slot_setShowStatusBar);
 
     showScrollBarsAct = new QAction(tr("Scrollbars"), this);
     showScrollBarsAct->setCheckable(true);
-    showScrollBarsAct->setChecked(true);
     connect(showScrollBarsAct, &QAction::triggered, this, &MainWindow::slot_setShowScrollBars);
 
     layerUpAct = new QAction(QIcon::fromTheme("go-up", QIcon(":/icons/layerup.png")),
@@ -1314,7 +1318,7 @@ void MainWindow::slot_setShowStatusBar()
     const bool showStatusBar = this->showStatusBarAct->isChecked();
     qInfo() << "Setting showStatusBar to " << showStatusBar;
     statusBar()->setVisible(showStatusBar);
-    // TODO CONFIGsetConfig().general.alwaysOnTop = alwaysOnTop;
+    setConfig().general.showStatusBar= showStatusBar;
     show();
 }
 
@@ -1323,7 +1327,7 @@ void MainWindow::slot_setShowScrollBars()
     const bool showScrollBars = this->showScrollBarsAct->isChecked();
     qInfo() << "Setting showScrollBars to " << showScrollBars;
     m_mapWindow->setScrollBarsVisible(showScrollBars);
-    // TODO Config
+    setConfig().general.showScrollBars = showScrollBars;
     show();
 }
 

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -647,15 +647,15 @@ void MainWindow::createActions()
     zoomResetAct->setShortcut(tr("Ctrl+0"));
     zoomResetAct->setStatusTip(tr("Zoom to original size"));
 
-    alwaysOnTopAct = new QAction(tr("Always on top"), this);
+    alwaysOnTopAct = new QAction(tr("Always On Top"), this);
     alwaysOnTopAct->setCheckable(true);
     connect(alwaysOnTopAct, &QAction::triggered, this, &MainWindow::slot_alwaysOnTop);
 
-    showStatusBarAct = new QAction(tr("Status Bar"), this);
+    showStatusBarAct = new QAction(tr("Always Show Status Bar"), this);
     showStatusBarAct->setCheckable(true);
     connect(showStatusBarAct, &QAction::triggered, this, &MainWindow::slot_setShowStatusBar);
 
-    showScrollBarsAct = new QAction(tr("Scrollbars"), this);
+    showScrollBarsAct = new QAction(tr("Always Show Scrollbars"), this);
     showScrollBarsAct->setCheckable(true);
     connect(showScrollBarsAct, &QAction::triggered, this, &MainWindow::slot_setShowScrollBars);
 
@@ -1016,7 +1016,7 @@ void MainWindow::createActions()
     groupNetwork.groupNetworkGroup->addAction(groupNetwork.networkStartAct);
     groupNetwork.groupNetworkGroup->addAction(groupNetwork.networkStopAct);
 
-    rebuildMeshesAct = new QAction(QIcon(":/icons/graphicscfg.png"), tr("&Rebuild world"), this);
+    rebuildMeshesAct = new QAction(QIcon(":/icons/graphicscfg.png"), tr("&Rebuild World"), this);
     rebuildMeshesAct->setStatusTip(tr("Reconstruct the world mesh to fix graphical rendering bugs"));
     rebuildMeshesAct->setCheckable(false);
     connect(rebuildMeshesAct, &QAction::triggered, getCanvas(), &MapCanvas::mapAndInfomarksChanged);

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -645,6 +645,11 @@ void MainWindow::createActions()
     alwaysOnTopAct->setCheckable(true);
     connect(alwaysOnTopAct, &QAction::triggered, this, &MainWindow::slot_alwaysOnTop);
 
+    showStatusBarAct = new QAction(tr("Status Bar"), this);
+    showStatusBarAct->setCheckable(true);
+    showStatusBarAct->setChecked(true);
+    connect(showStatusBarAct, &QAction::triggered, this, &MainWindow::slot_setShowStatusBar);
+
     layerUpAct = new QAction(QIcon::fromTheme("go-up", QIcon(":/icons/layerup.png")),
                              tr("Layer Up"),
                              this);
@@ -1195,6 +1200,7 @@ void MainWindow::setupMenuBar()
     sidepanels->addAction(m_dockDialogClient->toggleViewAction());
     sidepanels->addAction(m_dockDialogGroup->toggleViewAction());
     sidepanels->addAction(m_dockDialogRoom->toggleViewAction());
+    viewMenu->addAction(showStatusBarAct);
     viewMenu->addSeparator();
     viewMenu->addAction(zoomInAct);
     viewMenu->addAction(zoomOutAct);
@@ -1294,6 +1300,15 @@ void MainWindow::slot_alwaysOnTop()
     qInfo() << "Setting AlwaysOnTop flag to " << alwaysOnTop;
     setWindowFlag(Qt::WindowStaysOnTopHint, alwaysOnTop);
     setConfig().general.alwaysOnTop = alwaysOnTop;
+    show();
+}
+
+void MainWindow::slot_setShowStatusBar()
+{
+    const bool showStatusBar = this->showStatusBarAct->isChecked();
+    qInfo() << "Setting showStatusBar to" << showStatusBar;
+    statusBar()->setVisible(showStatusBar);
+    // TODO CONFIGsetConfig().general.alwaysOnTop = alwaysOnTop;
     show();
 }
 

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -1316,7 +1316,6 @@ void MainWindow::slot_alwaysOnTop()
 void MainWindow::slot_setShowStatusBar()
 {
     const bool showStatusBar = this->showStatusBarAct->isChecked();
-    qInfo() << "Setting showStatusBar to " << showStatusBar;
     statusBar()->setVisible(showStatusBar);
     setConfig().general.showStatusBar= showStatusBar;
     show();
@@ -1325,7 +1324,6 @@ void MainWindow::slot_setShowStatusBar()
 void MainWindow::slot_setShowScrollBars()
 {
     const bool showScrollBars = this->showScrollBarsAct->isChecked();
-    qInfo() << "Setting showScrollBars to " << showScrollBars;
     m_mapWindow->setShowScrollBars(showScrollBars);
     setConfig().general.showScrollBars = showScrollBars;
     show();

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -1326,7 +1326,7 @@ void MainWindow::slot_setShowScrollBars()
 {
     const bool showScrollBars = this->showScrollBarsAct->isChecked();
     qInfo() << "Setting showScrollBars to " << showScrollBars;
-    m_mapWindow->setScrollBarsVisible(showScrollBars);
+    m_mapWindow->setShowScrollBars(showScrollBars);
     setConfig().general.showScrollBars = showScrollBars;
     show();
 }

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -1324,8 +1324,8 @@ void MainWindow::slot_setShowStatusBar()
 void MainWindow::slot_setShowScrollBars()
 {
     const bool showScrollBars = this->showScrollBarsAct->isChecked();
-    m_mapWindow->setShowScrollBars(showScrollBars);
     setConfig().general.showScrollBars = showScrollBars;
+    m_mapWindow->updateScrollBars();
     show();
 }
 

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -650,6 +650,11 @@ void MainWindow::createActions()
     showStatusBarAct->setChecked(true);
     connect(showStatusBarAct, &QAction::triggered, this, &MainWindow::slot_setShowStatusBar);
 
+    showScrollBarsAct = new QAction(tr("Scroll Bars"), this);
+    showScrollBarsAct->setCheckable(true);
+    showScrollBarsAct->setChecked(true);
+    connect(showScrollBarsAct, &QAction::triggered, this, &MainWindow::slot_setShowScrollBars);
+
     layerUpAct = new QAction(QIcon::fromTheme("go-up", QIcon(":/icons/layerup.png")),
                              tr("Layer Up"),
                              this);
@@ -1201,6 +1206,7 @@ void MainWindow::setupMenuBar()
     sidepanels->addAction(m_dockDialogGroup->toggleViewAction());
     sidepanels->addAction(m_dockDialogRoom->toggleViewAction());
     viewMenu->addAction(showStatusBarAct);
+    viewMenu->addAction(showScrollBarsAct);
     viewMenu->addSeparator();
     viewMenu->addAction(zoomInAct);
     viewMenu->addAction(zoomOutAct);
@@ -1306,9 +1312,18 @@ void MainWindow::slot_alwaysOnTop()
 void MainWindow::slot_setShowStatusBar()
 {
     const bool showStatusBar = this->showStatusBarAct->isChecked();
-    qInfo() << "Setting showStatusBar to" << showStatusBar;
+    qInfo() << "Setting showStatusBar to " << showStatusBar;
     statusBar()->setVisible(showStatusBar);
     // TODO CONFIGsetConfig().general.alwaysOnTop = alwaysOnTop;
+    show();
+}
+
+void MainWindow::slot_setShowScrollBars()
+{
+    const bool showScrollBars = this->showScrollBarsAct->isChecked();
+    qInfo() << "Setting showScrollBars to " << showScrollBars;
+    m_mapWindow->setScrollBarsVisible(showScrollBars);
+    // TODO Config
     show();
 }
 

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -650,7 +650,7 @@ void MainWindow::createActions()
     showStatusBarAct->setChecked(true);
     connect(showStatusBarAct, &QAction::triggered, this, &MainWindow::slot_setShowStatusBar);
 
-    showScrollBarsAct = new QAction(tr("Scroll Bars"), this);
+    showScrollBarsAct = new QAction(tr("Scrollbars"), this);
     showScrollBarsAct->setCheckable(true);
     showScrollBarsAct->setChecked(true);
     connect(showScrollBarsAct, &QAction::triggered, this, &MainWindow::slot_setShowScrollBars);
@@ -1205,8 +1205,6 @@ void MainWindow::setupMenuBar()
     sidepanels->addAction(m_dockDialogClient->toggleViewAction());
     sidepanels->addAction(m_dockDialogGroup->toggleViewAction());
     sidepanels->addAction(m_dockDialogRoom->toggleViewAction());
-    viewMenu->addAction(showStatusBarAct);
-    viewMenu->addAction(showScrollBarsAct);
     viewMenu->addSeparator();
     viewMenu->addAction(zoomInAct);
     viewMenu->addAction(zoomOutAct);
@@ -1218,6 +1216,8 @@ void MainWindow::setupMenuBar()
     viewMenu->addSeparator();
     viewMenu->addAction(rebuildMeshesAct);
     viewMenu->addSeparator();
+    viewMenu->addAction(showStatusBarAct);
+    viewMenu->addAction(showScrollBarsAct);
     viewMenu->addAction(alwaysOnTopAct);
 
     settingsMenu = menuBar()->addMenu(tr("&Tools"));

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -1317,7 +1317,7 @@ void MainWindow::slot_setShowStatusBar()
 {
     const bool showStatusBar = this->showStatusBarAct->isChecked();
     statusBar()->setVisible(showStatusBar);
-    setConfig().general.showStatusBar= showStatusBar;
+    setConfig().general.showStatusBar = showStatusBar;
     show();
 }
 

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -123,6 +123,7 @@ public slots:
     void slot_onOfflineMode();
     void slot_setMode(MapModeEnum mode);
     void slot_alwaysOnTop();
+    void slot_setShowStatusBar();
 
     void slot_newRoomSelection(const SigRoomSelection &);
     void slot_newConnectionSelection(ConnectionSelection *);
@@ -233,6 +234,7 @@ private:
     QAction *zoomOutAct = nullptr;
     QAction *zoomResetAct = nullptr;
     QAction *alwaysOnTopAct = nullptr;
+    QAction *showStatusBarAct = nullptr;
     QAction *preferencesAct = nullptr;
 
     QAction *layerUpAct = nullptr;

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -124,6 +124,7 @@ public slots:
     void slot_setMode(MapModeEnum mode);
     void slot_alwaysOnTop();
     void slot_setShowStatusBar();
+    void slot_setShowScrollBars();
 
     void slot_newRoomSelection(const SigRoomSelection &);
     void slot_newConnectionSelection(ConnectionSelection *);
@@ -235,6 +236,7 @@ private:
     QAction *zoomResetAct = nullptr;
     QAction *alwaysOnTopAct = nullptr;
     QAction *showStatusBarAct = nullptr;
+    QAction *showScrollBarsAct = nullptr;
     QAction *preferencesAct = nullptr;
 
     QAction *layerUpAct = nullptr;


### PR DESCRIPTION
Fixes #251 

Some exploratory and trivial tweaks to enable a menu option under View... for hiding the Status Bar and Scroll Bars. I just followed the general pattern of alwaysOnTop.

One conscious design decision: currently in the MainWindow constructor when it fetches the config value for alwaysOnTop, it inlines the code to manage that setting directly. I thought it made more sense to invoke the slot handler rather than copy-paste code. But eager for guidance here. 

Funny thing on naming: do we call it Scrollbars? ScrollBars? Scroll Bars? Currently in the app we say "Status Bar" but also "Toolbar". @nschimme please decide!

LMK on the debug messages I can delete them.

Also should I squash commits? Forgive my verbose commit style I haven't submitted a PR in 10 years.
