### PR TITLE
Timer bugfix

### DIFF
--- a/src/parser/AbstractParser-Actions.cpp
+++ b/src/parser/AbstractParser-Actions.cpp
@@ -281,7 +281,7 @@ void AbstractParser::initActionMap()
     /// Stat
     addRegex(R"(^)"
              R"((?:Needed:(?: [\d,]+ xp)?(?:,? [\d,]+ tp)\. )?)" // Needed
-             R"(Gold: [\d,]+\.)"                                 // Gold
+             R"((Gold|Lauren): [\d,]+\.)"                        // Gold
              R"((?: Iv: [^.]+\.)?)"                              // God Invis Level
              R"( Alert: \w+\.)"                                  // Alertness
              R"((?: Condition: [^.]+\.)?)",                      // Hunger or Thirst

--- a/src/parser/AbstractParser-Timer.cpp
+++ b/src/parser/AbstractParser-Timer.cpp
@@ -58,10 +58,10 @@ void AbstractParser::parseTimer(StringView input)
             const std::string desc = concatenate_unquoted(v[4].getVector());
 
             m_timers.addCountdown(name, desc, delay * 1000);
-            os << "Added countdown timer" << name;
+            os << "Added countdown timer " << name;
             if (!desc.empty())
                 os << " <" << desc << ">";
-            os << " for duration of " << delay << " seconds." << std::endl;
+            os << " for the duration of " << delay << " seconds." << std::endl;
             send_ok(os);
         },
         "add countdown timer");
@@ -80,7 +80,7 @@ void AbstractParser::parseTimer(StringView input)
             const std::string desc = concatenate_unquoted(v[3].getVector());
 
             m_timers.addTimer(name, desc);
-            os << "Added simple timer" << name;
+            os << "Added simple timer " << name;
             if (!desc.empty())
                 os << " <" << desc << ">";
             os << "." << std::endl;


### PR DESCRIPTION
1. Fixes bug when "Lauren" is in "stat" instead of "Gold", then timers were not shown
2. Fixes grammar bug where "_timer add simple qq" would produce text "Added simple timerqq." instead of "Added simple timer qq."
3. Fixes grammar bug where "_timer add countdown jj 299" would produce text "Added countdown timerjj for duration of 299 seconds." instead of "Added countdown timer jj for duration of 299 seconds."