### PR TITLE
Add missing include for uint64_t

### DIFF
--- a/src/global/utils.h
+++ b/src/global/utils.h
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstdint>
 #include <cstring>
 #include <memory>
 #include <optional>


### PR DESCRIPTION
With gcc 15 it is necessary to explicitly include <cstdint> for uint64_t.