### PR TITLE
integrated client uses a virtual socket to connect to the proxy

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -480,6 +480,7 @@ set(mmapper_SRCS
     preferences/parserpage.h
     preferences/pathmachinepage.cpp
     preferences/pathmachinepage.h
+    proxy/AbstractSocket.h
     proxy/AbstractTelnet.cpp
     proxy/AbstractTelnet.h
     proxy/GmcpMessage.cpp
@@ -492,10 +493,14 @@ set(mmapper_SRCS
     proxy/MudTelnet.h
     proxy/ProxyParserApi.cpp
     proxy/ProxyParserApi.h
+    proxy/TcpSocket.cpp
+    proxy/TcpSocket.h
     proxy/TextCodec.cpp
     proxy/TextCodec.h
     proxy/UserTelnet.cpp
     proxy/UserTelnet.h
+    proxy/VirtualSocket.cpp
+    proxy/VirtualSocket.h
     proxy/connectionlistener.cpp
     proxy/connectionlistener.h
     proxy/mumesocket.cpp

--- a/src/client/ClientTelnet.h
+++ b/src/client/ClientTelnet.h
@@ -8,10 +8,12 @@
 #include "../global/io.h"
 #include "../global/utils.h"
 #include "../proxy/AbstractTelnet.h"
+#include "../proxy/VirtualSocket.h"
 
 #include <QAbstractSocket>
 #include <QObject>
-#include <QTcpSocket>
+
+class ConnectionListener;
 
 struct ClientTelnetOutputs
 {
@@ -43,7 +45,7 @@ class NODISCARD ClientTelnet final : AbstractTelnet
 private:
     ClientTelnetOutputs &m_output;
     io::buffer<(1 << 15)> m_buffer;
-    QTcpSocket m_socket;
+    VirtualSocket m_socket;
     QObject m_dummy;
 
 public:
@@ -54,8 +56,9 @@ private:
     NODISCARD ClientTelnetOutputs &getOutput() { return m_output; }
 
 public:
-    void connectToHost();
+    void connectToHost(ConnectionListener *listener);
     void disconnectFromHost();
+    NODISCARD bool isConnected() const { return m_socket.isConnected(); }
 
 private:
     void virt_sendToMapper(const RawBytes &, bool goAhead) final;

--- a/src/client/ClientWidget.h
+++ b/src/client/ClientWidget.h
@@ -19,6 +19,7 @@ class QEvent;
 class QObject;
 class StackedInputWidget;
 class PreviewWidget;
+class ConnectionListener;
 
 struct ClientTelnetOutputs;
 struct DisplayWidgetOutputs;
@@ -54,9 +55,10 @@ private:
     };
 
     Pipeline m_pipeline;
+    ConnectionListener *m_listener = nullptr;
 
 public:
-    explicit ClientWidget(QWidget *parent);
+    explicit ClientWidget(ConnectionListener *listener, QWidget *parent);
     ~ClientWidget() final;
 
 private:
@@ -78,6 +80,7 @@ private:
 
 public:
     NODISCARD bool isUsingClient() const;
+    void displayReconnectHint();
 
 private:
     void relayMessage(const QString &msg) { emit sig_relayMessage(msg); }

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -148,18 +148,6 @@ MainWindow::MainWindow()
     m_gameObserver = std::make_unique<GameObserver>();
     m_adventureTracker = new AdventureTracker(deref(m_gameObserver), this);
 
-    // View -> Side Panels -> Client Panel
-    m_clientWidget = new ClientWidget(this);
-    m_clientWidget->setObjectName("InternalMudClientWidget");
-    m_dockDialogClient = new QDockWidget("Client Panel", this);
-    m_dockDialogClient->setObjectName("DockWidgetClient");
-    m_dockDialogClient->setAllowedAreas(Qt::AllDockWidgetAreas);
-    m_dockDialogClient->setFeatures(QDockWidget::DockWidgetMovable
-                                    | QDockWidget::DockWidgetFloatable
-                                    | QDockWidget::DockWidgetClosable);
-    addDockWidget(Qt::LeftDockWidgetArea, m_dockDialogClient);
-    m_dockDialogClient->setWidget(m_clientWidget);
-
     // View -> Side Panels -> Log Panel
     m_dockDialogLog = new QDockWidget(tr("Log Panel"), this);
     m_dockDialogLog->setObjectName("DockWidgetLog");
@@ -234,16 +222,6 @@ MainWindow::MainWindow()
         m_updateDialog = new UpdateDialog(this);
     }
 
-    createActions();
-    setupToolBars();
-    setupMenuBar();
-    setupStatusBar();
-
-    setCorner(Qt::TopLeftCorner, Qt::TopDockWidgetArea);
-    setCorner(Qt::BottomLeftCorner, Qt::BottomDockWidgetArea);
-    setCorner(Qt::TopRightCorner, Qt::TopDockWidgetArea);
-    setCorner(Qt::BottomRightCorner, Qt::BottomDockWidgetArea);
-
     m_logger = new AutoLogger(this);
 
     // TODO move this connect() wiring into AutoLogger::ctor ?
@@ -270,6 +248,28 @@ MainWindow::MainWindow()
                                         deref(getCanvas()),
                                         deref(m_gameObserver),
                                         this);
+
+    // View -> Side Panels -> Client Panel
+    m_clientWidget = new ClientWidget(m_listener, this);
+    m_clientWidget->setObjectName("InternalMudClientWidget");
+    m_dockDialogClient = new QDockWidget("Client Panel", this);
+    m_dockDialogClient->setObjectName("DockWidgetClient");
+    m_dockDialogClient->setAllowedAreas(Qt::AllDockWidgetAreas);
+    m_dockDialogClient->setFeatures(QDockWidget::DockWidgetMovable
+                                    | QDockWidget::DockWidgetFloatable
+                                    | QDockWidget::DockWidgetClosable);
+    addDockWidget(Qt::LeftDockWidgetArea, m_dockDialogClient);
+    m_dockDialogClient->setWidget(m_clientWidget);
+
+    createActions();
+    setupToolBars();
+    setupMenuBar();
+    setupStatusBar();
+
+    setCorner(Qt::TopLeftCorner, Qt::TopDockWidgetArea);
+    setCorner(Qt::BottomLeftCorner, Qt::BottomDockWidgetArea);
+    setCorner(Qt::TopRightCorner, Qt::TopDockWidgetArea);
+    setCorner(Qt::BottomRightCorner, Qt::BottomDockWidgetArea);
 
     // update connections
     wireConnections();
@@ -1675,7 +1675,6 @@ void MainWindow::slot_onFindRoom()
 void MainWindow::slot_onLaunchClient()
 {
     m_dockDialogClient->show();
-    m_clientWidget->setFocus();
 }
 
 void MainWindow::setCurrentFile(const QString &fileName)

--- a/src/proxy/AbstractSocket.h
+++ b/src/proxy/AbstractSocket.h
@@ -1,0 +1,33 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2025 The MMapper Authors
+// Author: Nils Schimmelmann <nschimme@gmail.com> (Jahara)
+
+#include "../global/macros.h"
+
+#include <QIODevice>
+
+class NODISCARD_QOBJECT AbstractSocket : public QIODevice
+{
+    Q_OBJECT
+
+public:
+    explicit AbstractSocket(QObject *parent = nullptr)
+        : QIODevice(parent)
+    {}
+    ~AbstractSocket() override = default;
+
+public:
+    void flush() { virt_flush(); }
+    void disconnectFromHost() { virt_disconnectFromHost(); }
+    NODISCARD bool isConnected() const { return virt_isConnected(); }
+
+private:
+    virtual void virt_flush() = 0;
+    virtual void virt_disconnectFromHost() = 0;
+    NODISCARD virtual bool virt_isConnected() const = 0;
+
+signals:
+    void sig_connected();
+    void sig_disconnected();
+};

--- a/src/proxy/TcpSocket.cpp
+++ b/src/proxy/TcpSocket.cpp
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2025 The MMapper Authors
+// Author: Nils Schimmelmann <nschimme@gmail.com> (Jahara)
+
+#include "TcpSocket.h"
+
+#include <stdexcept>
+
+TcpSocket::TcpSocket(qintptr socketDescriptor, QObject *parent)
+    : AbstractSocket(parent)
+{
+    if (!m_socket.setSocketDescriptor(socketDescriptor)) {
+        throw std::runtime_error("failed to accept user socket");
+    }
+    m_socket.setSocketOption(QAbstractSocket::LowDelayOption, true);
+    m_socket.setSocketOption(QAbstractSocket::KeepAliveOption, true);
+    connect(&m_socket, &QAbstractSocket::connected, this, &AbstractSocket::sig_connected);
+    connect(&m_socket, &QAbstractSocket::disconnected, this, &AbstractSocket::sig_disconnected);
+    connect(&m_socket, &QIODevice::readyRead, this, &AbstractSocket::readyRead);
+    open(QIODevice::ReadWrite);
+}
+
+TcpSocket::~TcpSocket()
+{
+    disconnectFromHost();
+}
+
+void TcpSocket::virt_flush()
+{
+    m_socket.flush();
+}
+
+void TcpSocket::virt_disconnectFromHost()
+{
+    m_socket.disconnectFromHost();
+    if (m_socket.state() != QAbstractSocket::UnconnectedState) {
+        m_socket.waitForDisconnected();
+    }
+}
+
+bool TcpSocket::virt_isConnected() const
+{
+    return m_socket.state() == QAbstractSocket::ConnectedState;
+}
+
+qint64 TcpSocket::bytesAvailable() const
+{
+    return m_socket.bytesAvailable();
+}
+
+qint64 TcpSocket::readData(char *data, qint64 maxlen)
+{
+    return m_socket.read(data, maxlen);
+}
+
+qint64 TcpSocket::writeData(const char *data, qint64 len)
+{
+    return m_socket.write(data, len);
+}

--- a/src/proxy/TcpSocket.h
+++ b/src/proxy/TcpSocket.h
@@ -1,0 +1,30 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2025 The MMapper Authors
+// Author: Nils Schimmelmann <nschimme@gmail.com> (Jahara)
+
+#include "AbstractSocket.h"
+
+#include <QTcpSocket>
+
+class NODISCARD_QOBJECT TcpSocket final : public AbstractSocket
+{
+    Q_OBJECT
+
+public:
+    explicit TcpSocket(qintptr socketDescriptor, QObject *parent = nullptr);
+    ~TcpSocket() final;
+
+    void virt_flush() override;
+    void virt_disconnectFromHost() override;
+    NODISCARD bool virt_isConnected() const override;
+
+    NODISCARD qint64 bytesAvailable() const override;
+
+protected:
+    NODISCARD qint64 readData(char *data, qint64 maxlen) override;
+    NODISCARD qint64 writeData(const char *data, qint64 len) override;
+
+private:
+    QTcpSocket m_socket;
+};

--- a/src/proxy/VirtualSocket.cpp
+++ b/src/proxy/VirtualSocket.cpp
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2025 The MMapper Authors
+// Author: Nils Schimmelmann <nschimme@gmail.com> (Jahara)
+
+#include "VirtualSocket.h"
+
+#include <algorithm>
+#include <stdexcept>
+
+#include <QPointer>
+#include <QTimer>
+
+VirtualSocket::VirtualSocket(QObject *parent)
+    : AbstractSocket(parent)
+{
+    open(QIODevice::ReadWrite);
+}
+
+VirtualSocket::~VirtualSocket()
+{
+    disconnectFromHost();
+}
+
+void VirtualSocket::connectToPeer(VirtualSocket *peer)
+{
+    assert(peer != nullptr && this != peer);
+
+    if (m_peer != nullptr || peer->m_peer != nullptr) {
+        throw std::runtime_error("already connected");
+    }
+
+    m_peer = peer;
+    peer->m_peer = this;
+    QObject::connect(peer, &QObject::destroyed, this, &VirtualSocket::slot_onPeerDestroyed);
+    emit sig_connected();
+    emit peer->sig_connected();
+}
+
+void VirtualSocket::virt_flush() {}
+
+void VirtualSocket::virt_disconnectFromHost()
+{
+    if (!m_peer) {
+        return;
+    }
+
+    QPointer<VirtualSocket> peerToNotify = m_peer;
+    if (m_peer) {
+        m_peer->m_peer = nullptr;
+    }
+    m_peer = nullptr;
+
+    emit sig_disconnected();
+    if (peerToNotify) {
+        emit peerToNotify->sig_disconnected();
+    }
+}
+
+bool VirtualSocket::virt_isConnected() const
+{
+    return m_peer != nullptr && m_peer->m_peer != nullptr;
+}
+
+void VirtualSocket::slot_onPeerDestroyed()
+{
+    if (m_peer) {
+        m_peer = nullptr;
+        emit sig_disconnected();
+    }
+}
+
+void VirtualSocket::writeToPeer(const QByteArray &data)
+{
+    m_buffer.append(data);
+    QTimer::singleShot(0, this, [this]() { emit readyRead(); });
+}
+
+qint64 VirtualSocket::bytesAvailable() const
+{
+    return m_buffer.size();
+}
+
+qint64 VirtualSocket::readData(char *data, qint64 maxlen)
+{
+    auto len = std::min(maxlen, static_cast<qint64>(m_buffer.size()));
+    memcpy(data, m_buffer.constData(), static_cast<size_t>(len));
+    m_buffer.remove(0, len);
+    return len;
+}
+
+qint64 VirtualSocket::writeData(const char *data, qint64 len)
+{
+    if (m_peer) {
+        m_peer->writeToPeer(QByteArray(data, len));
+    }
+    return len;
+}

--- a/src/proxy/VirtualSocket.h
+++ b/src/proxy/VirtualSocket.h
@@ -1,0 +1,38 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2025 The MMapper Authors
+// Author: Nils Schimmelmann <nschimme@gmail.com> (Jahara)
+
+#include "AbstractSocket.h"
+
+#include <QByteArray>
+#include <QPointer>
+
+class NODISCARD_QOBJECT VirtualSocket final : public AbstractSocket
+{
+    Q_OBJECT
+
+public:
+    explicit VirtualSocket(QObject *parent = nullptr);
+    ~VirtualSocket() final;
+
+    void virt_flush() override;
+    void virt_disconnectFromHost() override;
+    NODISCARD bool virt_isConnected() const override;
+
+    void connectToPeer(VirtualSocket *peer);
+
+    NODISCARD qint64 bytesAvailable() const override;
+
+protected:
+    NODISCARD qint64 readData(char *data, qint64 maxlen) override;
+    NODISCARD qint64 writeData(const char *data, qint64 len) override;
+
+private slots:
+    void slot_onPeerDestroyed();
+
+private:
+    void writeToPeer(const QByteArray &data);
+    QPointer<VirtualSocket> m_peer;
+    QByteArray m_buffer;
+};

--- a/src/proxy/connectionlistener.h
+++ b/src/proxy/connectionlistener.h
@@ -43,9 +43,14 @@ signals:
     void signal_incomingConnection(qintptr socketDescriptor);
 };
 
+#include "AbstractSocket.h"
+
 class NODISCARD_QOBJECT ConnectionListener final : public QObject
 {
     Q_OBJECT
+
+public:
+    void startClient(std::unique_ptr<AbstractSocket> socket);
 
 private:
     MapData &m_mapData;

--- a/src/proxy/proxy.h
+++ b/src/proxy/proxy.h
@@ -50,6 +50,7 @@ class RemoteEdit;
 class RoomManager;
 class TelnetLineFilter;
 class UserTelnet;
+class AbstractSocket;
 
 struct AbstractParserOutputs;
 struct AnsiWarningMessage;
@@ -75,8 +76,8 @@ private:
     MumeClock &m_mumeClock;
     MapCanvas &m_mapCanvas;
     GameObserver &m_gameObserver;
-    const qintptr m_socketDescriptor;
     MainWindow &m_mainWindow;
+    std::unique_ptr<AbstractSocket> m_userSocket;
 
 private:
     class UserSocket;
@@ -172,7 +173,7 @@ public:
                                                MumeClock &,
                                                MapCanvas &,
                                                GameObserver &,
-                                               qintptr &,
+                                               std::unique_ptr<AbstractSocket>,
                                                ConnectionListener &);
 
 public:
@@ -184,7 +185,7 @@ public:
                    MumeClock &,
                    MapCanvas &,
                    GameObserver &,
-                   qintptr &,
+                   std::unique_ptr<AbstractSocket>,
                    ConnectionListener &);
     ~Proxy() final;
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce a unified socket abstraction and integrate the embedded client to communicate with the proxy via an in-memory virtual socket, replacing raw QTcpSocket usage and socket descriptors.

New Features:
- Allow the embedded client to connect to the proxy over a VirtualSocket in memory instead of TCP

Enhancements:
- Add AbstractSocket interface with TcpSocket and VirtualSocket implementations to decouple socket operations
- Refactor Proxy::UserSocket and ConnectionListener to accept unique_ptr<AbstractSocket> instead of raw socket descriptors
- Update ClientTelnet to use VirtualSocket and delegate socket creation through ConnectionListener
- Enhance ClientWidget to manage a ConnectionListener, display a reconnect hint, and handle connect/disconnect on visibility changes

Build:
- Register AbstractSocket, TcpSocket, and VirtualSocket sources in CMakeLists.txt