### PR TITLE
Game Observer (Refactoring, no-op)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -200,6 +200,8 @@ set(mmapper_SRCS
     mpi/remoteeditsession.h
     mpi/remoteeditwidget.cpp
     mpi/remoteeditwidget.h
+    observer/gameobserver.cpp
+    observer/gameobserver.h
     opengl/Font.cpp
     opengl/Font.h
     opengl/FontFormatFlags.h

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -247,7 +247,6 @@ MainWindow::MainWindow()
     m_roomManager = new RoomManager(this);
     m_roomManager->setObjectName("RoomManager");
     connect(m_gameObserver, &GameObserver::sig_sentToUserGmcp, m_roomManager, &RoomManager::slot_parseGmcpInput);
-
     m_roomWidget = new RoomWidget(deref(m_roomManager), this);
     m_dockDialogRoom = new QDockWidget(tr("Room Panel"), this);
     m_dockDialogRoom->setObjectName("DockWidgetRoom");
@@ -276,13 +275,16 @@ MainWindow::MainWindow()
     setCorner(Qt::BottomRightCorner, Qt::BottomDockWidgetArea);
 
     m_logger = new AutoLogger(this);
+    connect(m_gameObserver, &GameObserver::sig_connected, m_logger, &AutoLogger::slot_onConnected);
+    connect(m_gameObserver, &GameObserver::sig_toggledEchoMode, m_logger, &AutoLogger::slot_shouldLog);
+    connect(m_gameObserver, &GameObserver::sig_sentToMudText, m_logger, &AutoLogger::slot_writeToLog);
+    connect(m_gameObserver, &GameObserver::sig_sentToUserText, m_logger, &AutoLogger::slot_writeToLog);
 
     m_listener = new ConnectionListener(mapData,
                                         deref(m_pathMachine),
                                         deref(m_prespammedPath),
                                         deref(m_groupManager),
                                         deref(m_mumeClock),
-                                        deref(m_logger),
                                         deref(getCanvas()),
                                         deref(m_gameObserver),
                                         this);

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -246,6 +246,8 @@ MainWindow::MainWindow()
 
     m_roomManager = new RoomManager(this);
     m_roomManager->setObjectName("RoomManager");
+    connect(m_gameObserver, &GameObserver::sig_sentToUserGmcp, m_roomManager, &RoomManager::slot_parseGmcpInput);
+
     m_roomWidget = new RoomWidget(deref(m_roomManager), this);
     m_dockDialogRoom = new QDockWidget(tr("Room Panel"), this);
     m_dockDialogRoom->setObjectName("DockWidgetRoom");
@@ -279,7 +281,6 @@ MainWindow::MainWindow()
                                         deref(m_pathMachine),
                                         deref(m_prespammedPath),
                                         deref(m_groupManager),
-                                        deref(m_roomManager),
                                         deref(m_mumeClock),
                                         deref(m_logger),
                                         deref(getCanvas()),

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -246,7 +246,10 @@ MainWindow::MainWindow()
 
     m_roomManager = new RoomManager(this);
     m_roomManager->setObjectName("RoomManager");
-    connect(m_gameObserver, &GameObserver::sig_sentToUserGmcp, m_roomManager, &RoomManager::slot_parseGmcpInput);
+    connect(m_gameObserver,
+            &GameObserver::sig_sentToUserGmcp,
+            m_roomManager,
+            &RoomManager::slot_parseGmcpInput);
     m_roomWidget = new RoomWidget(deref(m_roomManager), this);
     m_dockDialogRoom = new QDockWidget(tr("Room Panel"), this);
     m_dockDialogRoom->setObjectName("DockWidgetRoom");
@@ -276,9 +279,18 @@ MainWindow::MainWindow()
 
     m_logger = new AutoLogger(this);
     connect(m_gameObserver, &GameObserver::sig_connected, m_logger, &AutoLogger::slot_onConnected);
-    connect(m_gameObserver, &GameObserver::sig_toggledEchoMode, m_logger, &AutoLogger::slot_shouldLog);
-    connect(m_gameObserver, &GameObserver::sig_sentToMudText, m_logger, &AutoLogger::slot_writeToLog);
-    connect(m_gameObserver, &GameObserver::sig_sentToUserText, m_logger, &AutoLogger::slot_writeToLog);
+    connect(m_gameObserver,
+            &GameObserver::sig_toggledEchoMode,
+            m_logger,
+            &AutoLogger::slot_shouldLog);
+    connect(m_gameObserver,
+            &GameObserver::sig_sentToMudText,
+            m_logger,
+            &AutoLogger::slot_writeToLog);
+    connect(m_gameObserver,
+            &GameObserver::sig_sentToUserText,
+            m_logger,
+            &AutoLogger::slot_writeToLog);
 
     m_listener = new ConnectionListener(mapData,
                                         deref(m_pathMachine),

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -206,6 +206,8 @@ MainWindow::MainWindow()
     m_pathMachine = new Mmapper2PathMachine(m_mapData, this);
     m_pathMachine->setObjectName("Mmapper2PathMachine");
 
+    m_gameObserver = new GameObserver(this);
+
     m_clientWidget = new ClientWidget(this);
     m_clientWidget->setObjectName("InternalMudClientWidget");
     m_dockDialogClient = new QDockWidget("Client Panel", this);
@@ -281,6 +283,7 @@ MainWindow::MainWindow()
                                         deref(m_mumeClock),
                                         deref(m_logger),
                                         deref(getCanvas()),
+                                        deref(m_gameObserver),
                                         this);
 
     // update connections

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -22,6 +22,7 @@
 #include "../display/CanvasMouseModeEnum.h"
 #include "../mapdata/roomselection.h"
 #include "../pandoragroup/mmapper2group.h"
+#include "observer/gameobserver.h"
 
 class AutoLogger;
 class AbstractAction;
@@ -164,6 +165,7 @@ private:
     QDockWidget *m_dockDialogGroup = nullptr;
     QDockWidget *m_dockDialogClient = nullptr;
 
+    GameObserver *m_gameObserver = nullptr;
     AutoLogger *m_logger = nullptr;
     ConnectionListener *m_listener = nullptr;
     Mmapper2PathMachine *m_pathMachine = nullptr;

--- a/src/observer/gameobserver.cpp
+++ b/src/observer/gameobserver.cpp
@@ -14,7 +14,18 @@ void GameObserver::slot_sendToUser(const QByteArray &ba, bool goAhead)
     emit sig_sendToUser(ba, goAhead);
 }
 
+void GameObserver::slot_sendGmcpToMud(const GmcpMessage &m)
+{
+    emit sig_sendGmcpToMud(m);
+}
+
+void GameObserver::slot_sendGmcpToUser(const GmcpMessage &m)
+{
+    emit sig_sendGmcpToUser(m);
+}
+
 void GameObserver::slot_log(const QString &ba, const QString &s)
 {
     emit sig_log(ba, s);
 }
+

--- a/src/observer/gameobserver.cpp
+++ b/src/observer/gameobserver.cpp
@@ -43,4 +43,3 @@ void GameObserver::slot_log(const QString &ba, const QString &s)
 {
     emit sig_log(ba, s);
 }
-

--- a/src/observer/gameobserver.cpp
+++ b/src/observer/gameobserver.cpp
@@ -1,0 +1,20 @@
+#include "gameobserver.h"
+
+GameObserver::GameObserver(QObject *parent)
+    : QObject{parent}
+{}
+
+void GameObserver::slot_sendtoMud(const QByteArray &ba)
+{
+    emit sig_sendToMud(ba);
+}
+
+void GameObserver::slot_sendToUser(const QByteArray &ba, bool goAhead)
+{
+    emit sig_sendToUser(ba, goAhead);
+}
+
+void GameObserver::slot_log(const QString &ba, const QString &s)
+{
+    emit sig_log(ba, s);
+}

--- a/src/observer/gameobserver.cpp
+++ b/src/observer/gameobserver.cpp
@@ -4,6 +4,16 @@ GameObserver::GameObserver(QObject *parent)
     : QObject{parent}
 {}
 
+void GameObserver::slot_observeConnected()
+{
+    emit sig_connected();
+}
+
+void GameObserver::slot_observeDisconnected()
+{
+    emit sig_disconnected();
+}
+
 void GameObserver::slot_observeSentToMudText(const QByteArray &ba)
 {
     emit sig_sentToMudText(ba);
@@ -22,6 +32,11 @@ void GameObserver::slot_observeSentToMudGmcp(const GmcpMessage &m)
 void GameObserver::slot_observeSentToUserGmcp(const GmcpMessage &m)
 {
     emit sig_sentToUserGmcp(m);
+}
+
+void GameObserver::slot_observeToggledEchoMode(bool echo)
+{
+    emit sig_toggledEchoMode(echo);
 }
 
 void GameObserver::slot_log(const QString &ba, const QString &s)

--- a/src/observer/gameobserver.cpp
+++ b/src/observer/gameobserver.cpp
@@ -4,24 +4,24 @@ GameObserver::GameObserver(QObject *parent)
     : QObject{parent}
 {}
 
-void GameObserver::slot_sendtoMud(const QByteArray &ba)
+void GameObserver::slot_observeSentToMudText(const QByteArray &ba)
 {
-    emit sig_sendToMud(ba);
+    emit sig_sentToMudText(ba);
 }
 
-void GameObserver::slot_sendToUser(const QByteArray &ba, bool goAhead)
+void GameObserver::slot_observeSentToUserText(const QByteArray &ba, bool goAhead)
 {
-    emit sig_sendToUser(ba, goAhead);
+    emit sig_sentToUserText(ba, goAhead);
 }
 
-void GameObserver::slot_sendGmcpToMud(const GmcpMessage &m)
+void GameObserver::slot_observeSentToMudGmcp(const GmcpMessage &m)
 {
-    emit sig_sendGmcpToMud(m);
+    emit sig_sentToMudGmcp(m);
 }
 
-void GameObserver::slot_sendGmcpToUser(const GmcpMessage &m)
+void GameObserver::slot_observeSentToUserGmcp(const GmcpMessage &m)
 {
-    emit sig_sendGmcpToUser(m);
+    emit sig_sentToUserGmcp(m);
 }
 
 void GameObserver::slot_log(const QString &ba, const QString &s)

--- a/src/observer/gameobserver.h
+++ b/src/observer/gameobserver.h
@@ -1,5 +1,4 @@
-#ifndef GAMEOBSERVER_H
-#define GAMEOBSERVER_H
+#pragma once
 
 #include "proxy/GmcpMessage.h"
 #include <QObject>
@@ -39,5 +38,3 @@ public slots:
 
     void slot_log(const QString &ba, const QString &);
 };
-
-#endif // GAMEOBSERVER_H

--- a/src/observer/gameobserver.h
+++ b/src/observer/gameobserver.h
@@ -1,0 +1,28 @@
+#ifndef GAMEOBSERVER_H
+#define GAMEOBSERVER_H
+
+#include <QObject>
+
+class GameObserver : public QObject
+{
+    Q_OBJECT
+public:
+    explicit GameObserver(QObject *parent = nullptr);
+
+signals:
+    void sig_sendToMud(const QByteArray &);
+    void sig_sendToUser(const QByteArray &, bool goAhead);
+    //void sig_mapChanged();
+    //void sig_graphicsSettingsChanged();
+    //void sig_releaseAllPaths();
+
+    // used to log
+    void sig_log(const QString &, const QString &);
+
+public slots:
+    void slot_sendtoMud(const QByteArray &ba);
+    void slot_sendToUser(const QByteArray &ba, bool goAhead);
+    void slot_log(const QString &ba, const QString &);
+};
+
+#endif // GAMEOBSERVER_H

--- a/src/observer/gameobserver.h
+++ b/src/observer/gameobserver.h
@@ -1,6 +1,7 @@
 #ifndef GAMEOBSERVER_H
 #define GAMEOBSERVER_H
 
+#include "proxy/GmcpMessage.h"
 #include <QObject>
 
 class GameObserver : public QObject
@@ -12,6 +13,9 @@ public:
 signals:
     void sig_sendToMud(const QByteArray &);
     void sig_sendToUser(const QByteArray &, bool goAhead);
+
+    void sig_sendGmcpToMud(const GmcpMessage &);
+    void sig_sendGmcpToUser(const GmcpMessage &);
     //void sig_mapChanged();
     //void sig_graphicsSettingsChanged();
     //void sig_releaseAllPaths();
@@ -22,6 +26,8 @@ signals:
 public slots:
     void slot_sendtoMud(const QByteArray &ba);
     void slot_sendToUser(const QByteArray &ba, bool goAhead);
+    void slot_sendGmcpToMud(const GmcpMessage &m);
+    void slot_sendGmcpToUser(const GmcpMessage &m);
     void slot_log(const QString &ba, const QString &);
 };
 

--- a/src/observer/gameobserver.h
+++ b/src/observer/gameobserver.h
@@ -11,11 +11,12 @@ public:
     explicit GameObserver(QObject *parent = nullptr);
 
 signals:
-    void sig_sendToMud(const QByteArray &);
-    void sig_sendToUser(const QByteArray &, bool goAhead);
+    void sig_sentToMudText(const QByteArray &);
+    void sig_sentToUserText(const QByteArray &, bool goAhead);
 
-    void sig_sendGmcpToMud(const GmcpMessage &);
-    void sig_sendGmcpToUser(const GmcpMessage &);
+    void sig_sentToMudGmcp(const GmcpMessage &);
+    void sig_sentToUserGmcp(const GmcpMessage &);
+
     //void sig_mapChanged();
     //void sig_graphicsSettingsChanged();
     //void sig_releaseAllPaths();
@@ -24,10 +25,12 @@ signals:
     void sig_log(const QString &, const QString &);
 
 public slots:
-    void slot_sendtoMud(const QByteArray &ba);
-    void slot_sendToUser(const QByteArray &ba, bool goAhead);
-    void slot_sendGmcpToMud(const GmcpMessage &m);
-    void slot_sendGmcpToUser(const GmcpMessage &m);
+    void slot_observeSentToMudText(const QByteArray &ba);
+    void slot_observeSentToUserText(const QByteArray &ba, bool goAhead);
+
+    void slot_observeSentToMudGmcp(const GmcpMessage &m);
+    void slot_observeSentToUserGmcp(const GmcpMessage &m);
+
     void slot_log(const QString &ba, const QString &);
 };
 

--- a/src/observer/gameobserver.h
+++ b/src/observer/gameobserver.h
@@ -11,25 +11,31 @@ public:
     explicit GameObserver(QObject *parent = nullptr);
 
 signals:
+    void sig_connected();
+    void sig_disconnected();
+
     void sig_sentToMudText(const QByteArray &);
     void sig_sentToUserText(const QByteArray &, bool goAhead);
 
     void sig_sentToMudGmcp(const GmcpMessage &);
     void sig_sentToUserGmcp(const GmcpMessage &);
 
-    //void sig_mapChanged();
-    //void sig_graphicsSettingsChanged();
-    //void sig_releaseAllPaths();
+    void sig_toggledEchoMode(bool echo);
 
     // used to log
     void sig_log(const QString &, const QString &);
 
 public slots:
+    void slot_observeConnected();
+    void slot_observeDisconnected();
+
     void slot_observeSentToMudText(const QByteArray &ba);
     void slot_observeSentToUserText(const QByteArray &ba, bool goAhead);
 
     void slot_observeSentToMudGmcp(const GmcpMessage &m);
     void slot_observeSentToUserGmcp(const GmcpMessage &m);
+
+    void slot_observeToggledEchoMode(bool echo);
 
     void slot_log(const QString &ba, const QString &);
 };

--- a/src/proxy/connectionlistener.cpp
+++ b/src/proxy/connectionlistener.cpp
@@ -30,7 +30,6 @@ ConnectionListener::ConnectionListener(MapData &md,
                                        PrespammedPath &pp,
                                        Mmapper2Group &gm,
                                        MumeClock &mc,
-                                       AutoLogger &al,
                                        MapCanvas &mca,
                                        GameObserver &go,
                                        QObject *const parent)
@@ -40,7 +39,6 @@ ConnectionListener::ConnectionListener(MapData &md,
     , m_prespammedPath{pp}
     , m_groupManager{gm}
     , m_mumeClock{mc}
-    , m_autoLogger{al}
     , m_mapCanvas{mca}
     , m_gameOberver{go}
 {}
@@ -104,7 +102,6 @@ void ConnectionListener::slot_onIncomingConnection(qintptr socketDescriptor)
                                           m_prespammedPath,
                                           m_groupManager,
                                           m_mumeClock,
-                                          m_autoLogger,
                                           m_mapCanvas,
                                           m_gameOberver,
                                           socketDescriptor,

--- a/src/proxy/connectionlistener.cpp
+++ b/src/proxy/connectionlistener.cpp
@@ -33,6 +33,7 @@ ConnectionListener::ConnectionListener(MapData &md,
                                        MumeClock &mc,
                                        AutoLogger &al,
                                        MapCanvas &mca,
+                                       GameObserver &go,
                                        QObject *const parent)
     : QObject(parent)
     , m_mapData{md}
@@ -43,6 +44,7 @@ ConnectionListener::ConnectionListener(MapData &md,
     , m_mumeClock{mc}
     , m_autoLogger{al}
     , m_mapCanvas{mca}
+    , m_gameOberver{go}
 {}
 
 ConnectionListener::~ConnectionListener()
@@ -107,6 +109,7 @@ void ConnectionListener::slot_onIncomingConnection(qintptr socketDescriptor)
                                           m_mumeClock,
                                           m_autoLogger,
                                           m_mapCanvas,
+                                          m_gameOberver,
                                           socketDescriptor,
                                           *this);
 

--- a/src/proxy/connectionlistener.cpp
+++ b/src/proxy/connectionlistener.cpp
@@ -29,7 +29,6 @@ ConnectionListener::ConnectionListener(MapData &md,
                                        Mmapper2PathMachine &pm,
                                        PrespammedPath &pp,
                                        Mmapper2Group &gm,
-                                       RoomManager &rm,
                                        MumeClock &mc,
                                        AutoLogger &al,
                                        MapCanvas &mca,
@@ -40,7 +39,6 @@ ConnectionListener::ConnectionListener(MapData &md,
     , m_pathMachine{pm}
     , m_prespammedPath{pp}
     , m_groupManager{gm}
-    , m_roomManager{rm}
     , m_mumeClock{mc}
     , m_autoLogger{al}
     , m_mapCanvas{mca}
@@ -105,7 +103,6 @@ void ConnectionListener::slot_onIncomingConnection(qintptr socketDescriptor)
                                           m_pathMachine,
                                           m_prespammedPath,
                                           m_groupManager,
-                                          m_roomManager,
                                           m_mumeClock,
                                           m_autoLogger,
                                           m_mapCanvas,

--- a/src/proxy/connectionlistener.h
+++ b/src/proxy/connectionlistener.h
@@ -51,7 +51,6 @@ public:
                                 PrespammedPath &,
                                 Mmapper2Group &,
                                 MumeClock &,
-                                AutoLogger &,
                                 MapCanvas &,
                                 GameObserver &,
                                 QObject *parent);
@@ -79,7 +78,6 @@ private:
     PrespammedPath &m_prespammedPath;
     Mmapper2Group &m_groupManager;
     MumeClock &m_mumeClock;
-    AutoLogger &m_autoLogger;
     MapCanvas &m_mapCanvas;
     GameObserver &m_gameOberver;
     using ServerList = std::vector<QPointer<ConnectionListenerTcpServer>>;

--- a/src/proxy/connectionlistener.h
+++ b/src/proxy/connectionlistener.h
@@ -15,7 +15,6 @@
 #include <QtCore>
 #include <QtGlobal>
 
-class AutoLogger;
 class ConnectionListener;
 class MapCanvas;
 class MapData;

--- a/src/proxy/connectionlistener.h
+++ b/src/proxy/connectionlistener.h
@@ -5,6 +5,7 @@
 // Author: Marek Krejza <krejza@gmail.com> (Caligor)
 // Author: Nils Schimmelmann <nschimme@gmail.com> (Jahara)
 
+#include "observer/gameobserver.h"
 #include <memory>
 #include <vector>
 #include <QHostAddress>
@@ -53,6 +54,7 @@ public:
                                 MumeClock &,
                                 AutoLogger &,
                                 MapCanvas &,
+                                GameObserver &,
                                 QObject *parent);
     ~ConnectionListener() final;
 
@@ -81,6 +83,7 @@ private:
     MumeClock &m_mumeClock;
     AutoLogger &m_autoLogger;
     MapCanvas &m_mapCanvas;
+    GameObserver &m_gameOberver;
     using ServerList = std::vector<QPointer<ConnectionListenerTcpServer>>;
     ServerList m_servers;
     std::unique_ptr<Proxy> m_proxy;

--- a/src/proxy/connectionlistener.h
+++ b/src/proxy/connectionlistener.h
@@ -50,7 +50,6 @@ public:
                                 Mmapper2PathMachine &,
                                 PrespammedPath &,
                                 Mmapper2Group &,
-                                RoomManager &,
                                 MumeClock &,
                                 AutoLogger &,
                                 MapCanvas &,
@@ -79,7 +78,6 @@ private:
     Mmapper2PathMachine &m_pathMachine;
     PrespammedPath &m_prespammedPath;
     Mmapper2Group &m_groupManager;
-    RoomManager &m_roomManager;
     MumeClock &m_mumeClock;
     AutoLogger &m_autoLogger;
     MapCanvas &m_mapCanvas;

--- a/src/proxy/proxy.cpp
+++ b/src/proxy/proxy.cpp
@@ -54,7 +54,6 @@ Proxy::Proxy(MapData &md,
              Mmapper2PathMachine &pm,
              PrespammedPath &pp,
              Mmapper2Group &gm,
-             RoomManager &rm,
              MumeClock &mc,
              AutoLogger &al,
              MapCanvas &mca,
@@ -66,7 +65,6 @@ Proxy::Proxy(MapData &md,
     , m_pathMachine(pm)
     , m_prespammedPath(pp)
     , m_groupManager(gm)
-    , m_roomManager(rm)
     , m_mumeClock(mc)
     , m_logger(al)
     , m_mapCanvas(mca)
@@ -173,8 +171,6 @@ void Proxy::slot_start()
             &m_groupManager,
             &Mmapper2Group::slot_parseGmcpInput);
     connect(mudTelnet, &MudTelnet::sig_relayGmcp, m_parserXml, &MumeXmlParser::slot_parseGmcpInput);
-
-    connect(mudTelnet, &MudTelnet::sig_relayGmcp, &m_roomManager, &RoomManager::slot_parseGmcpInput);
 
     connect(this, &Proxy::sig_analyzeUserStream, userTelnet, &UserTelnet::slot_onAnalyzeUserStream);
 

--- a/src/proxy/proxy.cpp
+++ b/src/proxy/proxy.cpp
@@ -228,13 +228,31 @@ void Proxy::slot_start()
             &AbstractParser::slot_sendGTellToUser);
 
     // Game Observer (re-broadcasts text and gmcp updates to downstream consumers)
-    connect(mudSocket, &MumeSocket::sig_connected, &m_gameObserver, &GameObserver::slot_observeConnected);
-    connect(parserXml, &MumeXmlParser::sig_sendToMud, &m_gameObserver, &GameObserver::slot_observeSentToMudText);
-    connect(parserXml, &MumeXmlParser::sig_sendToUser, &m_gameObserver, &GameObserver::slot_observeSentToUserText);
+    connect(mudSocket,
+            &MumeSocket::sig_connected,
+            &m_gameObserver,
+            &GameObserver::slot_observeConnected);
+    connect(parserXml,
+            &MumeXmlParser::sig_sendToMud,
+            &m_gameObserver,
+            &GameObserver::slot_observeSentToMudText);
+    connect(parserXml,
+            &MumeXmlParser::sig_sendToUser,
+            &m_gameObserver,
+            &GameObserver::slot_observeSentToUserText);
     // note the polarity, unlike above: MudTelnet::relay is SentToUser, UserTelnet::relay is SentToMud
-    connect(mudTelnet, &MudTelnet::sig_relayGmcp, &m_gameObserver, &GameObserver::slot_observeSentToUserGmcp);
-    connect(userTelnet, &UserTelnet::sig_relayGmcp, &m_gameObserver, &GameObserver::slot_observeSentToMudGmcp);
-    connect(mudTelnet, &MudTelnet::sig_relayEchoMode, &m_gameObserver, &GameObserver::slot_observeToggledEchoMode);
+    connect(mudTelnet,
+            &MudTelnet::sig_relayGmcp,
+            &m_gameObserver,
+            &GameObserver::slot_observeSentToUserGmcp);
+    connect(userTelnet,
+            &UserTelnet::sig_relayGmcp,
+            &m_gameObserver,
+            &GameObserver::slot_observeSentToMudGmcp);
+    connect(mudTelnet,
+            &MudTelnet::sig_relayEchoMode,
+            &m_gameObserver,
+            &GameObserver::slot_observeToggledEchoMode);
 
     log("Connection to client established ...");
 

--- a/src/proxy/proxy.cpp
+++ b/src/proxy/proxy.cpp
@@ -231,7 +231,6 @@ void Proxy::slot_start()
     connect(mudSocket, &MumeSocket::sig_connected, &m_gameObserver, &GameObserver::slot_observeConnected);
     connect(parserXml, &MumeXmlParser::sig_sendToMud, &m_gameObserver, &GameObserver::slot_observeSentToMudText);
     connect(parserXml, &MumeXmlParser::sig_sendToUser, &m_gameObserver, &GameObserver::slot_observeSentToUserText);
-
     // note the polarity, unlike above: MudTelnet::relay is SentToUser, UserTelnet::relay is SentToMud
     connect(mudTelnet, &MudTelnet::sig_relayGmcp, &m_gameObserver, &GameObserver::slot_observeSentToUserGmcp);
     connect(userTelnet, &UserTelnet::sig_relayGmcp, &m_gameObserver, &GameObserver::slot_observeSentToMudGmcp);

--- a/src/proxy/proxy.cpp
+++ b/src/proxy/proxy.cpp
@@ -231,11 +231,17 @@ void Proxy::slot_start()
 
     // Group Manager Support
     connect(parserXml, &AbstractParser::sig_showPath, &m_groupManager, &Mmapper2Group::slot_setPath);
+
     // Group Tell
     connect(&m_groupManager,
             &Mmapper2Group::sig_displayGroupTellEvent,
             parserXml,
             &AbstractParser::slot_sendGTellToUser);
+
+    // Game Observer (re-broadcasts text and gmcp updates to downstream consumers)
+    connect(parserXml, &MumeXmlParser::sig_sendToMud, &m_gameObserver, &GameObserver::slot_observeSentToMudText);
+    connect(parserXml, &MumeXmlParser::sig_sendToUser, &m_gameObserver, &GameObserver::slot_observeSentToUserText);
+    connect(mudTelnet, &MudTelnet::sig_relayGmcp, &m_gameObserver, &GameObserver::slot_observeSentToUserGmcp);
 
     log("Connection to client established ...");
 

--- a/src/proxy/proxy.cpp
+++ b/src/proxy/proxy.cpp
@@ -58,6 +58,7 @@ Proxy::Proxy(MapData &md,
              MumeClock &mc,
              AutoLogger &al,
              MapCanvas &mca,
+             GameObserver &go,
              qintptr &socketDescriptor,
              ConnectionListener &listener)
     : QObject(nullptr)
@@ -69,6 +70,7 @@ Proxy::Proxy(MapData &md,
     , m_mumeClock(mc)
     , m_logger(al)
     , m_mapCanvas(mca)
+    , m_gameObserver(go)
     , m_listener(listener)
     , m_socketDescriptor(socketDescriptor)
     // TODO: pass this in as a non-owning pointer.

--- a/src/proxy/proxy.h
+++ b/src/proxy/proxy.h
@@ -49,7 +49,6 @@ public:
                    Mmapper2PathMachine &,
                    PrespammedPath &,
                    Mmapper2Group &,
-                   RoomManager &,
                    MumeClock &,
                    AutoLogger &,
                    MapCanvas &,
@@ -104,7 +103,6 @@ private:
     Mmapper2PathMachine &m_pathMachine;
     PrespammedPath &m_prespammedPath;
     Mmapper2Group &m_groupManager;
-    RoomManager &m_roomManager;
     MumeClock &m_mumeClock;
     AutoLogger &m_logger;
     MapCanvas &m_mapCanvas;

--- a/src/proxy/proxy.h
+++ b/src/proxy/proxy.h
@@ -104,8 +104,8 @@ private:
     MumeClock &m_mumeClock;
     MapCanvas &m_mapCanvas;
     GameObserver &m_gameObserver;
-    ConnectionListener &m_listener;
     const qintptr m_socketDescriptor;
+    ConnectionListener &m_listener;
 
     // initialized in ctor
     QPointer<RemoteEdit> m_remoteEdit;

--- a/src/proxy/proxy.h
+++ b/src/proxy/proxy.h
@@ -19,6 +19,7 @@
 #include "../pandoragroup/GroupManagerApi.h"
 #include "GmcpMessage.h"
 #include "ProxyParserApi.h"
+#include "observer/gameobserver.h"
 
 class AutoLogger;
 class ConnectionListener;
@@ -52,6 +53,7 @@ public:
                    MumeClock &,
                    AutoLogger &,
                    MapCanvas &,
+                   GameObserver &,
                    qintptr &,
                    ConnectionListener &);
     ~Proxy() final;
@@ -106,6 +108,7 @@ private:
     MumeClock &m_mumeClock;
     AutoLogger &m_logger;
     MapCanvas &m_mapCanvas;
+    GameObserver &m_gameObserver;
     ConnectionListener &m_listener;
     const qintptr m_socketDescriptor;
 

--- a/src/proxy/proxy.h
+++ b/src/proxy/proxy.h
@@ -50,7 +50,6 @@ public:
                    PrespammedPath &,
                    Mmapper2Group &,
                    MumeClock &,
-                   AutoLogger &,
                    MapCanvas &,
                    GameObserver &,
                    qintptr &,
@@ -104,7 +103,6 @@ private:
     PrespammedPath &m_prespammedPath;
     Mmapper2Group &m_groupManager;
     MumeClock &m_mumeClock;
-    AutoLogger &m_logger;
     MapCanvas &m_mapCanvas;
     GameObserver &m_gameObserver;
     ConnectionListener &m_listener;

--- a/src/proxy/proxy.h
+++ b/src/proxy/proxy.h
@@ -21,7 +21,6 @@
 #include "ProxyParserApi.h"
 #include "observer/gameobserver.h"
 
-class AutoLogger;
 class ConnectionListener;
 class MapCanvas;
 class MapData;


### PR DESCRIPTION
This should be a functional no-op (no changes from player's perspective).

- As discussed in #277, introduce a `GameObserver` which brokers internal events from `Proxy`, `ConnectListener`, the `Parser`s, and `TelnetClient`s outward to downstream consumers.
- Ideally, after this change, no one should need to touch `ConnectionListener` or `Proxy` unless significantly changing how mapper communicates with the game and external client. Folks wanting to add "mud client style" windows should hopefully be saved that complexity.
- Stop passing `AutoLogger` and 'RoomManager`' instances all the way into `Proxy`.
- In `MainWindow`, port `m_Logger` and `m_roomManager` instances to use a local `m_gameObserver` instance.
- Next up, in future PRs, I will introduce a Comms window (Tells/Narrates) and other game client functionality to leverage GameObserver. 

This turned out to be way simpler than I thought, apologies for the delusions of grandeur on my previous PR.