### PR TITLE
Restrict /Ob2 to RelWithDebInfo build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,7 +380,7 @@ if(MSVC)
     add_compile_options(/Zc:__cplusplus)
     add_compile_options(/utf-8)
     add_compile_options(/permissive-)
-    if(CMAKE_BUILD_TYPE_UPPER MATCHES "^(DEBUG|RELWITHDEBINFO)$")
+    if(CMAKE_BUILD_TYPE_UPPER MATCHES "^RELWITHDEBINFO$")
 	    # improve performance
 	    add_compile_options(/Ob2)
 	endif()


### PR DESCRIPTION
## Summary by Sourcery

Restrict MSVC /Ob2 optimization flag to RelWithDebInfo builds only.

Build:
- Only enable the /Ob2 compile option when the build type is RELWITHDEBINFO
- Remove /Ob2 optimization from DEBUG builds