### PR TITLE
split log saving into separate actions

### DIFF
--- a/src/client/ClientWidget.h
+++ b/src/client/ClientWidget.h
@@ -93,4 +93,5 @@ public slots:
     void slot_onVisibilityChanged(bool);
     void slot_onShowMessage(const QString &);
     void slot_saveLog();
+    void slot_saveLogAsHtml();
 };

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -879,10 +879,19 @@ void MainWindow::createActions()
     connect(clientAct, &QAction::triggered, this, &MainWindow::slot_onLaunchClient);
 
     saveLogAct = new QAction(QIcon::fromTheme("document-save", QIcon(":/icons/save.png")),
-                             tr("&Save log as..."),
+                             tr("Save Log as &Plain Text..."),
                              this);
     connect(saveLogAct, &QAction::triggered, m_clientWidget, &ClientWidget::slot_saveLog);
-    saveLogAct->setStatusTip(tr("Save log as file"));
+    saveLogAct->setStatusTip(tr("Save log as plain text file"));
+
+    saveLogAsHtmlAct = new QAction(QIcon::fromTheme("document-save", QIcon(":/icons/save.png")),
+                                   tr("Save Log as &HTML..."),
+                                   this);
+    connect(saveLogAsHtmlAct,
+            &QAction::triggered,
+            m_clientWidget,
+            &ClientWidget::slot_saveLogAsHtml);
+    saveLogAsHtmlAct->setStatusTip(tr("Save log as HTML file"));
 
     releaseAllPathsAct = new QAction(QIcon(":/icons/cancel.png"), tr("Release All Paths"), this);
     releaseAllPathsAct->setStatusTip(tr("Release all paths"));
@@ -1186,6 +1195,7 @@ void MainWindow::setupMenuBar()
                                               tr("&Integrated Mud Client"));
     clientMenu->addAction(clientAct);
     clientMenu->addAction(saveLogAct);
+    clientMenu->addAction(saveLogAsHtmlAct);
     QMenu *pathMachineMenu = settingsMenu->addMenu(QIcon(":/icons/goto.png"), tr("&Path Machine"));
     pathMachineMenu->addAction(mouseMode.modeRoomSelectAct);
     pathMachineMenu->addSeparator();

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -222,6 +222,7 @@ private:
 
     QAction *clientAct = nullptr;
     QAction *saveLogAct = nullptr;
+    QAction *saveLogAsHtmlAct = nullptr;
 
     QAction *gotoRoomAct = nullptr;
     QAction *forceRoomAct = nullptr;


### PR DESCRIPTION
## Summary by Sourcery

Split log saving into distinct plain text and HTML actions with timestamped default filenames and simplified saving logic

New Features:
- Add slot_saveLogAsHtml method and corresponding "Save Log as HTML" action
- Rename existing save log action to reflect plain text saving

Enhancements:
- Simplify slot_saveLog to always save plain text using QFileDialog::saveFileContent
- Remove interactive file type selection and generate timestamped default filenames for both log formats