### PR TITLE
add visual bell and configuration toggle for audible bell

### DIFF
--- a/src/client/ClientTelnet.cpp
+++ b/src/client/ClientTelnet.cpp
@@ -13,7 +13,6 @@
 #include <limits>
 #include <tuple>
 
-#include <QApplication>
 #include <QByteArray>
 #include <QHostAddress>
 #include <QMessageLogContext>
@@ -134,14 +133,6 @@ void ClientTelnet::virt_sendToMapper(const RawBytes &data, bool /*goAhead*/)
     // The encoding for the built-in client is always Utf8.
     assert(getEncoding() == CharacterEncodingEnum::UTF8);
     QString out = QString::fromUtf8(data.getQByteArray());
-
-    // Replace BEL character with an application beep
-    // REVISIT: This seems like the WRONG place to do this.
-    static constexpr const QChar BEL = mmqt::QC_ALERT;
-    if (out.contains(BEL)) {
-        out.remove(BEL);
-        QApplication::beep();
-    }
 
     // REVISIT: Why is virt_sendToMapper() calling sendToUser()? One needs to be renamed?
     m_output.sendToUser(out);

--- a/src/client/ClientWidget.cpp
+++ b/src/client/ClientWidget.cpp
@@ -163,7 +163,7 @@ void ClientWidget::initClientTelnet()
         }
         void virt_disconnected() final
         {
-            getDisplay().slot_displayText("\n\n\n");
+            getDisplay().slot_displayText(QStringLiteral("\n\n\n"));
             getClient().relayMessage("Disconnected using the integrated client");
         }
         void virt_socketError(const QString &errorStr) final

--- a/src/client/displaywidget.h
+++ b/src/client/displaywidget.h
@@ -16,6 +16,7 @@
 #include <QTextCursor>
 #include <QTextEdit>
 #include <QTextFormat>
+#include <QTimer>
 #include <QtCore>
 #include <QtGui>
 
@@ -62,7 +63,7 @@ struct NODISCARD AnsiTextHelper final
     {}
 
     void init();
-    void displayText(const QString &str);
+    void displayText(const QStringView str);
     void limitScrollback(int lineLimit);
 };
 
@@ -101,6 +102,7 @@ private:
 private:
     DisplayWidgetOutputs *m_output = nullptr;
     AnsiTextHelper m_ansiTextHelper;
+    QTimer *m_timer = nullptr;
     bool m_canCopy = false;
 
 public:
@@ -135,5 +137,5 @@ protected:
     void keyPressEvent(QKeyEvent *event) override;
 
 public slots:
-    void slot_displayText(const QString &str);
+    void slot_displayText(const QStringView str);
 };

--- a/src/configuration/configuration.cpp
+++ b/src/configuration/configuration.cpp
@@ -291,6 +291,8 @@ ConstString KEY_USE_INTERNAL_EDITOR = "Use internal editor";
 ConstString KEY_USE_TRILINEAR_FILTERING = "Use trilinear filtering";
 ConstString KEY_WINDOW_GEOMETRY = "Window Geometry";
 ConstString KEY_WINDOW_STATE = "Window State";
+ConstString KEY_BELL_AUDIBLE = "Bell audible";
+ConstString KEY_BELL_VISUAL = "Bell visual";
 
 void Settings::tryCopyOldSettings()
 {
@@ -716,6 +718,8 @@ void Configuration::IntegratedMudClientSettings::read(const QSettings &conf)
     clearInputOnEnter = conf.value(KEY_CLEAR_INPUT_ON_ENTER, false).toBool();
     autoResizeTerminal = conf.value(KEY_AUTO_RESIZE_TERMINAL, true).toBool();
     linesOfPeekPreview = conf.value(KEY_LINES_OF_PEEK_PREVIEW, 7).toInt();
+    audibleBell = conf.value(KEY_BELL_AUDIBLE, true).toBool();
+    visualBell = conf.value(KEY_BELL_VISUAL, false).toBool();
 }
 
 void Configuration::RoomPanelSettings::read(const QSettings &conf)
@@ -882,6 +886,8 @@ void Configuration::IntegratedMudClientSettings::write(QSettings &conf) const
     conf.setValue(KEY_CLEAR_INPUT_ON_ENTER, clearInputOnEnter);
     conf.setValue(KEY_AUTO_RESIZE_TERMINAL, autoResizeTerminal);
     conf.setValue(KEY_LINES_OF_PEEK_PREVIEW, linesOfPeekPreview);
+    conf.setValue(KEY_BELL_AUDIBLE, audibleBell);
+    conf.setValue(KEY_BELL_VISUAL, visualBell);
 }
 
 void Configuration::RoomPanelSettings::write(QSettings &conf) const

--- a/src/configuration/configuration.h
+++ b/src/configuration/configuration.h
@@ -347,6 +347,8 @@ public:
         bool clearInputOnEnter = false;
         bool autoResizeTerminal = false;
         int linesOfPeekPreview = 0;
+        bool audibleBell = false;
+        bool visualBell = false;
 
     private:
         SUBGROUP();

--- a/src/preferences/clientpage.cpp
+++ b/src/preferences/clientpage.cpp
@@ -66,6 +66,14 @@ ClientPage::ClientPage(QWidget *parent)
         /* NOTE: This directly modifies the global setting. */
         setConfig().integratedClient.autoResizeTerminal = isChecked;
     });
+
+    connect(ui->audibleBellCheckBox, &QCheckBox::toggled, [](bool isChecked) {
+        setConfig().integratedClient.audibleBell = isChecked;
+    });
+
+    connect(ui->visualBellCheckBox, &QCheckBox::toggled, [](bool isChecked) {
+        setConfig().integratedClient.visualBell = isChecked;
+    });
 }
 
 ClientPage::~ClientPage()
@@ -86,6 +94,8 @@ void ClientPage::slot_loadConfig()
     ui->tabDictionarySpinBox->setValue(settings.tabCompletionDictionarySize);
     ui->clearInputCheckBox->setChecked(settings.clearInputOnEnter);
     ui->autoResizeTerminalCheckBox->setChecked(settings.autoResizeTerminal);
+    ui->audibleBellCheckBox->setChecked(settings.audibleBell);
+    ui->visualBellCheckBox->setChecked(settings.visualBell);
 }
 
 void ClientPage::updateFontAndColors()

--- a/src/preferences/clientpage.ui
+++ b/src/preferences/clientpage.ui
@@ -207,6 +207,26 @@
       <item row="5" column="1">
        <widget class="QSpinBox" name="previewSpinBox"/>
       </item>
+      <item row="7" column="0" colspan="2">
+       <widget class="QCheckBox" name="audibleBellCheckBox">
+        <property name="text">
+         <string>Audible bell</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0" colspan="2">
+       <widget class="QCheckBox" name="visualBellCheckBox">
+        <property name="text">
+         <string>Visual bell</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
## Summary by Sourcery

Implement a configurable visual bell alongside the existing audible bell by centralizing bell processing in the display logic, exposing new toggles in the preferences, and persisting these settings.

New Features:
- Add visual bell flash effect when receiving a bell character
- Introduce user preferences to enable or disable audible and visual bells

Enhancements:
- Centralize bell handling in AnsiTextHelper and remove legacy beep logic from ClientTelnet
- Persist audible and visual bell settings in configuration and sync with the preferences UI