### PR TITLE
enable /Ob2 for MSVC debug enabled builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,6 +380,10 @@ if(MSVC)
     add_compile_options(/Zc:__cplusplus)
     add_compile_options(/utf-8)
     add_compile_options(/permissive-)
+    if(CMAKE_BUILD_TYPE_UPPER MATCHES "^(DEBUG|RELWITHDEBINFO)$")
+	    # improve performance
+	    add_compile_options(/Ob2)
+	endif()
 endif()
 
 # Download arda.mm2


### PR DESCRIPTION
Enables inline function expansion for MSVC builds to improve performance

## Summary by Sourcery

Build:
- Add /Ob2 flag to MSVC compile options for DEBUG and RelWithDebInfo configurations to improve performance