### PR TITLE
Requesting Discussion: game communication window to show narrates and tells

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,8 @@ set(mmapper_SRCS
     main.cpp
     adventure/adventurejournal.cpp
     adventure/adventurejournal.h
+    adventure/commswidget.cpp
+    adventure/commswidget.h
     client/ClientTelnet.cpp
     client/ClientTelnet.h
     client/ClientWidget.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(mmapper_SRCS
     main.cpp
+    adventure/adventurejournal.cpp
+    adventure/adventurejournal.h
     client/ClientTelnet.cpp
     client/ClientTelnet.h
     client/ClientWidget.cpp

--- a/src/adventure/adventurejournal.cpp
+++ b/src/adventure/adventurejournal.cpp
@@ -1,0 +1,39 @@
+#include "adventurejournal.h"
+#include "global/TextUtils.h"
+#include "parser/parserutils.h"
+
+#include <QDebug>
+
+AdventureJournal::AdventureJournal(QObject *const parent)
+    : QObject{parent}
+{}
+
+AdventureJournal::~AdventureJournal()
+{
+    //m_debugFile.flush();
+    //m_debugFile.close();
+}
+
+void AdventureJournal::slot_updateJournal(const QByteArray &ba)
+{
+    //qDebug() << "AdventureJournal::slot_updateJournal called";
+
+    // Remove ANSI and convert to UTF-8
+    QString str = QString::fromLatin1(ba).trimmed();
+    ParserUtils::removeAnsiMarksInPlace(str);
+    //QString line = ::toStdStringUtf8(str);
+
+    auto idx_isdead = str.indexOf(" is dead! R.I.P.");
+    if (idx_isdead > 0) {
+        qDebug().noquote() << "AdventureJournal: player killed: " << str.left(idx_isdead);
+    }
+
+    if(str.contains("You gain a level!")) {
+        qDebug().noquote() << "AdventureJournal: player gained a level!";
+    }
+
+    if(str.contains("tells you") or str.contains("narrates")) {
+        qDebug().noquote() << "Adventure Journal: comm received: " << str;
+        m_commsList.append(str);
+    }
+}

--- a/src/adventure/adventurejournal.cpp
+++ b/src/adventure/adventurejournal.cpp
@@ -35,5 +35,6 @@ void AdventureJournal::slot_updateJournal(const QByteArray &ba)
     if(str.contains("tells you") or str.contains("narrates")) {
         qDebug().noquote() << "Adventure Journal: comm received: " << str;
         m_commsList.append(str);
+        emit sig_receivedComm(str);
     }
 }

--- a/src/adventure/adventurejournal.h
+++ b/src/adventure/adventurejournal.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <fstream>
+#include <QObject>
+
+class AdventureJournal final : public QObject
+{
+    Q_OBJECT
+public:
+    explicit AdventureJournal(QObject * const parent = nullptr);
+    ~AdventureJournal() final;
+
+public slots:
+    void slot_updateJournal(const QByteArray &ba);
+
+private:
+    std::fstream m_debugFile;
+    QList<QString> m_commsList;
+};
+
+

--- a/src/adventure/adventurejournal.h
+++ b/src/adventure/adventurejournal.h
@@ -10,6 +10,9 @@ public:
     explicit AdventureJournal(QObject * const parent = nullptr);
     ~AdventureJournal() final;
 
+signals:
+    void sig_receivedComm(const QString &comm);
+
 public slots:
     void slot_updateJournal(const QByteArray &ba);
 

--- a/src/adventure/commswidget.cpp
+++ b/src/adventure/commswidget.cpp
@@ -4,16 +4,29 @@
 
 #include "commswidget.h"
 
-CommsWidget::CommsWidget(QWidget *parent)
-    : QWidget{parent}
+CommsWidget::CommsWidget(AdventureJournal &aj, QWidget *parent)
+    : QWidget{parent},
+      m_adventureJournal{aj}
 {
     auto *layout = new QVBoxLayout(this);
     layout->setAlignment(Qt::AlignTop);
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(0);
 
-    auto *textEdit = new QTextEdit(this);
-    textEdit->setPlainText("comms will go here");
+    m_commsTextEdit = new QTextEdit(this);
+    m_commsTextEdit->setPlainText("comms will go here");
 
-    layout->addWidget(textEdit);
+    layout->addWidget(m_commsTextEdit);
+
+    connect(&m_adventureJournal,
+            &AdventureJournal::sig_receivedComm,
+            this,
+            &CommsWidget::slot_onCommReceived,
+            Qt::QueuedConnection);
+}
+
+void CommsWidget::slot_onCommReceived(const QString &data)
+{
+    m_commsTextEdit->append(data);
+
 }

--- a/src/adventure/commswidget.cpp
+++ b/src/adventure/commswidget.cpp
@@ -1,0 +1,19 @@
+
+#include <QtCore>
+#include <QtWidgets>
+
+#include "commswidget.h"
+
+CommsWidget::CommsWidget(QWidget *parent)
+    : QWidget{parent}
+{
+    auto *layout = new QVBoxLayout(this);
+    layout->setAlignment(Qt::AlignTop);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(0);
+
+    auto *textEdit = new QTextEdit(this);
+    textEdit->setPlainText("comms will go here");
+
+    layout->addWidget(textEdit);
+}

--- a/src/adventure/commswidget.h
+++ b/src/adventure/commswidget.h
@@ -1,0 +1,16 @@
+#ifndef COMMSWINDOW_H
+#define COMMSWINDOW_H
+
+#include <QWidget>
+
+class CommsWidget : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit CommsWidget(QWidget *parent = nullptr);
+
+signals:
+
+};
+
+#endif // COMMSWINDOW_H

--- a/src/adventure/commswidget.h
+++ b/src/adventure/commswidget.h
@@ -1,16 +1,19 @@
-#ifndef COMMSWINDOW_H
-#define COMMSWINDOW_H
+#pragma once
 
+#include "adventure/adventurejournal.h"
+#include <QtWidgets>
 #include <QWidget>
 
 class CommsWidget : public QWidget
 {
     Q_OBJECT
 public:
-    explicit CommsWidget(QWidget *parent = nullptr);
+    explicit CommsWidget(AdventureJournal &aj, QWidget *parent = nullptr);
 
-signals:
+public slots:
+    void slot_onCommReceived(const QString &data);
 
+private:
+    AdventureJournal &m_adventureJournal;
+    QTextEdit *m_commsTextEdit = nullptr;
 };
-
-#endif // COMMSWINDOW_H

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -70,6 +70,7 @@
 #include "UpdateDialog.h"
 #include "aboutdialog.h"
 #include "adventure/adventurejournal.h"
+#include "adventure/commswidget.h"
 #include "findroomsdlg.h"
 #include "infomarkseditdlg.h"
 #include "roomeditattrdlg.h"
@@ -254,6 +255,18 @@ MainWindow::MainWindow()
     addDockWidget(Qt::BottomDockWidgetArea, m_dockDialogRoom);
     m_dockDialogRoom->setWidget(m_roomWidget);
     m_dockDialogRoom->hide();
+
+    m_commsWidget = new CommsWidget(this);
+    m_dockDialogComms = new QDockWidget(tr("Comms"), this);
+    m_dockDialogComms->setObjectName("DockWidgetComms");
+    m_dockDialogComms->setAllowedAreas(Qt::BottomDockWidgetArea
+                                       | Qt::TopDockWidgetArea);
+    m_dockDialogComms->setFeatures(QDockWidget::DockWidgetClosable
+                                   | QDockWidget::DockWidgetFloatable
+                                   | QDockWidget::DockWidgetMovable);
+    addDockWidget(Qt::BottomDockWidgetArea, m_dockDialogComms);
+    m_dockDialogComms->setWidget(m_commsWidget);
+    m_dockDialogComms->show();
 
     m_findRoomsDlg = new FindRoomsDlg(mapData, this);
     m_findRoomsDlg->setObjectName("FindRoomsDlg");

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -69,6 +69,7 @@
 #include "../roompanel/RoomWidget.h"
 #include "UpdateDialog.h"
 #include "aboutdialog.h"
+#include "adventure/adventurejournal.h"
 #include "findroomsdlg.h"
 #include "infomarkseditdlg.h"
 #include "roomeditattrdlg.h"
@@ -272,6 +273,7 @@ MainWindow::MainWindow()
     setCorner(Qt::BottomRightCorner, Qt::BottomDockWidgetArea);
 
     m_logger = new AutoLogger(this);
+    m_adventureJournal = new AdventureJournal(this);
 
     m_listener = new ConnectionListener(mapData,
                                         deref(m_pathMachine),
@@ -280,6 +282,7 @@ MainWindow::MainWindow()
                                         deref(m_roomManager),
                                         deref(m_mumeClock),
                                         deref(m_logger),
+                                        deref(m_adventureJournal),
                                         deref(getCanvas()),
                                         this);
 

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -256,7 +256,8 @@ MainWindow::MainWindow()
     m_dockDialogRoom->setWidget(m_roomWidget);
     m_dockDialogRoom->hide();
 
-    m_commsWidget = new CommsWidget(this);
+    m_adventureJournal = new AdventureJournal(this);
+    m_commsWidget = new CommsWidget(deref(m_adventureJournal), this);
     m_dockDialogComms = new QDockWidget(tr("Comms"), this);
     m_dockDialogComms->setObjectName("DockWidgetComms");
     m_dockDialogComms->setAllowedAreas(Qt::BottomDockWidgetArea
@@ -286,7 +287,6 @@ MainWindow::MainWindow()
     setCorner(Qt::BottomRightCorner, Qt::BottomDockWidgetArea);
 
     m_logger = new AutoLogger(this);
-    m_adventureJournal = new AdventureJournal(this);
 
     m_listener = new ConnectionListener(mapData,
                                         deref(m_pathMachine),

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -27,6 +27,7 @@ class AutoLogger;
 class AbstractAction;
 class AdventureJournal;
 class ClientWidget;
+class CommsWidget;
 class ConfigDialog;
 class ConnectionListener;
 class ConnectionSelection;
@@ -164,6 +165,7 @@ private:
     QDockWidget *m_dockDialogLog = nullptr;
     QDockWidget *m_dockDialogGroup = nullptr;
     QDockWidget *m_dockDialogClient = nullptr;
+    QDockWidget *m_dockDialogComms = nullptr;
 
     AutoLogger *m_logger = nullptr;
     AdventureJournal *m_adventureJournal = nullptr;
@@ -180,6 +182,8 @@ private:
 
     RoomWidget *m_roomWidget = nullptr;
     RoomManager *m_roomManager = nullptr;
+
+    CommsWidget *m_commsWidget = nullptr;
 
     ClientWidget *m_clientWidget = nullptr;
     UpdateDialog *m_updateDialog = nullptr;

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -25,6 +25,7 @@
 
 class AutoLogger;
 class AbstractAction;
+class AdventureJournal;
 class ClientWidget;
 class ConfigDialog;
 class ConnectionListener;
@@ -165,6 +166,7 @@ private:
     QDockWidget *m_dockDialogClient = nullptr;
 
     AutoLogger *m_logger = nullptr;
+    AdventureJournal *m_adventureJournal = nullptr;
     ConnectionListener *m_listener = nullptr;
     Mmapper2PathMachine *m_pathMachine = nullptr;
     MapData *m_mapData = nullptr;

--- a/src/proxy/connectionlistener.cpp
+++ b/src/proxy/connectionlistener.cpp
@@ -32,6 +32,7 @@ ConnectionListener::ConnectionListener(MapData &md,
                                        RoomManager &rm,
                                        MumeClock &mc,
                                        AutoLogger &al,
+                                       AdventureJournal &aj,
                                        MapCanvas &mca,
                                        QObject *const parent)
     : QObject(parent)
@@ -42,6 +43,7 @@ ConnectionListener::ConnectionListener(MapData &md,
     , m_roomManager{rm}
     , m_mumeClock{mc}
     , m_autoLogger{al}
+    , m_adventureJournal{aj}
     , m_mapCanvas{mca}
 {}
 
@@ -106,6 +108,7 @@ void ConnectionListener::slot_onIncomingConnection(qintptr socketDescriptor)
                                           m_roomManager,
                                           m_mumeClock,
                                           m_autoLogger,
+                                          m_adventureJournal,
                                           m_mapCanvas,
                                           socketDescriptor,
                                           *this);

--- a/src/proxy/connectionlistener.h
+++ b/src/proxy/connectionlistener.h
@@ -15,6 +15,7 @@
 #include <QtGlobal>
 
 class AutoLogger;
+class AdventureJournal;
 class ConnectionListener;
 class MapCanvas;
 class MapData;
@@ -52,6 +53,7 @@ public:
                                 RoomManager &,
                                 MumeClock &,
                                 AutoLogger &,
+                                AdventureJournal &,
                                 MapCanvas &,
                                 QObject *parent);
     ~ConnectionListener() final;
@@ -80,6 +82,7 @@ private:
     RoomManager &m_roomManager;
     MumeClock &m_mumeClock;
     AutoLogger &m_autoLogger;
+    AdventureJournal &m_adventureJournal;
     MapCanvas &m_mapCanvas;
     using ServerList = std::vector<QPointer<ConnectionListenerTcpServer>>;
     ServerList m_servers;

--- a/src/proxy/proxy.cpp
+++ b/src/proxy/proxy.cpp
@@ -34,6 +34,7 @@
 #include "GmcpUtils.h"
 #include "MudTelnet.h"
 #include "UserTelnet.h"
+#include "adventure/adventurejournal.h"
 #include "connectionlistener.h"
 #include "mumesocket.h"
 #include "telnetfilter.h"
@@ -57,6 +58,7 @@ Proxy::Proxy(MapData &md,
              RoomManager &rm,
              MumeClock &mc,
              AutoLogger &al,
+             AdventureJournal &aj,
              MapCanvas &mca,
              qintptr &socketDescriptor,
              ConnectionListener &listener)
@@ -68,6 +70,7 @@ Proxy::Proxy(MapData &md,
     , m_roomManager(rm)
     , m_mumeClock(mc)
     , m_logger(al)
+    , m_adventureJournal(aj)
     , m_mapCanvas(mca)
     , m_listener(listener)
     , m_socketDescriptor(socketDescriptor)
@@ -201,6 +204,9 @@ void Proxy::slot_start()
     connect(parserXml, &MumeXmlParser::sig_sendToMud, &m_logger, &AutoLogger::slot_writeToLog);
     connect(mudTelnet, &MudTelnet::sig_relayEchoMode, &m_logger, &AutoLogger::slot_shouldLog);
     connect(mudSocket, &MumeSocket::sig_connected, &m_logger, &AutoLogger::slot_onConnected);
+
+    connect(parserXml, &MumeXmlParser::sig_sendToUser, &m_adventureJournal, &AdventureJournal::slot_updateJournal);
+    connect(parserXml, &MumeXmlParser::sig_sendToMud, &m_adventureJournal, &AdventureJournal::slot_updateJournal);
 
     connect(parserXml,
             &MumeXmlParser::sig_handleParseEvent,

--- a/src/proxy/proxy.h
+++ b/src/proxy/proxy.h
@@ -21,6 +21,7 @@
 #include "ProxyParserApi.h"
 
 class AutoLogger;
+class AdventureJournal;
 class ConnectionListener;
 class MapCanvas;
 class MapData;
@@ -51,6 +52,7 @@ public:
                    RoomManager &,
                    MumeClock &,
                    AutoLogger &,
+                   AdventureJournal &,
                    MapCanvas &,
                    qintptr &,
                    ConnectionListener &);
@@ -105,6 +107,7 @@ private:
     RoomManager &m_roomManager;
     MumeClock &m_mumeClock;
     AutoLogger &m_logger;
+    AdventureJournal &m_adventureJournal;
     MapCanvas &m_mapCanvas;
     ConnectionListener &m_listener;
     const qintptr m_socketDescriptor;


### PR DESCRIPTION
Just a crude proof of concept now, but I'm filing a PR to request some discussion and architectural alignment. 

The prevailing pattern we have now is that new windows/sidepanels and features (AutoLogger, RoomManager, and more) are passed all the way into ConnectionListener and ultimately the Proxy class for wiring up the key signals/slots directly from the parsers and telnet clients. I propose a better solution might be:
- Have a single `GameObserver` which watches all game play (both raw text lines sent/received and gmcp as well) and then can emit to listeners.
- All "downstream" features/widgets (like AutoLogger, RoomManager, GameComms (this PR) and more) could register with the Observer and receive signals from it.
- This would simplify the code (and eliminate the verbose constructor chains) and allow us to consolidate common "listener" code, thread proxying, etc.

Concretely, my proposal would be to:
 - Take the current AutoLogger code and refactor that, splitting it out into GameObserver and a new, listening AutoLogger
 - Register my CommsWindow and perhaps the RoomManager (and others) as listeners to the Observer

What do you guys think? If you want to avoid this refactoring now that's totally ok, just felt a bit inelegant to be adding Yet Another Constructor Chained Manager so thought I would ask.

<img width="585" alt="Screen Shot 2022-12-31 at 4 50 16 PM" src="https://user-images.githubusercontent.com/56870/210158385-6624960c-9844-4d61-8e3e-61fb62b34ca4.png">
