### PR TITLE
refactor top level widgets to use a standard, non-modal QWidget

### DIFF
--- a/src/mpi/remoteeditwidget.h
+++ b/src/mpi/remoteeditwidget.h
@@ -9,14 +9,12 @@
 #include <memory>
 
 #include <QAction>
-#include <QMainWindow>
+#include <QDialog>
 #include <QPlainTextEdit>
 #include <QScopedPointer>
 #include <QSize>
 #include <QString>
 #include <QtCore>
-#include <QtWidgets/QMenuBar>
-#include <QtWidgets/QVBoxLayout>
 
 struct EditViewCommand;
 struct EditCommand2;
@@ -27,8 +25,9 @@ class QMenu;
 class QMenuBar;
 class QObject;
 class QPlainTextEdit;
-class QWidget;
 class QStatusBar;
+class QVBoxLayout;
+class QWidget;
 class GotoWidget;
 class FindReplaceWidget;
 
@@ -132,9 +131,13 @@ private:
     void handle_toolTip(QEvent *event) const;
 };
 
-class NODISCARD_QOBJECT RemoteEditWidget : public QMainWindow
+class NODISCARD_QOBJECT RemoteEditWidget : public QDialog
 {
     Q_OBJECT
+
+private:
+    QMenuBar *m_menuBar;
+    QStatusBar *m_statusBar;
 
 public:
     using Editor = RemoteTextEdit;
@@ -159,8 +162,8 @@ public:
     NODISCARD QSize sizeHint() const override;
     void closeEvent(QCloseEvent *event) override;
 
-public:
-    void setVisible(bool visible) override;
+protected:
+    void showEvent(QShowEvent *event) override;
 
 private:
     NODISCARD Editor *createTextEdit();
@@ -170,8 +173,8 @@ private:
     void addToMenu(QMenu *menu, const EditViewCommand &cmd);
     void addToMenu(QMenu *menu, const EditCommand2 &cmd, const Editor *pTextEdit);
 
-    void addFileMenu(QMenuBar *menuBar, const Editor *pTextEdit);
-    void addEditAndViewMenus(QMenuBar *menuBar, const Editor *pTextEdit);
+    void addFileMenu(const Editor *pTextEdit);
+    void addEditAndViewMenus(const Editor *pTextEdit);
     void addSave(QMenu *fileMenu);
     void addExit(QMenu *fileMenu);
     void addStatusBar(const Editor *pTextEdit);

--- a/src/viewers/AnsiViewWindow.cpp
+++ b/src/viewers/AnsiViewWindow.cpp
@@ -10,19 +10,23 @@
 
 #include <tuple>
 
-#include <QMainWindow>
+#include <QDialog>
 #include <QStyle>
 #include <QTextBrowser>
+#include <QVBoxLayout>
 
 AnsiViewWindow::AnsiViewWindow(const QString &program,
                                const QString &title,
                                const std::string_view message)
     : m_view{std::make_unique<QTextBrowser>(this)}
 {
-    setWindowFlags(windowFlags() | Qt::WindowType::Widget);
     setWindowFlags(windowFlags() & ~Qt::WindowStaysOnTopHint);
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
     mmqt::setWindowTitle2(*this, program, title);
+
+    QVBoxLayout *mainLayout = new QVBoxLayout(this);
+    mainLayout->setContentsMargins(0, 0, 0, 0);
+    mainLayout->setSpacing(0);
 
     auto &view = deref(m_view);
     setAnsiText(&view, message);
@@ -38,7 +42,7 @@ AnsiViewWindow::AnsiViewWindow(const QString &program,
     show();
     raise();
     activateWindow();
-    setCentralWidget(&view);
+    mainLayout->addWidget(&view, 0);
     view.setFocus(); // REVISIT: can this be done in the creation function?
 }
 

--- a/src/viewers/AnsiViewWindow.h
+++ b/src/viewers/AnsiViewWindow.h
@@ -7,12 +7,12 @@
 #include <memory>
 #include <string_view>
 
-#include <QMainWindow>
+#include <QDialog>
 #include <QString>
 
 class QTextBrowser;
 
-class NODISCARD AnsiViewWindow final : public QMainWindow
+class NODISCARD AnsiViewWindow final : public QDialog
 {
 private:
     std::unique_ptr<QTextBrowser> m_view;

--- a/src/viewers/TopLevelWindows.cpp
+++ b/src/viewers/TopLevelWindows.cpp
@@ -12,7 +12,7 @@
 #include <memory>
 
 #include <QDebug>
-#include <QMainWindow>
+#include <QDialog>
 #include <QPointer>
 #include <QTimer>
 
@@ -28,12 +28,12 @@ private:
     class NODISCARD Entry final
     {
     private:
-        std::unique_ptr<QMainWindow> m_unique;
+        std::unique_ptr<QDialog> m_unique;
         QString m_name;
-        QPointer<QMainWindow> m_weak_ptr;
+        QPointer<QDialog> m_weak_ptr;
 
     public:
-        explicit Entry(std::unique_ptr<QMainWindow> ptr)
+        explicit Entry(std::unique_ptr<QDialog> ptr)
             : m_unique{std::move(ptr)}
             , m_name{deref(m_unique).windowTitle()}
             , m_weak_ptr{m_unique.get()}
@@ -51,14 +51,14 @@ private:
         NODISCARD const QString &getName() const { return m_name; }
 
     private:
-        NODISCARD QMainWindow *try_get() { return m_weak_ptr.data(); }
-        NODISCARD const QMainWindow *try_get() const { return m_weak_ptr.data(); }
+        NODISCARD QDialog *try_get() { return m_weak_ptr.data(); }
+        NODISCARD const QDialog *try_get() const { return m_weak_ptr.data(); }
 
     public:
         NODISCARD bool isVisible() const
         {
-            if (const QMainWindow *const ptr = try_get()) {
-                const QMainWindow &w = deref(ptr);
+            if (const QDialog *const ptr = try_get()) {
+                const QDialog &w = deref(ptr);
                 if (w.isVisible()) {
                     return true;
                 }
@@ -68,7 +68,7 @@ private:
 
         void disconnectAllChildren()
         {
-            if (QMainWindow *const ptr = try_get()) {
+            if (QDialog *const ptr = try_get()) {
                 if (verbose_debugging) {
                     qDebug() << "Disconnecting all chidren of window" << getName();
                 }
@@ -78,8 +78,8 @@ private:
 
         void deleteWindowLater()
         {
-            if (QMainWindow *const ptr = try_get()) {
-                QMainWindow &w = deref(ptr);
+            if (QDialog *const ptr = try_get()) {
+                QDialog &w = deref(ptr);
                 if (verbose_debugging) {
                     qDebug() << "Marking window" << getName() << "for destruction.";
                 }
@@ -160,7 +160,7 @@ private:
     }
 
 public:
-    void add(std::unique_ptr<QMainWindow> pWindow)
+    void add(std::unique_ptr<QDialog> pWindow)
     {
         auto &window = deref(pWindow);
         const auto title = window.windowTitle();
@@ -205,7 +205,7 @@ void destroyTopLevelWindows()
     g_topLevelWindows.reset();
 }
 
-void addTopLevelWindow(std::unique_ptr<QMainWindow> window)
+void addTopLevelWindow(std::unique_ptr<QDialog> window)
 {
     ABORT_IF_NOT_ON_MAIN_THREAD();
     deref(g_topLevelWindows).add(std::move(window));

--- a/src/viewers/TopLevelWindows.h
+++ b/src/viewers/TopLevelWindows.h
@@ -5,8 +5,8 @@
 #include <memory>
 
 class QString;
-class QMainWindow;
+class QDialog;
 
 extern void initTopLevelWindows();
 extern void destroyTopLevelWindows();
-extern void addTopLevelWindow(std::unique_ptr<QMainWindow> window);
+extern void addTopLevelWindow(std::unique_ptr<QDialog> window);


### PR DESCRIPTION
## Summary by Sourcery

Refactor top-level windows to use QDialog instead of QMainWindow and replace central widget handling with standard layouts, menu bar, and status bar management.

Enhancements:
- Convert RemoteEditWidget to subclass QDialog, embedding its menu bar and status bar in a QVBoxLayout and removing centralWidget usage
- Update AnsiViewWindow to subclass QDialog and host the QTextBrowser in a QVBoxLayout
- Modify TopLevelWindows to track and manage QDialog instances instead of QMainWindow
- Add a setVisible override in RemoteEditWidget to refresh the status bar when shown