### PR TITLE
switch to supported macOS 15 Intel runner

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, macos-14-large, macos-14, ubuntu-22.04, ubuntu-22.04-arm]
+        os: [windows-2022, macos-15-intel, macos-15, ubuntu-22.04, ubuntu-22.04-arm]
     steps:
     - uses: actions/checkout@v5
       with:


### PR DESCRIPTION
macOS 15 Intel runner image will be retired in Fall 2027. We should switch to macos-15-intel when macOS 14 is unsupported.

## Summary by Sourcery

Enhancements:
- Update GitHub Actions build-release matrix to replace the deprecated macos-13 runner with the supported macos-14-large runner