### PR TITLE
refactor storage to use QIODevice

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -352,6 +352,10 @@ set(mmapper_SRCS
     mapfrontend/MapHistory.h
     mapfrontend/mapfrontend.cpp
     mapfrontend/mapfrontend.h
+    mapstorage/MapDestination.cpp
+    mapstorage/MapDestination.h
+    mapstorage/MapSource.cpp
+    mapstorage/MapSource.h
     mapstorage/MmpMapStorage.cpp
     mapstorage/MmpMapStorage.h
     mapstorage/PandoraMapStorage.cpp

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,8 +69,13 @@ NODISCARD static bool tryLoad(MainWindow &mw, const QDir &dir, const QString &in
         return false;
     }
 
-    mw.loadFile(absoluteFilePath);
-    return true;
+    try {
+        mw.loadFile(MapSource::alloc(absoluteFilePath, std::nullopt));
+        return true;
+    } catch (const std::runtime_error &e) {
+        qCritical() << "Failed to load autoload map:" << e.what();
+        return false;
+    }
 }
 
 static void tryAutoLoadMap(MainWindow &mw)

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -5,20 +5,19 @@
 // Author: Marek Krejza <krejza@gmail.com> (Caligor)
 // Author: Nils Schimmelmann <nschimme@gmail.com> (Jahara)
 
-#include "../configuration/configuration.h"
 #include "../display/CanvasMouseModeEnum.h"
-#include "../global/Connections.h"
 #include "../global/Signal2.h"
 #include "../global/macros.h"
 #include "../group/mmapper2group.h"
-#include "../map/Changes.h"
 #include "../mapdata/roomselection.h"
+#include "../mapstorage/MapDestination.h"
+#include "../mapstorage/MapSource.h"
 
-#include <exception>
 #include <memory>
 #include <optional>
 
 #include <QActionGroup>
+#include <QByteArray>
 #include <QDockWidget>
 #include <QFileDialog>
 #include <QMainWindow>
@@ -28,6 +27,7 @@
 #include <QTextBrowser>
 #include <QtCore>
 #include <QtGlobal>
+#include <QtWidgets>
 
 class AbstractMapStorage;
 class AdventureTracker;
@@ -66,8 +66,8 @@ class RoomSelection;
 class RoomWidget;
 class UpdateDialog;
 class DescriptionWidget;
-
 struct MapLoadData;
+class MapDestination;
 
 enum class NODISCARD AsyncTypeEnum : uint8_t { Load, Merge, Save };
 
@@ -267,19 +267,17 @@ public:
     explicit MainWindow();
     ~MainWindow() final;
 
-    enum class NODISCARD SaveModeEnum { FULL, BASEMAP };
-    enum class NODISCARD SaveFormatEnum { MM2, MM2XML, WEB, MMP };
-    NODISCARD bool saveFile(const QString &fileName, SaveModeEnum mode, SaveFormatEnum format);
-    void loadFile(const QString &fileName);
+    NODISCARD bool saveFile(std::shared_ptr<MapDestination> pDest,
+                            SaveModeEnum mode,
+                            SaveFormatEnum format);
+    void loadFile(std::shared_ptr<MapSource> source);
     void setCurrentFile(const QString &fileName);
     void percentageChanged(uint32_t);
 
 private:
     void showAsyncFailure(const QString &fileName, AsyncTypeEnum mode, bool wasCanceled);
     NODISCARD std::unique_ptr<AbstractMapStorage> getLoadOrMergeMapStorage(
-        const std::shared_ptr<ProgressCounter> &pc,
-        const QString &fileName,
-        std::shared_ptr<QFile> &pFile);
+        const std::shared_ptr<ProgressCounter> &pc, std::shared_ptr<MapSource> &source);
 
 protected:
     void closeEvent(QCloseEvent *event) override;
@@ -374,12 +372,9 @@ private:
 
 private:
     void applyGroupAction(const std::function<Change(const RawRoom &)> &getChange);
-    NODISCARD QString chooseLoadOrMergeFileName();
     void onSuccessfulLoad(const MapLoadData &mapLoadData);
     void onSuccessfulMerge(const Map &map);
     void onSuccessfulSave(SaveModeEnum mode, SaveFormatEnum format, const QString &fileName);
-    void reportOpenFileFailure(const QString &fileName, const QString &reason);
-    void reportOpenFileException(const QString &fileName, const std::exception_ptr &eptr);
 
 public slots:
     void slot_newFile();

--- a/src/mapstorage/MapDestination.cpp
+++ b/src/mapstorage/MapDestination.cpp
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2025 The MMapper Authors
+
+#include "MapDestination.h"
+
+#include "filesaver.h"
+
+#include <stdexcept>
+
+#include <QBuffer>
+#include <QDir>
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QIODevice>
+
+std::shared_ptr<MapDestination> MapDestination::alloc(const QString fileName, SaveFormatEnum format)
+{
+    std::shared_ptr<FileSaver> fileSaver = nullptr;
+
+    if (format == SaveFormatEnum::WEB) {
+        QDir destDir(fileName);
+        if (!destDir.exists()) {
+            if (!destDir.mkpath(fileName)) {
+                throw std::runtime_error(
+                    QString("Cannot create directory %1.").arg(fileName).toStdString());
+            }
+        }
+        if (!QFileInfo(fileName).isWritable()) {
+            throw std::runtime_error(
+                QString("Directory %1 is not writable.").arg(fileName).toStdString());
+        }
+    } else {
+        fileSaver = std::make_shared<FileSaver>();
+        try {
+            fileSaver->open(fileName);
+        } catch (const std::exception &e) {
+            throw std::runtime_error(
+                QString("Cannot write file %1:\n%2.").arg(fileName, e.what()).toStdString());
+        }
+    }
+
+    return std::make_shared<MapDestination>(Badge<MapDestination>{},
+                                            std::move(fileName),
+                                            std::move(fileSaver));
+}
+
+MapDestination::MapDestination(Badge<MapDestination>,
+                               const QString fileName,
+                               std::shared_ptr<FileSaver> fileSaver)
+    : m_fileName(std::move(fileName))
+    , m_fileSaver(std::move(fileSaver))
+{}
+
+std::shared_ptr<QIODevice> MapDestination::getIODevice() const
+{
+    if (isFileNative()) {
+        assert(m_fileSaver);
+        return m_fileSaver->getSharedFile();
+    }
+    return nullptr;
+}
+
+void MapDestination::finalize(bool /*success*/)
+{
+    if (isFileNative()) {
+        assert(m_fileSaver);
+        m_fileSaver->close();
+    } else {
+        assert(isDirectory());
+    }
+}

--- a/src/mapstorage/MapDestination.h
+++ b/src/mapstorage/MapDestination.h
@@ -1,0 +1,47 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2025 The MMapper Authors
+
+#include "../global/Badge.h"
+#include "../global/macros.h"
+#include "filesaver.h"
+
+#include <memory>
+
+#include <QBuffer>
+#include <QIODevice>
+#include <QString>
+
+enum class NODISCARD SaveModeEnum { FULL, BASEMAP };
+enum class NODISCARD SaveFormatEnum { MM2, MM2XML, WEB, MMP };
+
+class NODISCARD MapDestination final : public std::enable_shared_from_this<MapDestination>
+{
+private:
+    QString m_fileName;
+    std::shared_ptr<FileSaver> m_fileSaver;
+
+public:
+    NODISCARD static std::shared_ptr<MapDestination> alloc(const QString fileName,
+                                                           SaveFormatEnum format) CAN_THROW;
+
+public:
+    explicit MapDestination(Badge<MapDestination>,
+                            const QString fileName,
+                            std::shared_ptr<FileSaver> fileSaver);
+    DELETE_CTORS(MapDestination);
+    DELETE_COPY_ASSIGN_OP(MapDestination);
+
+private:
+    DEFAULT_MOVE_ASSIGN_OP(MapDestination);
+
+public:
+    NODISCARD bool isFileNative() const { return m_fileSaver != nullptr; }
+    NODISCARD bool isDirectory() const { return !isFileNative(); }
+
+    NODISCARD const QString &getFileName() const { return m_fileName; }
+
+    NODISCARD std::shared_ptr<QIODevice> getIODevice() const;
+
+    void finalize(bool success);
+};

--- a/src/mapstorage/MapSource.cpp
+++ b/src/mapstorage/MapSource.cpp
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2025 The MMapper Authors
+
+#include "MapSource.h"
+
+#include <stdexcept>
+
+#include <QBuffer>
+#include <QFile>
+
+std::shared_ptr<MapSource> MapSource::alloc(const QString fileName,
+                                            const std::optional<QByteArray> &fileContent)
+{
+    if (fileContent.has_value()) {
+        auto pBuffer = std::make_shared<QBuffer>();
+        pBuffer->setData(fileContent.value());
+        if (!pBuffer->open(QIODevice::ReadOnly)) {
+            throw std::runtime_error(QString("Failed to open QBuffer for reading: %1.")
+                                         .arg(pBuffer->errorString())
+                                         .toStdString());
+        }
+        return std::make_shared<MapSource>(Badge<MapSource>{},
+                                           std::move(fileName),
+                                           std::move(pBuffer));
+    } else {
+        auto pFile = std::make_shared<QFile>(fileName);
+        if (!pFile->open(QFile::ReadOnly)) {
+            throw std::runtime_error(QString("Failed to open file \"%1\" for reading: %2.")
+                                         .arg(fileName, pFile->errorString())
+                                         .toStdString());
+        }
+        return std::make_shared<MapSource>(Badge<MapSource>{},
+                                           std::move(fileName),
+                                           std::move(pFile));
+    }
+}
+
+MapSource::MapSource(Badge<MapSource>, const QString fileName, std::shared_ptr<QIODevice> device)
+    : m_fileName(std::move(fileName))
+    , m_device(std::move(device))
+{}

--- a/src/mapstorage/MapSource.h
+++ b/src/mapstorage/MapSource.h
@@ -1,0 +1,40 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2025 The MMapper Authors
+
+#include "../global/Badge.h"
+#include "../global/RuleOf5.h"
+#include "../global/macros.h"
+
+#include <memory>
+#include <optional>
+
+#include <QBuffer>
+#include <QByteArray>
+#include <QFile>
+#include <QIODevice>
+#include <QString>
+
+class NODISCARD MapSource final : public std::enable_shared_from_this<MapSource>
+{
+private:
+    QString m_fileName;
+    std::shared_ptr<QIODevice> m_device;
+
+public:
+    NODISCARD static std::shared_ptr<MapSource> alloc(
+        const QString fileName,
+        const std::optional<QByteArray> &fileContent = std::nullopt) CAN_THROW;
+
+public:
+    explicit MapSource(Badge<MapSource>, const QString fileName, std::shared_ptr<QIODevice> device);
+    DELETE_CTORS(MapSource);
+    DELETE_COPY_ASSIGN_OP(MapSource);
+
+private:
+    DEFAULT_MOVE_ASSIGN_OP(MapSource);
+
+public:
+    NODISCARD std::shared_ptr<QIODevice> getIODevice() { return m_device; }
+    NODISCARD const QString &getFileName() const { return m_fileName; }
+};

--- a/src/mapstorage/MmpMapStorage.cpp
+++ b/src/mapstorage/MmpMapStorage.cpp
@@ -119,7 +119,7 @@ bool MmpMapStorage::virt_saveData(const MapLoadData &mapData)
     progressCounter.reset();
     progressCounter.increaseTotalStepsBy(roomsCount + 3);
 
-    QXmlStreamWriter stream(getFile());
+    QXmlStreamWriter stream(&getDevice());
     stream.setAutoFormatting(true);
     stream.writeStartDocument();
 

--- a/src/mapstorage/PandoraMapStorage.cpp
+++ b/src/mapstorage/PandoraMapStorage.cpp
@@ -185,11 +185,11 @@ std::optional<RawMapLoadData> PandoraMapStorage::virt_loadData()
     auto &progressCounter = getProgressCounter();
     progressCounter.reset();
 
-    QFile *const file = getFile();
-    QXmlStreamReader xml{file};
+    QIODevice *const device = &getDevice();
+    QXmlStreamReader xml{device};
 
     // Discover total number of rooms
-    const QString &file_fileName = file->fileName();
+    const QString &file_fileName = getFilename();
     if (xml.readNextStartElement() && xml.error() != QXmlStreamReader::NoError) {
         qWarning() << "File cannot be read" << file_fileName;
         return std::nullopt;
@@ -222,7 +222,7 @@ std::optional<RawMapLoadData> PandoraMapStorage::virt_loadData()
     }
 
     log(QString("Finished reading %1 rooms.").arg(loading.size()));
-    file->close();
+    device->close();
 
     if (!exitsToDeathTrap.empty()) {
         log(QString("Adding %1 death trap rooms").arg(exitsToDeathTrap.size()));

--- a/src/mapstorage/XmlMapStorage.cpp
+++ b/src/mapstorage/XmlMapStorage.cpp
@@ -284,14 +284,14 @@ std::optional<RawMapLoadData> XmlMapStorage::virt_loadData()
 {
     try {
         log("Loading data ...");
-        QFile &file = deref(getFile());
-        QXmlStreamReader stream(&file);
+        QIODevice &device = getDevice();
+        QXmlStreamReader stream(&device);
 
         m_loading = std::make_unique<Loading>();
-        m_loading->result.filename = file.fileName();
-        m_loading->result.readonly = !QFileInfo(file).isWritable();
+        m_loading->result.filename = getFilename();
+        m_loading->result.readonly = !device.isWritable();
         m_loading->loadProgressDivisor = static_cast<uint64_t>(
-            std::max<int64_t>(1, file.size() / LOAD_PROGRESS_MAX));
+            std::max<int64_t>(1, device.size() / LOAD_PROGRESS_MAX));
 
         loadWorld(stream);
         log("Finished loading.");
@@ -709,7 +709,7 @@ bool XmlMapStorage::virt_saveData(const MapLoadData &map)
     m_saving = std::make_unique<Saving>(map);
     try {
         log("Writing data to file ...");
-        QXmlStreamWriter stream(getFile());
+        QXmlStreamWriter stream(&getDevice());
         saveWorld(stream);
         stream.writeEndDocument();
         log("Writing data finished.");

--- a/src/mapstorage/abstractmapstorage.cpp
+++ b/src/mapstorage/abstractmapstorage.cpp
@@ -10,7 +10,6 @@
 
 #include <optional>
 #include <stdexcept>
-#include <utility>
 
 #include <QObject>
 
@@ -51,4 +50,24 @@ bool AbstractMapStorage::saveData(const MapData &mapData, const bool baseMapOnly
     }
 
     return virt_saveData(rawMapData);
+}
+
+const QString &AbstractMapStorage::getFilename() const
+{
+    if (m_data.saveDestination) {
+        return m_data.saveDestination->getFileName();
+    }
+    return m_data.loadSource->getFileName();
+}
+
+QIODevice &AbstractMapStorage::getDevice() const
+{
+    if (m_data.saveDestination) {
+        auto device = m_data.saveDestination->getIODevice();
+        if (!device) {
+            throw std::runtime_error("No QIODevice available");
+        }
+        return *device;
+    }
+    return *m_data.loadSource->getIODevice();
 }

--- a/src/mapstorage/mapstorage.cpp
+++ b/src/mapstorage/mapstorage.cpp
@@ -227,14 +227,10 @@ NODISCARD std::optional<MM2FileVersion> getMM2FileVersion(LoadRoomHelper &helper
 
 } // namespace
 
-NODISCARD std::optional<MM2FileVersion> getMM2FileVersion(const QString &fileName)
+NODISCARD std::optional<MM2FileVersion> getMM2FileVersion(QIODevice &file)
 {
     try {
-        QFile f{fileName};
-        if (!f.open(QIODevice::ReadOnly)) {
-            return std::nullopt;
-        }
-        QDataStream stream{&f};
+        QDataStream stream(&file);
         auto helper = LoadRoomHelper{stream};
         return getMM2FileVersion(helper);
     } catch (...) {
@@ -364,7 +360,7 @@ std::optional<RawMapLoadData> MapStorage::virt_loadData()
         auto &progressCounter = getProgressCounter();
         progressCounter.reset();
 
-        QDataStream stream{getFile()};
+        QDataStream stream{&getDevice()};
         auto helper = LoadRoomHelper{stream};
 
         // Read the version and magic
@@ -600,7 +596,7 @@ bool MapStorage::virt_saveData(const MapLoadData &mapData)
 
     const auto &map = mapData.mapPair.modified;
 
-    QDataStream fileStream(getFile());
+    QDataStream fileStream(&getDevice());
     fileStream.setVersion(QDataStream::Qt_4_8);
 
     // Collect the room and marker lists. The room list can't be acquired

--- a/src/mapstorage/mapstorage.h
+++ b/src/mapstorage/mapstorage.h
@@ -56,4 +56,4 @@ struct NODISCARD MM2FileVersion final
     Relative relative = Relative::Older;
 };
 
-NODISCARD extern std::optional<MM2FileVersion> getMM2FileVersion(const QString &fileName);
+NODISCARD extern std::optional<MM2FileVersion> getMM2FileVersion(QIODevice &file);


### PR DESCRIPTION
## Summary by Sourcery

Refactor map loading and saving to work with generic QIODevice-based sources and destinations instead of direct QFile/file paths.

New Features:
- Introduce MapSource to represent map input from files or in-memory buffers for loading and merging maps.
- Introduce MapDestination to represent map save targets, supporting both files and web-export directories.

Enhancements:
- Update MainWindow async load/merge/save flows and storage backends to operate on QIODevice abstractions rather than raw file paths or QFile pointers.
- Improve error reporting and status messages when opening or saving maps fails, including directory writability checks for web exports.
- Simplify and standardize suggested filenames in save/export dialogs across different map formats.

Build:
- Register new MapSource and MapDestination sources in the CMake build configuration.