### PR TITLE
Adventure Panel fixes: xp hourly rate, player trophy, unit tests

### DIFF
--- a/src/adventure/adventuresession.cpp
+++ b/src/adventure/adventuresession.cpp
@@ -101,7 +101,9 @@ double AdventureSession::calculateHourlyRateXP() const
 
 double AdventureSession::calculateHourlyRate(double points) const
 {
-    return points / static_cast<double>(std::chrono::hours(1) / elapsed());
+    auto seconds = elapsed().count();
+
+    return points / static_cast<double>(seconds) * 3600.0;
 }
 
 std::chrono::seconds AdventureSession::elapsed() const

--- a/src/adventure/adventuresession.h
+++ b/src/adventure/adventuresession.h
@@ -6,6 +6,8 @@
 #include <chrono>
 #include <QString>
 
+#include "../../tests/testadventure.h"
+
 class AdventureSession
 {
     template<typename T>
@@ -55,6 +57,8 @@ public:
     double calculateHourlyRateTP() const;
     double calculateHourlyRateXP() const;
     static const QString formatPoints(double points);
+
+    friend TestAdventure;
 
 private:
     double calculateHourlyRate(double points) const;

--- a/src/adventure/lineparsers.cpp
+++ b/src/adventure/lineparsers.cpp
@@ -66,12 +66,19 @@ bool HintParser::parse(QString line)
 bool KillAndXPParser::parse(QString line)
 {
     // A kill and exp earned event as follows:
-    //   (1) A line exactly matching "You receive your share of experience."
-    // ... and then within the next 5 lines, a line:
+    // A line matching exactly either of:
+    //   (1a) "You receive your share of experience." (mob)
+    //   (1b) "You feel more experienced." (player)
+    // And then within the next _5_ lines, a line:
+    // For mob kill:
     //   (2a) matching " is dead! R.I.P."
     //   (2b) OR matching " disappears into nothing."
+    // For player kill:
+    //   (3a) matching " has drawn his last breath! R.I.P."
+    //   (3a) matching " has drawn her last breath! R.I.P."
 
-    if (line.startsWith("You receive your share of experience.")) {
+    if (line.startsWith("You receive your share of experience.")
+        || line.startsWith("You feel more experienced.")) {
         m_pending = true;
         m_linesSinceShareExp = 0;
         return false;
@@ -89,8 +96,20 @@ bool KillAndXPParser::parse(QString line)
 
     } else {
         // We're in a pending share of experience, let's see if a kill
-        auto idx_dead = std::max(line.indexOf(" is dead! R.I.P."),
-                                 line.indexOf(" disappears into nothing."));
+        auto idx_dead = line.indexOf(" is dead! R.I.P.");
+        if (idx_dead == -1)
+            line.indexOf(" disappears into nothing.");
+
+        if (idx_dead > -1) {
+            // Kill, extract the mob/enemy name and reset pending
+            m_lastSuccessVal = line.left(idx_dead);
+            m_pending = false;
+            return true;
+        }
+
+        idx_dead = line.indexOf(" has drawn his last breath! R.I.P.");
+        if (idx_dead == -1)
+            idx_dead = line.indexOf(" has drawn her last breath! R.I.P.");
 
         if (idx_dead > -1) {
             // Kill, extract the mob/enemy name and reset pending

--- a/src/adventure/lineparsers.cpp
+++ b/src/adventure/lineparsers.cpp
@@ -98,7 +98,7 @@ bool KillAndXPParser::parse(QString line)
         // We're in a pending share of experience, let's see if a kill
         auto idx_dead = line.indexOf(" is dead! R.I.P.");
         if (idx_dead == -1)
-            line.indexOf(" disappears into nothing.");
+            idx_dead = line.indexOf(" disappears into nothing.");
 
         if (idx_dead > -1) {
             // Kill, extract the mob/enemy name and reset pending

--- a/src/adventure/lineparsers.cpp
+++ b/src/adventure/lineparsers.cpp
@@ -28,7 +28,7 @@ bool AchievementParser::parse(QString line)
     //   (2) The next line is interpreted as the achievement text.
 
     if (m_pending) {
-        m_lastSuccessVal = line;
+        m_lastSuccessVal = line.trimmed();
         m_pending = false;
         return true;
     }
@@ -54,7 +54,7 @@ bool HintParser::parse(QString line)
     //   (1) A line matching exactly "# Hint:"
     //   (2) The next line is interpreted as the hint text.
     if (m_pending) {
-        m_lastSuccessVal = line.mid(4); // Chomp the leading "#  "
+        m_lastSuccessVal = line.mid(4).trimmed(); // mid(4) is to chomp the leading "#  "
         m_pending = false;
         return true;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -171,12 +171,8 @@ set(adventure_SRCS
         ../src/adventure/adventuresession.h
         ../src/adventure/adventuretracker.cpp
         ../src/adventure/adventuretracker.h
-        ../src/adventure/adventurewidget.cpp
-        ../src/adventure/adventurewidget.h
         ../src/adventure/lineparsers.cpp
         ../src/adventure/lineparsers.h
-        ../src/adventure/xpstatuswidget.cpp
-        ../src/adventure/xpstatuswidget.h
         ../src/configuration/configobserver.h
         ../src/configuration/configuration.cpp
         ../src/configuration/configuration.h

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -164,3 +164,42 @@ set_target_properties(
   UNITY_BUILD ON
 )
 add_test(NAME TestGlobal COMMAND TestGlobal)
+
+# Adventure
+set(adventure_SRCS
+        ../src/adventure/adventuresession.cpp
+        ../src/adventure/adventuresession.h
+        ../src/adventure/adventuretracker.cpp
+        ../src/adventure/adventuretracker.h
+        ../src/adventure/adventurewidget.cpp
+        ../src/adventure/adventurewidget.h
+        ../src/adventure/lineparsers.cpp
+        ../src/adventure/lineparsers.h
+        ../src/adventure/xpstatuswidget.cpp
+        ../src/adventure/xpstatuswidget.h
+        ../src/configuration/configobserver.h
+        ../src/configuration/configuration.cpp
+        ../src/configuration/configuration.h
+        ../src/global/Color.cpp
+        ../src/global/Color.h
+        ../src/global/NamedColors.cpp
+        ../src/global/NamedColors.h
+        ../src/global/utils.cpp
+        ../src/global/utils.h
+        ../src/observer/gameobserver.cpp
+        ../src/observer/gameobserver.h
+        ../src/parser/parserutils.cpp
+        ../src/parser/parserutils.h
+        )
+set(TestAdventure_SRCS testadventure.cpp testadventure.h)
+add_executable(TestAdventure ${TestAdventure_SRCS} ${adventure_SRCS})
+target_link_libraries(TestAdventure Qt5::Widgets Qt5::Network Qt5::Test coverage_config)
+set_target_properties(
+        TestAdventure PROPERTIES
+        CXX_STANDARD 17
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+        COMPILE_FLAGS "${WARNING_FLAGS}"
+        UNITY_BUILD ON
+)
+add_test(NAME TestAdventure COMMAND TestAdventure)

--- a/tests/testadventure.cpp
+++ b/tests/testadventure.cpp
@@ -47,6 +47,13 @@ struct
            {true, "A tree-snake is dead! R.I.P."}};
     const char *killMob3Success = "A tree-snake";
 
+    std::vector<TestLine> killMob4 = {{false,
+                                       "You cleave a spirit's body extremely hard and shatter it."},
+                                      {false, "You receive your share of experience."},
+                                      {false, "**Yawn** Boring kill, wasn't it?"},
+                                      {true, "A spirit disappears into nothing.}"}};
+    const char *killMob4Success = "A spirit";
+
     std::vector<TestLine> killPlayer1 = {
         {false, "You pierce *an Elf* (k)'s right hand extremely hard and shatter it."},
         {false, "You feel more experienced."},
@@ -150,6 +157,9 @@ void TestAdventure::testKillAndXPParser()
     testParser(parser, TestLines.killMob3);
     QCOMPARE(parser.getLastSuccessVal(), TestLines.killMob3Success);
 
+    testParser(parser, TestLines.killMob4);
+    QCOMPARE(parser.getLastSuccessVal(), TestLines.killMob4Success);
+
     testParser(parser, TestLines.killPlayer1);
     QCOMPARE(parser.getLastSuccessVal(), TestLines.killPlayer1Success);
 
@@ -190,13 +200,14 @@ void TestAdventure::testE2E()
     pump(TestLines.killMob1);
     pump(TestLines.killMob2);
     pump(TestLines.killMob3);
+    pump(TestLines.killMob4);
     pump(TestLines.killPlayer1);
     pump(TestLines.killPlayer2);
     pump(TestLines.killPlayer3);
 
     QCOMPARE(achievements->size(), 1u);
     QCOMPARE(hints->size(), 1u);
-    QCOMPARE(killedMobs->size(), 6u);
+    QCOMPARE(killedMobs->size(), 7u);
 }
 
 QTEST_MAIN(TestAdventure)

--- a/tests/testadventure.cpp
+++ b/tests/testadventure.cpp
@@ -3,13 +3,8 @@
 
 #include "testadventure.h"
 #include "../src/adventure/adventuresession.h"
-#include "../src/adventure/lineparsers.h"
 
 #include <QtTest/QtTest>
-
-TestAdventure::TestAdventure() = default;
-
-TestAdventure::~TestAdventure() = default;
 
 void TestAdventure::testSessionHourlyRateXP()
 {
@@ -46,24 +41,45 @@ void TestAdventure::testSessionHourlyRateXP()
     QCOMPARE(session.calculateHourlyRateXP(), 6000.0);
 }
 
+void TestAdventure::testParser(AbstractLineParser &parser, std::vector<TestLine> testLines)
+{
+    for (auto &tl : testLines) {
+        QVERIFY2(parser.parse(tl.line) == tl.expected, qPrintable(tl.errorMsg()));
+    }
+}
+
 void TestAdventure::testAccomplishedTaskParser() {}
 
 void TestAdventure::testAchievementParser() {}
-
-void TestAdventure::testDiedParser() {}
-
-void TestAdventure::testGainedLevelParser() {}
 
 void TestAdventure::testHintParser() {}
 
 void TestAdventure::testKillAndXPParser()
 {
-    std::vector<QString> lines = {"foo", "bar", "baz"};
-    std::vector<bool> parseResults{};
-
     KillAndXPParser parser{};
 
-    //std::for_each(lines.begin(), lines.end(), [parser, parseResults](QString l){parseResults.insert(parser.parse(l))})
+    testParser(parser,
+               {{false, "You cleave a husky smuggler's right leg extremely hard and shatter it."},
+                {false, "You receive your share of experience."},
+                {false, "Congratulations! This is the first time you've killed it!"},
+                {true, "A husky smuggler is dead! R.I.P."}});
+    QCOMPARE(parser.getLastSuccessVal(), "A husky smuggler");
+
+    testParser(parser,
+               {{false, "You cleave a wild bull (x)'s body extremely hard and shatter it."},
+                {false, "Your victim is shocked by your hit!"},
+                {false, "You receive your share of experience."},
+                {false, "Congratulations! This is the first time you've killed it!"},
+                {true, "A wild bull (x) is dead! R.I.P."}});
+    QCOMPARE(parser.getLastSuccessVal(), "A wild bull (x)"); // TODO FIXME remove the (label)
+
+    testParser(parser,
+               {{false, "You cleave a tree-snake's body extremely hard and shatter it."},
+                {false, "Your victim is shocked by your hit!"},
+                {false, "You receive your share of experience."},
+                {false, "Yes! You're beginning to get the idea."},
+                {true, "A tree-snake is dead! R.I.P."}});
+    QCOMPARE(parser.getLastSuccessVal(), "A tree-snake");
 }
 
 QTEST_MAIN(TestAdventure)

--- a/tests/testadventure.cpp
+++ b/tests/testadventure.cpp
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2023 The MMapper Authors
+
+#include "testadventure.h"
+#include "../src/adventure/lineparsers.h"
+
+#include <QtTest/QtTest>
+
+TestAdventure::TestAdventure() = default;
+
+TestAdventure::~TestAdventure() = default;
+
+void TestAdventure::testAccomplishedTaskParser() {}
+
+void TestAdventure::testAchievementParser() {}
+
+void TestAdventure::testDiedParser() {}
+
+void TestAdventure::testGainedLevelParser() {}
+
+void TestAdventure::testHintParser() {}
+
+void TestAdventure::testKillAndXPParser()
+{
+    std::vector<QString> lines = {"foo", "bar", "hoochie"};
+    std::vector<bool> parseResults{};
+
+    KillAndXPParser parser{};
+
+    //std::for_each(lines.begin(), lines.end(), [parser, parseResults](QString l){parseResults.insert(parser.parse(l))})
+}
+
+QTEST_MAIN(TestAdventure)

--- a/tests/testadventure.cpp
+++ b/tests/testadventure.cpp
@@ -3,8 +3,51 @@
 
 #include "testadventure.h"
 #include "../src/adventure/adventuresession.h"
+#include "adventure/adventuretracker.h"
+#include "observer/gameobserver.h"
 
+#include <algorithm>
 #include <QtTest/QtTest>
+
+struct
+{
+    std::vector<TestLine> achievement1
+        = {{false, "An accomplished hunter says 'Good job, Gomgâl! One more to go!'"},
+           {false, "You achieved something new!"},
+           {true, "You aided the hunter in the Tower Hills by cleaning out a rat infestation."}};
+    const char *achievement1Success
+        = "You aided the hunter in the Tower Hills by cleaning out a rat infestation.";
+
+    std::vector<TestLine> hint1 = {{false, "It seems to be latched."},
+                                   {false, ""},
+                                   {false, "# Hint:"},
+                                   {true, "#   Type unlock hatch to unlatch the hatch."}};
+    const char *hint1Success = "Type unlock hatch to unlatch the hatch.";
+
+    std::vector<TestLine> killMob1
+        = {{false, "You cleave a husky smuggler's right leg extremely hard and shatter it."},
+           {false, "You receive your share of experience."},
+           {false, "Congratulations! This is the first time you've killed it!"},
+           {true, "A husky smuggler is dead! R.I.P."}};
+    const char *killMob1Success = "A husky smuggler";
+
+    std::vector<TestLine> killMob2
+        = {{false, "You cleave a wild bull (x)'s body extremely hard and shatter it."},
+           {false, "Your victim is shocked by your hit!"},
+           {false, "You receive your share of experience."},
+           {false, "Congratulations! This is the first time you've killed it!"},
+           {true, "A wild bull (x) is dead! R.I.P."}};
+    const char *killMob2Success = "A wild bull (x)"; // TODO FIXME remove the (label) when parsing
+
+    std::vector<TestLine> killMob3
+        = {{false, "You cleave a tree-snake's body extremely hard and shatter it."},
+           {false, "Your victim is shocked by your hit!"},
+           {false, "You receive your share of experience."},
+           {false, "Yes! You're beginning to get the idea."},
+           {true, "A tree-snake is dead! R.I.P."}};
+    const char *killMob3Success = "A tree-snake";
+
+} TestLines;
 
 void TestAdventure::testSessionHourlyRateXP()
 {
@@ -48,38 +91,68 @@ void TestAdventure::testParser(AbstractLineParser &parser, std::vector<TestLine>
     }
 }
 
-void TestAdventure::testAccomplishedTaskParser() {}
+void TestAdventure::testAchievementParser()
+{
+    AchievementParser parser{};
+    testParser(parser, TestLines.achievement1);
+    QCOMPARE(parser.getLastSuccessVal(), TestLines.achievement1Success);
+}
 
-void TestAdventure::testAchievementParser() {}
-
-void TestAdventure::testHintParser() {}
+void TestAdventure::testHintParser()
+{
+    HintParser parser{};
+    testParser(parser, TestLines.hint1);
+    QCOMPARE(parser.getLastSuccessVal(), TestLines.hint1Success);
+}
 
 void TestAdventure::testKillAndXPParser()
 {
     KillAndXPParser parser{};
 
-    testParser(parser,
-               {{false, "You cleave a husky smuggler's right leg extremely hard and shatter it."},
-                {false, "You receive your share of experience."},
-                {false, "Congratulations! This is the first time you've killed it!"},
-                {true, "A husky smuggler is dead! R.I.P."}});
-    QCOMPARE(parser.getLastSuccessVal(), "A husky smuggler");
+    testParser(parser, TestLines.killMob1);
+    QCOMPARE(parser.getLastSuccessVal(), TestLines.killMob1Success);
 
-    testParser(parser,
-               {{false, "You cleave a wild bull (x)'s body extremely hard and shatter it."},
-                {false, "Your victim is shocked by your hit!"},
-                {false, "You receive your share of experience."},
-                {false, "Congratulations! This is the first time you've killed it!"},
-                {true, "A wild bull (x) is dead! R.I.P."}});
-    QCOMPARE(parser.getLastSuccessVal(), "A wild bull (x)"); // TODO FIXME remove the (label)
+    testParser(parser, TestLines.killMob2);
+    QCOMPARE(parser.getLastSuccessVal(), TestLines.killMob2Success);
 
-    testParser(parser,
-               {{false, "You cleave a tree-snake's body extremely hard and shatter it."},
-                {false, "Your victim is shocked by your hit!"},
-                {false, "You receive your share of experience."},
-                {false, "Yes! You're beginning to get the idea."},
-                {true, "A tree-snake is dead! R.I.P."}});
-    QCOMPARE(parser.getLastSuccessVal(), "A tree-snake");
+    testParser(parser, TestLines.killMob3);
+    QCOMPARE(parser.getLastSuccessVal(), TestLines.killMob3Success);
+}
+
+void TestAdventure::testE2E()
+{
+    GameObserver *observer = new GameObserver();
+    AdventureTracker *tracker = new AdventureTracker(*observer);
+
+    std::vector<QString> achievements;
+    std::vector<QString> hints;
+    std::vector<QString> killedMobs;
+
+    connect(tracker, &AdventureTracker::sig_achievedSomething, [&achievements](QString x) {
+        achievements.push_back(x);
+    });
+    connect(tracker, &AdventureTracker::sig_receivedHint, [&hints](QString x) {
+        hints.push_back(x);
+    });
+    connect(tracker, &AdventureTracker::sig_killedMob, [&killedMobs](QString x) {
+        killedMobs.push_back(x);
+    });
+
+    auto pump = [observer](std::vector<TestLine> lines) {
+        for (auto tl : lines) {
+            observer->slot_observeSentToUser(qPrintable(tl.line), true);
+        }
+    };
+
+    pump(TestLines.achievement1);
+    pump(TestLines.hint1);
+    pump(TestLines.killMob1);
+    pump(TestLines.killMob2);
+    pump(TestLines.killMob3);
+
+    QCOMPARE(achievements.size(), 1u);
+    QCOMPARE(hints.size(), 1u);
+    QCOMPARE(killedMobs.size(), 3u);
 }
 
 QTEST_MAIN(TestAdventure)

--- a/tests/testadventure.cpp
+++ b/tests/testadventure.cpp
@@ -6,7 +6,6 @@
 #include "adventure/adventuretracker.h"
 #include "observer/gameobserver.h"
 
-#include <algorithm>
 #include <QtTest/QtTest>
 
 struct
@@ -85,7 +84,6 @@ struct
            {true, "*Gaer the Dúnadan Man* has drawn his last breath! R.I.P."},
            {false, "A shadow slowly rises above the corpse of *Gaer the Dúnadan Man*."}};
     const char *killPlayer3Success = "*Gaer the Dúnadan Man*";
-
 } TestLines;
 
 void TestAdventure::testSessionHourlyRateXP()

--- a/tests/testadventure.cpp
+++ b/tests/testadventure.cpp
@@ -121,21 +121,21 @@ void TestAdventure::testKillAndXPParser()
 
 void TestAdventure::testE2E()
 {
-    GameObserver *observer = new GameObserver();
-    AdventureTracker *tracker = new AdventureTracker(*observer);
+    GameObserver *observer{};
+    AdventureTracker *tracker{};
 
-    std::vector<QString> achievements;
-    std::vector<QString> hints;
-    std::vector<QString> killedMobs;
+    std::vector<QString> *achievements{};
+    std::vector<QString> *hints{};
+    std::vector<QString> *killedMobs{};
 
-    connect(tracker, &AdventureTracker::sig_achievedSomething, [&achievements](QString x) {
-        achievements.push_back(x);
+    connect(tracker, &AdventureTracker::sig_achievedSomething, [achievements](QString x) {
+        achievements->push_back(x);
     });
-    connect(tracker, &AdventureTracker::sig_receivedHint, [&hints](QString x) {
-        hints.push_back(x);
+    connect(tracker, &AdventureTracker::sig_receivedHint, [hints](QString x) {
+        hints->push_back(x);
     });
-    connect(tracker, &AdventureTracker::sig_killedMob, [&killedMobs](QString x) {
-        killedMobs.push_back(x);
+    connect(tracker, &AdventureTracker::sig_killedMob, [killedMobs](QString x) {
+        killedMobs->push_back(x);
     });
 
     auto pump = [observer](std::vector<TestLine> lines) {
@@ -150,9 +150,9 @@ void TestAdventure::testE2E()
     pump(TestLines.killMob2);
     pump(TestLines.killMob3);
 
-    QCOMPARE(achievements.size(), 1u);
-    QCOMPARE(hints.size(), 1u);
-    QCOMPARE(killedMobs.size(), 3u);
+    QCOMPARE(achievements->size(), 1u);
+    QCOMPARE(hints->size(), 1u);
+    QCOMPARE(killedMobs->size(), 3u);
 }
 
 QTEST_MAIN(TestAdventure)

--- a/tests/testadventure.cpp
+++ b/tests/testadventure.cpp
@@ -47,6 +47,27 @@ struct
            {true, "A tree-snake is dead! R.I.P."}};
     const char *killMob3Success = "A tree-snake";
 
+    std::vector<TestLine> killPlayer1 = {
+        {false, "You pierce *an Elf* (k)'s right hand extremely hard and shatter it."},
+        {false, "You feel more experienced."},
+        {false, "Congratulations! This is the first time you've killed it!"},
+        {false,
+         "You feel revitalized as the dark power within you drains the last bit of life from *an Elf* (k)."},
+        {false, "You are surrounded by a misty shroud."},
+        {false, "You hear *an Elf* (k)'s death cry as he collapses."},
+        {true, "*an Elf* (k) has drawn his last breath! R.I.P."},
+        {false, "A shadow slowly rises above the corpse of *an Elf* (k)."}};
+    const char *killPlayer1Success = "*an Elf* (k)";
+
+    std::vector<TestLine> killPlayer2
+        = {{false, "You slash *a Half-Elf*'s right hand extremely hard and shatter it."},
+           {false, "Your victim is shocked by your hit!"},
+           {false, "You feel more experienced."},
+           {false, "Yes! You're beginning to get the idea."},
+           {false, "You hear *a Half-Elf*'s death cry as she collapses."},
+           {true, "*a Half-Elf* has drawn her last breath! R.I.P."}};
+    const char *killPlayer2Success = "*a Half-Elf*";
+
 } TestLines;
 
 void TestAdventure::testSessionHourlyRateXP()
@@ -117,16 +138,22 @@ void TestAdventure::testKillAndXPParser()
 
     testParser(parser, TestLines.killMob3);
     QCOMPARE(parser.getLastSuccessVal(), TestLines.killMob3Success);
+
+    testParser(parser, TestLines.killPlayer1);
+    QCOMPARE(parser.getLastSuccessVal(), TestLines.killPlayer1Success);
+
+    testParser(parser, TestLines.killPlayer2);
+    QCOMPARE(parser.getLastSuccessVal(), TestLines.killPlayer2Success);
 }
 
 void TestAdventure::testE2E()
 {
-    GameObserver *observer{};
-    AdventureTracker *tracker{};
+    GameObserver *observer = new GameObserver();
+    AdventureTracker *tracker = new AdventureTracker(*observer);
 
-    std::vector<QString> *achievements{};
-    std::vector<QString> *hints{};
-    std::vector<QString> *killedMobs{};
+    std::vector<QString> *achievements = new std::vector<QString>();
+    std::vector<QString> *hints = new std::vector<QString>();
+    std::vector<QString> *killedMobs = new std::vector<QString>();
 
     connect(tracker, &AdventureTracker::sig_achievedSomething, [achievements](QString x) {
         achievements->push_back(x);
@@ -149,10 +176,12 @@ void TestAdventure::testE2E()
     pump(TestLines.killMob1);
     pump(TestLines.killMob2);
     pump(TestLines.killMob3);
+    pump(TestLines.killPlayer1);
+    pump(TestLines.killPlayer2);
 
     QCOMPARE(achievements->size(), 1u);
     QCOMPARE(hints->size(), 1u);
-    QCOMPARE(killedMobs->size(), 3u);
+    QCOMPARE(killedMobs->size(), 5u);
 }
 
 QTEST_MAIN(TestAdventure)

--- a/tests/testadventure.cpp
+++ b/tests/testadventure.cpp
@@ -68,6 +68,17 @@ struct
            {true, "*a Half-Elf* has drawn her last breath! R.I.P."}};
     const char *killPlayer2Success = "*a Half-Elf*";
 
+    std::vector<TestLine> killPlayer3
+        = {{false, "You pierce *Gaer the Dúnadan Man*'s body extremely hard and shatter it."},
+           {false, "Your victim is shocked by your hit!"},
+           {false, "You feel more experienced."},
+           {false, "Congratulations! This is the first time you've killed it!"},
+           {false, "You gained some renown in this battle!"},
+           {false, "You hear *Gaer the Dúnadan Man*'s death cry as he collapses."},
+           {true, "*Gaer the Dúnadan Man* has drawn his last breath! R.I.P."},
+           {false, "A shadow slowly rises above the corpse of *Gaer the Dúnadan Man*."}};
+    const char *killPlayer3Success = "*Gaer the Dúnadan Man*";
+
 } TestLines;
 
 void TestAdventure::testSessionHourlyRateXP()
@@ -144,6 +155,9 @@ void TestAdventure::testKillAndXPParser()
 
     testParser(parser, TestLines.killPlayer2);
     QCOMPARE(parser.getLastSuccessVal(), TestLines.killPlayer2Success);
+
+    testParser(parser, TestLines.killPlayer3);
+    QCOMPARE(parser.getLastSuccessVal(), TestLines.killPlayer3Success);
 }
 
 void TestAdventure::testE2E()
@@ -178,10 +192,11 @@ void TestAdventure::testE2E()
     pump(TestLines.killMob3);
     pump(TestLines.killPlayer1);
     pump(TestLines.killPlayer2);
+    pump(TestLines.killPlayer3);
 
     QCOMPARE(achievements->size(), 1u);
     QCOMPARE(hints->size(), 1u);
-    QCOMPARE(killedMobs->size(), 5u);
+    QCOMPARE(killedMobs->size(), 6u);
 }
 
 QTEST_MAIN(TestAdventure)

--- a/tests/testadventure.cpp
+++ b/tests/testadventure.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) 2023 The MMapper Authors
 
 #include "testadventure.h"
+#include "../src/adventure/adventuresession.h"
 #include "../src/adventure/lineparsers.h"
 
 #include <QtTest/QtTest>
@@ -9,6 +10,41 @@
 TestAdventure::TestAdventure() = default;
 
 TestAdventure::~TestAdventure() = default;
+
+void TestAdventure::testSessionHourlyRateXP()
+{
+    AdventureSession session{"ChillbroBaggins"};
+
+    session.updateXP(0.0);
+    session.updateXP(60000.0);
+    session.endSession(); // must endSession() else will keep internally using now() for endTime
+
+    QCOMPARE(session.xp().gainedSession(), 60000.0);
+
+    // 20 minutes, hourly rate = 60k x 3 = 180k
+    session.m_endTimePoint = session.m_startTimePoint + std::chrono::minutes(20);
+    QCOMPARE(session.calculateHourlyRateXP(), 180000.0);
+
+    // 30 minutes, hourly rate = 60k x 2 = 120k
+    session.m_endTimePoint = session.m_startTimePoint + std::chrono::minutes(30);
+    QCOMPARE(session.calculateHourlyRateXP(), 120000.0);
+
+    // 60 minutes, hourly rate = 60k x 1 = 60k
+    session.m_endTimePoint = session.m_startTimePoint + std::chrono::minutes(60);
+    QCOMPARE(session.calculateHourlyRateXP(), 60000.0);
+
+    // 90 minutes, hourly rate = 60k x 2/3 = 40k
+    session.m_endTimePoint = session.m_startTimePoint + std::chrono::minutes(90);
+    QCOMPARE(session.calculateHourlyRateXP(), 40000.0);
+
+    // 120 minutes, hourly rate = 60k x 1/2 = 30k
+    session.m_endTimePoint = session.m_startTimePoint + std::chrono::minutes(120);
+    QCOMPARE(session.calculateHourlyRateXP(), 30000.0);
+
+    // 600 minutes, hourly rate = 60k x 1/10 = 10k
+    session.m_endTimePoint = session.m_startTimePoint + std::chrono::minutes(600);
+    QCOMPARE(session.calculateHourlyRateXP(), 6000.0);
+}
 
 void TestAdventure::testAccomplishedTaskParser() {}
 
@@ -22,7 +58,7 @@ void TestAdventure::testHintParser() {}
 
 void TestAdventure::testKillAndXPParser()
 {
-    std::vector<QString> lines = {"foo", "bar", "hoochie"};
+    std::vector<QString> lines = {"foo", "bar", "baz"};
     std::vector<bool> parseResults{};
 
     KillAndXPParser parser{};

--- a/tests/testadventure.h
+++ b/tests/testadventure.h
@@ -13,6 +13,9 @@ public:
     ~TestAdventure() final;
 
 private Q_SLOTS:
+
+    void testSessionHourlyRateXP();
+
     void testAccomplishedTaskParser();
     void testAchievementParser();
     void testDiedParser();

--- a/tests/testadventure.h
+++ b/tests/testadventure.h
@@ -1,0 +1,22 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2023 The MMapper Authors
+
+#include <QObject>
+
+class TestAdventure final : public QObject
+{
+    Q_OBJECT
+
+public:
+    TestAdventure();
+    ~TestAdventure() final;
+
+private Q_SLOTS:
+    void testAccomplishedTaskParser();
+    void testAchievementParser();
+    void testDiedParser();
+    void testGainedLevelParser();
+    void testHintParser();
+    void testKillAndXPParser();
+};

--- a/tests/testadventure.h
+++ b/tests/testadventure.h
@@ -2,24 +2,32 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (C) 2023 The MMapper Authors
 
+#include "adventure/lineparsers.h"
 #include <QObject>
+
+struct TestLine
+{
+    bool expected;
+    QString line;
+
+    QString errorMsg()
+    {
+        return QString("Parsing failed, expected %1 for line: %2").arg(expected).arg(line);
+    }
+};
 
 class TestAdventure final : public QObject
 {
     Q_OBJECT
 
-public:
-    TestAdventure();
-    ~TestAdventure() final;
+    void testParser(AbstractLineParser &parser, std::vector<TestLine> testLines);
 
-private Q_SLOTS:
+private slots:
 
     void testSessionHourlyRateXP();
 
     void testAccomplishedTaskParser();
     void testAchievementParser();
-    void testDiedParser();
-    void testGainedLevelParser();
     void testHintParser();
     void testKillAndXPParser();
 };

--- a/tests/testadventure.h
+++ b/tests/testadventure.h
@@ -26,8 +26,9 @@ private slots:
 
     void testSessionHourlyRateXP();
 
-    void testAccomplishedTaskParser();
     void testAchievementParser();
     void testHintParser();
     void testKillAndXPParser();
+
+    void testE2E();
 };


### PR DESCRIPTION
Ready. I might add some more unit tests to bring code coverage up.

Basic stuff:
 - Fix XP hourly rate calculation which I sadly broke at the last minute trying to do std::chrono stuff
 - Add support for player kill trophy / xp
 - Simple unit tests

