### PR TITLE
fix sanitizer to replace control characters with a question mark

### DIFF
--- a/src/global/Charset.h
+++ b/src/global/Charset.h
@@ -256,6 +256,11 @@ public:
     void append_char(const char c) { get_ostream() << maybe_ascii(c); }
     void append_codepoint(const char32_t codepoint)
     {
+        if (codepoint <= char_consts::C_DELETE
+            && charset::ascii::isCntrl(static_cast<char>(codepoint))) {
+            append_char(charset_detail::DEFAULT_UNMAPPED_CHARACTER);
+            return;
+        }
         append_char(to_latin1(maybe_transit_unicode(codepoint)));
     }
     void operator()(const char32_t codepoint) { append_codepoint(codepoint); }


### PR DESCRIPTION
This fixes corrupted user maps with a "River Lh\x00n" room name.

## Summary by Sourcery

Map ASCII control characters including NUL to the default unmapped character ('?') during sanitization and charset insertion.

Bug Fixes:
- Sanitizer now replaces NUL (and other control characters) with '?' in one-line, multiline, and word-wrapped output
- BasicCharsetInserter now maps ASCII control code points to the default unmapped character instead of passing them through

Tests:
- Add test_nul to verify NUL is replaced with '?' in sanitizeOneLine, sanitizeMultiline, and sanitizeWordWrapped