### PR TITLE
Consolidate ANSI removal upstream

### DIFF
--- a/src/logger/autologger.cpp
+++ b/src/logger/autologger.cpp
@@ -66,7 +66,7 @@ bool AutoLogger::createFile()
     return true;
 }
 
-bool AutoLogger::writeLine(const QByteArray &ba)
+bool AutoLogger::writeLine(const QString &str)
 {
     if (!m_shouldLog || !getConfig().autoLog.autoLog)
         return false;
@@ -87,9 +87,7 @@ bool AutoLogger::writeLine(const QByteArray &ba)
         return false;
     }
 
-    // Remove ANSI and convert to UTF-8
-    QString str = QString::fromLatin1(ba);
-    ParserUtils::removeAnsiMarksInPlace(str);
+    // ANSI marks removed upstream by GameObserver
     const auto &line = ::toStdStringUtf8(str);
 
     m_logFile << line;
@@ -187,10 +185,9 @@ bool AutoLogger::showDeleteDialog(QString message)
     return result == QMessageBox::Yes;
 }
 
-void AutoLogger::slot_writeToLog(const QByteArray &ba)
+void AutoLogger::slot_writeToLog(const QString &str)
 {
-    MAYBE_UNUSED const auto igored = //
-        writeLine(ba);
+    MAYBE_UNUSED const auto ignored = writeLine(str);
 }
 
 void AutoLogger::slot_shouldLog(bool echo)

--- a/src/logger/autologger.h
+++ b/src/logger/autologger.h
@@ -18,12 +18,12 @@ public:
     ~AutoLogger() final;
 
 public slots:
-    void slot_writeToLog(const QByteArray &ba);
+    void slot_writeToLog(const QString &str);
     void slot_shouldLog(bool echo);
     void slot_onConnected();
 
 private:
-    NODISCARD bool writeLine(const QByteArray &ba);
+    NODISCARD bool writeLine(const QString &str);
     void deleteOldLogs();
     void deleteLogs(const QFileInfoList &files);
     NODISCARD bool showDeleteDialog(QString message);

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -284,11 +284,11 @@ MainWindow::MainWindow()
             m_logger,
             &AutoLogger::slot_shouldLog);
     connect(m_gameObserver,
-            &GameObserver::sig_sentToMudText,
+            &GameObserver::sig_sentToMudString,
             m_logger,
             &AutoLogger::slot_writeToLog);
     connect(m_gameObserver,
-            &GameObserver::sig_sentToUserText,
+            &GameObserver::sig_sentToUserString,
             m_logger,
             &AutoLogger::slot_writeToLog);
 

--- a/src/observer/gameobserver.cpp
+++ b/src/observer/gameobserver.cpp
@@ -45,8 +45,3 @@ void GameObserver::slot_observeToggledEchoMode(bool echo)
 {
     emit sig_toggledEchoMode(echo);
 }
-
-void GameObserver::slot_log(const QString &ba, const QString &s)
-{
-    emit sig_log(ba, s);
-}

--- a/src/observer/gameobserver.cpp
+++ b/src/observer/gameobserver.cpp
@@ -1,4 +1,5 @@
 #include "gameobserver.h"
+#include "parser/parserutils.h"
 
 GameObserver::GameObserver(QObject *parent)
     : QObject{parent}
@@ -14,14 +15,20 @@ void GameObserver::slot_observeDisconnected()
     emit sig_disconnected();
 }
 
-void GameObserver::slot_observeSentToMudText(const QByteArray &ba)
+void GameObserver::slot_observeSentToMud(const QByteArray &ba)
 {
-    emit sig_sentToMudText(ba);
+    emit sig_sentToMudBytes(ba);
+    QString str = QString::fromLatin1(ba);
+    ParserUtils::removeAnsiMarksInPlace(str);
+    emit sig_sentToMudString(str);
 }
 
-void GameObserver::slot_observeSentToUserText(const QByteArray &ba, bool goAhead)
+void GameObserver::slot_observeSentToUser(const QByteArray &ba, bool goAhead)
 {
-    emit sig_sentToUserText(ba, goAhead);
+    emit sig_sentToUserBytes(ba, goAhead);
+    QString str = QString::fromLatin1(ba);
+    ParserUtils::removeAnsiMarksInPlace(str);
+    emit sig_sentToUserString(str);
 }
 
 void GameObserver::slot_observeSentToMudGmcp(const GmcpMessage &m)

--- a/src/observer/gameobserver.h
+++ b/src/observer/gameobserver.h
@@ -13,8 +13,12 @@ signals:
     void sig_connected();
     void sig_disconnected();
 
-    void sig_sentToMudText(const QByteArray &);
-    void sig_sentToUserText(const QByteArray &, bool goAhead);
+    void sig_sentToMudBytes(const QByteArray &);
+    void sig_sentToUserBytes(const QByteArray &, bool goAhead);
+
+    // Helper versions of the above, which remove ANSI in place and create QString
+    void sig_sentToMudString(const QString &);
+    void sig_sentToUserString(const QString &);
 
     void sig_sentToMudGmcp(const GmcpMessage &);
     void sig_sentToUserGmcp(const GmcpMessage &);
@@ -28,8 +32,8 @@ public slots:
     void slot_observeConnected();
     void slot_observeDisconnected();
 
-    void slot_observeSentToMudText(const QByteArray &ba);
-    void slot_observeSentToUserText(const QByteArray &ba, bool goAhead);
+    void slot_observeSentToMud(const QByteArray &ba);
+    void slot_observeSentToUser(const QByteArray &ba, bool goAhead);
 
     void slot_observeSentToMudGmcp(const GmcpMessage &m);
     void slot_observeSentToUserGmcp(const GmcpMessage &m);

--- a/src/observer/gameobserver.h
+++ b/src/observer/gameobserver.h
@@ -25,9 +25,6 @@ signals:
 
     void sig_toggledEchoMode(bool echo);
 
-    // used to log
-    void sig_log(const QString &, const QString &);
-
 public slots:
     void slot_observeConnected();
     void slot_observeDisconnected();
@@ -39,6 +36,4 @@ public slots:
     void slot_observeSentToUserGmcp(const GmcpMessage &m);
 
     void slot_observeToggledEchoMode(bool echo);
-
-    void slot_log(const QString &ba, const QString &);
 };

--- a/src/proxy/proxy.cpp
+++ b/src/proxy/proxy.cpp
@@ -235,11 +235,11 @@ void Proxy::slot_start()
     connect(parserXml,
             &MumeXmlParser::sig_sendToMud,
             &m_gameObserver,
-            &GameObserver::slot_observeSentToMudText);
+            &GameObserver::slot_observeSentToMud);
     connect(parserXml,
             &MumeXmlParser::sig_sendToUser,
             &m_gameObserver,
-            &GameObserver::slot_observeSentToUserText);
+            &GameObserver::slot_observeSentToUser);
     // note the polarity, unlike above: MudTelnet::relay is SentToUser, UserTelnet::relay is SentToMud
     connect(mudTelnet,
             &MudTelnet::sig_relayGmcp,


### PR DESCRIPTION
(Hopefully minor)

@nschimme Per your feedback on the AdventureJournal PR, you requested I not duplicate the code to remove ansi in place and create a QString from Proxy-observed byte array. Here is a candidate fix submitted as its own PR for easy reviewing.