### PR TITLE
replace thick lines with quads

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -387,6 +387,8 @@ set(mmapper_SRCS
     opengl/Font.cpp
     opengl/Font.h
     opengl/FontFormatFlags.h
+    opengl/LineRendering.cpp
+    opengl/LineRendering.h
     opengl/OpenGL.cpp
     opengl/OpenGL.h
     opengl/OpenGLTypes.cpp

--- a/src/display/Characters.h
+++ b/src/display/Characters.h
@@ -103,9 +103,9 @@ private:
         std::vector<ColorVert> m_charTris;
         std::vector<ColorVert> m_charBeaconQuads;
         std::vector<ColorVert> m_charLines;
-        std::vector<ColorVert> m_pathPoints;
-        std::vector<ColorVert> m_pathLineVerts;
         std::vector<ColoredTexVert> m_charRoomQuads;
+        std::vector<ColorVert> m_pathPoints;
+        std::vector<ColorVert> m_pathLineQuads;
         std::vector<FontVert3d> m_screenSpaceArrows;
         std::map<Coordinate, int, CoordCompare> m_coordCounts;
 
@@ -151,15 +151,7 @@ private:
         void drawArrow(bool fill, bool beacon);
         void drawBox(const Coordinate &coord, bool fill, bool beacon, bool isFar);
         void addScreenSpaceArrow(const glm::vec3 &pos, float degrees, const Color &color, bool fill);
-
-        // with blending, without depth; always size 4
-        void drawPathLineStrip(const Color &color, const std::vector<glm::vec3> &points)
-        {
-            for (size_t i = 1, size = points.size(); i < size; ++i) {
-                m_pathLineVerts.emplace_back(color, points[i - 1]);
-                m_pathLineVerts.emplace_back(color, points[i]);
-            }
-        }
+        void drawPathSegment(const glm::vec3 &p1, const glm::vec3 &p2, const Color &color);
 
         // with blending, without depth; always size 8
         void drawPathPoint(const Color &color, const glm::vec3 &pos)

--- a/src/display/ConnectionLineBuilder.cpp
+++ b/src/display/ConnectionLineBuilder.cpp
@@ -163,7 +163,7 @@ void ConnectionLineBuilder::drawConnLineEnd1Way(const ExitDirEnum endDir,
     case ExitDirEnum::UP:
     case ExitDirEnum::DOWN:
         addVertex(dX + 0.75f, dY + 0.25f, dstZ);
-        addVertex(dX + 0.5f, dY + 0.5f, dstZ);
+        addVertex(dX + 0.55f, dY + 0.45f, dstZ);
         break;
     case ExitDirEnum::UNKNOWN:
         addVertex(dX + 0.75f, dY + 0.25f, dstZ);

--- a/src/display/Connections.h
+++ b/src/display/Connections.h
@@ -69,8 +69,8 @@ using BatchedRoomNames = std::unordered_map<int, UniqueMesh>;
 
 struct NODISCARD ConnectionDrawerColorBuffer final
 {
-    std::vector<ColorVert> lineVerts;
     std::vector<ColorVert> triVerts;
+    std::vector<ColorVert> quadVerts;
 
     ConnectionDrawerColorBuffer() = default;
     DEFAULT_MOVES_DELETE_COPIES(ConnectionDrawerColorBuffer);
@@ -78,18 +78,18 @@ struct NODISCARD ConnectionDrawerColorBuffer final
 
     void clear()
     {
-        lineVerts.clear();
         triVerts.clear();
+        quadVerts.clear();
     }
-    NODISCARD bool empty() const { return lineVerts.empty() && triVerts.empty(); }
+    NODISCARD bool empty() const { return triVerts.empty() && quadVerts.empty(); }
 };
 
 struct NODISCARD ConnectionMeshes final
 {
-    UniqueMesh normalLines;
     UniqueMesh normalTris;
-    UniqueMesh redLines;
     UniqueMesh redTris;
+    UniqueMesh normalQuads;
+    UniqueMesh redQuads;
 
     ConnectionMeshes() = default;
     DEFAULT_MOVES_DELETE_COPIES(ConnectionMeshes);

--- a/src/display/Infomarks.h
+++ b/src/display/Infomarks.h
@@ -22,8 +22,8 @@ class OpenGL;
 struct NODISCARD InfomarksMeshes final
 {
     UniqueMesh points;
-    UniqueMesh lines;
     UniqueMesh tris;
+    UniqueMesh quads;
     UniqueMesh textMesh;
     bool isValid = false;
     void render();
@@ -40,8 +40,8 @@ private:
     Color m_color;
 
     std::vector<ColorVert> m_points;
-    std::vector<ColorVert> m_lines;
     std::vector<ColorVert> m_tris;
+    std::vector<ColorVert> m_quads;
 
     // REVISIT: This is ill-advised and may contain bugs.
     struct NODISCARD Text final

--- a/src/opengl/LineRendering.cpp
+++ b/src/opengl/LineRendering.cpp
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2025 The MMapper Authors
+
+#include "LineRendering.h"
+
+#include <cassert>
+
+#include <glm/glm.hpp>
+#include <glm/gtx/norm.hpp>
+
+namespace mmgl {
+
+void generateLineQuad(std::vector<ColorVert> &verts,
+                      const glm::vec3 &p1,
+                      const glm::vec3 &p2,
+                      float width,
+                      const Color &color,
+                      const glm::vec3 &perpendicular_normal)
+{
+    // Assert that perpendicular_normal is unit length
+    assert(
+        glm::epsilonEqual(glm::length2(perpendicular_normal), 1.0f, mmgl::GEOMETRIC_EPSILON * 10.f));
+
+    const float half_width = width / 2.0f;
+    glm::vec3 offset1 = perpendicular_normal * half_width;
+
+    // Use p1 and p2 directly for quad vertices, applying the perpendicular offset.
+    glm::vec3 v1 = p1 + offset1;
+    glm::vec3 v2 = p1 - offset1;
+    glm::vec3 v3 = p2 - offset1;
+    glm::vec3 v4 = p2 + offset1;
+
+    verts.emplace_back(color, v1);
+    verts.emplace_back(color, v2);
+    verts.emplace_back(color, v3);
+    verts.emplace_back(color, v4);
+}
+
+bool isDegenerate(const glm::vec3 &vec)
+{
+    return glm::length2(vec) < mmgl::GEOMETRIC_EPSILON * 10.f;
+}
+
+bool isNearZero(const glm::vec3 &segment)
+{
+    return glm::length2(segment) < mmgl::ZERO_LENGTH_THRESHOLD_SQ;
+}
+
+glm::vec3 getPerpendicularNormal(const glm::vec3 &direction)
+{
+    glm::vec3 perp_normal_candidate = glm::vec3(-direction.y, direction.x, 0.0f);
+    if (isDegenerate(perp_normal_candidate)) {
+        return glm::vec3(1.0f, 0.0f, 0.0f);
+    }
+    return glm::normalize(perp_normal_candidate);
+}
+
+glm::vec3 getOrthogonalNormal(const glm::vec3 &direction, const glm::vec3 &perp_normal_1)
+{
+    glm::vec3 perp_normal_2_candidate = glm::cross(direction, perp_normal_1);
+    if (isDegenerate(perp_normal_2_candidate)) {
+        return glm::vec3(0.0f, 1.0f, 0.0f);
+    }
+    return glm::normalize(perp_normal_2_candidate);
+}
+
+void generateLineQuadsSafe(std::vector<ColorVert> &verts,
+                           const glm::vec3 &p1,
+                           const glm::vec3 &p2,
+                           float width,
+                           const Color &color)
+{
+    const glm::vec3 segment = p2 - p1;
+    if (isNearZero(segment)) {
+        drawZeroLengthSquare(verts, p1, width, color);
+        return;
+    }
+
+    const glm::vec3 normalized_dir = glm::normalize(segment);
+    const glm::vec3 perp_normal = getPerpendicularNormal(normalized_dir);
+    generateLineQuad(verts, p1, p2, width, color, perp_normal);
+}
+
+void drawZeroLengthSquare(std::vector<ColorVert> &verts,
+                          const glm::vec3 &center,
+                          float width,
+                          const Color &color)
+{
+    float half_size = width / 2.0f;
+    glm::vec3 v1 = center + glm::vec3(-half_size, -half_size, 0.0f);
+    glm::vec3 v2 = center + glm::vec3(half_size, -half_size, 0.0f);
+    glm::vec3 v3 = center + glm::vec3(half_size, half_size, 0.0f);
+    glm::vec3 v4 = center + glm::vec3(-half_size, half_size, 0.0f);
+
+    verts.emplace_back(color, v1);
+    verts.emplace_back(color, v2);
+    verts.emplace_back(color, v3);
+    verts.emplace_back(color, v4);
+}
+
+} // namespace mmgl

--- a/src/opengl/LineRendering.h
+++ b/src/opengl/LineRendering.h
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2025 The MMapper Authors
+
+#pragma once
+
+#include "../opengl/OpenGLTypes.h"
+
+#include <vector>
+
+#include <glm/glm.hpp>
+
+namespace mmgl {
+
+// Tolerance for projecting world coordinates to screen space.
+// Small but non-zero w values can cause numerical instability if used as divisors.
+// A threshold of 1e-6f is a balance between precision and avoiding noise amplification.
+static constexpr const float W_PROJECTION_EPSILON = 1e-6f;
+
+// Geometric epsilon for degeneracy checks (e.g., near-zero vectors, collinearity).
+// This is used for comparisons where small floating-point variations should be treated as equivalent to zero.
+static constexpr const float GEOMETRIC_EPSILON = 1e-5f;
+
+// Projection epsilon for clamping logic in screen space.
+// This handles numerical instability during world-to-screen projections.
+static constexpr const float PROJECTION_EPSILON = 1e-5f;
+
+// Squared threshold for zero-length segment checks to avoid sqrt operations.
+static constexpr const float ZERO_LENGTH_THRESHOLD_SQ = GEOMETRIC_EPSILON * GEOMETRIC_EPSILON;
+
+// NOTE: perpendicular_normal is assumed to be unit length.
+void generateLineQuad(std::vector<ColorVert> &verts,
+                      const glm::vec3 &p1,
+                      const glm::vec3 &p2,
+                      float width,
+                      const Color &color,
+                      const glm::vec3 &perpendicular_normal);
+
+void drawZeroLengthSquare(std::vector<ColorVert> &verts,
+                          const glm::vec3 &center,
+                          float width,
+                          const Color &color);
+
+// Returns a normalized vector perpendicular to the input direction, primarily in the XY plane.
+// Handles near-zero direction vectors by returning a default perpendicular (1,0,0).
+NODISCARD glm::vec3 getPerpendicularNormal(const glm::vec3 &direction);
+
+// Returns a normalized vector orthogonal to both the segment direction and the first perpendicular normal.
+// This is suitable for generating a second quad to form a "cross" shape.
+NODISCARD glm::vec3 getOrthogonalNormal(const glm::vec3 &direction, const glm::vec3 &perp_normal_1);
+
+// Generates a line quad, handling zero-length segments by drawing a square instead.
+// Uses getPerpendicularNormal for the quad generation.
+void generateLineQuadsSafe(std::vector<ColorVert> &verts,
+                           const glm::vec3 &p1,
+                           const glm::vec3 &p2,
+                           float width,
+                           const Color &color);
+
+// Checks if the squared length of a vector is below the degeneration threshold.
+NODISCARD bool isDegenerate(const glm::vec3 &vec);
+
+// Checks if the squared length of a segment vector is below the zero-length threshold.
+NODISCARD bool isNearZero(const glm::vec3 &segment);
+
+} // namespace mmgl


### PR DESCRIPTION
## Summary by Sourcery

Replace OpenGL thick line rendering with quad-based geometry for connections, infomark arrows, and character paths, while introducing shared line-rendering utilities and improved projection tolerances.

Enhancements:
- Render connection lines, infomark arrows, and character paths as colored quads instead of GL line primitives, including handling of long segments, zero-length segments, and multi-layer crossings.
- Introduce a reusable LineRendering utility module providing robust quad generation, perpendicular normal computation, and shared epsilon constants for geometric and projection calculations.
- Adjust connection and path line widths and minor connection endpoint positioning to better match the new quad-based visuals.
- Refine MapCanvas projection and unprojection logic to use shared projection epsilon thresholds from the new line-rendering utilities for more consistent visibility checks.

Build:
- Register the new LineRendering source and header files in the CMake build configuration.