### PR TITLE
bump minimum OpenGL version to 3.3 core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,49 @@ if(Qt6Core_FOUND)
     add_definitions(/DQT_DISABLE_DEPRECATED_UP_TO=0x060200)
 endif()
 
+if(Qt6OpenGL_FOUND)
+    file(WRITE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/CheckQtGLES30.cpp
+        "#include <QOpenGLExtraFunctions>
+        #ifndef GL_TRIANGLES
+        # error
+        #endif
+        #ifdef Q_OS_MAC
+        # error
+        #endif
+        int main(int argc, char** argv) { return 0; }")
+    try_compile(QT_HAS_GLES
+                    ${CMAKE_BINARY_DIR}
+                    ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/CheckQtGLES30.cpp
+                    LINK_LIBRARIES Qt6::OpenGL
+                    OUTPUT_VARIABLE OUTPUT)
+    file(WRITE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/CheckQtOpenGL33.cpp
+        "#include <QOpenGLFunctions_3_3_Core>
+        #ifndef GL_QUADS
+        # error
+        #endif
+        int main(int argc, char** argv) { return 0; }")
+    try_compile(QT_HAS_OPENGL
+                    ${CMAKE_BINARY_DIR}
+                    ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/CheckQtOpenGL33.cpp
+                    LINK_LIBRARIES Qt6::OpenGL
+                    OUTPUT_VARIABLE OUTPUT)
+    if (NOT QT_HAS_GLES)
+        add_definitions(/DMMAPPER_NO_GLES)
+    endif()
+    if (NOT QT_HAS_OPENGL)
+        add_definitions(/DMMAPPER_NO_OPENGL)
+    endif()
+    if(QT_HAS_GLES AND QT_HAS_OPENGL)
+        message(STATUS "QOpenGLExtraFunctions supports both GLES 3.0 and OpenGL 3.3")
+    elseif(QT_HAS_GLES)
+        message(STATUS "QOpenGLExtraFunctions supports GLES 3.0")
+    elseif(QT_HAS_OPENGL)
+        message(STATUS "QOpenGLExtraFunctions supports OpenGL 3.3")
+    else()
+        message(FATAL_ERROR "QOpenGLExtraFunctions does not support GLES 3.0 or OpenGL 3.3")
+    endif()
+endif()
+
 if(WITH_WEBSOCKET)
     if(NOT Qt6WebSockets_FOUND)
         message(FATAL_ERROR "Qt6 WebSockets module not found: use `-DWITH_WEBSOCKET=OFF` to build without WebSocket support")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -386,11 +386,15 @@ set(mmapper_SRCS
     observer/gameobserver.h
     opengl/Font.cpp
     opengl/Font.h
+    opengl/OpenGLProber.cpp
+    opengl/OpenGLProber.h
     opengl/FontFormatFlags.h
     opengl/LineRendering.cpp
     opengl/LineRendering.h
     opengl/OpenGL.cpp
     opengl/OpenGL.h
+    opengl/OpenGLConfig.cpp
+    opengl/OpenGLConfig.h
     opengl/OpenGLTypes.cpp
     opengl/OpenGLTypes.h
     opengl/legacy/AbstractShaderProgram.cpp
@@ -401,6 +405,10 @@ set(mmapper_SRCS
     opengl/legacy/FontMesh3d.h
     opengl/legacy/Legacy.cpp
     opengl/legacy/Legacy.h
+    opengl/legacy/FunctionsGL33.cpp
+    opengl/legacy/FunctionsGL33.h
+    opengl/legacy/FunctionsES30.cpp
+    opengl/legacy/FunctionsES30.h
     opengl/legacy/Meshes.cpp
     opengl/legacy/Meshes.h
     opengl/legacy/ShaderUtils.cpp
@@ -409,9 +417,10 @@ set(mmapper_SRCS
     opengl/legacy/Shaders.h
     opengl/legacy/SimpleMesh.cpp
     opengl/legacy/SimpleMesh.h
+    opengl/legacy/VAO.cpp
+    opengl/legacy/VAO.h
     opengl/legacy/VBO.cpp
     opengl/legacy/VBO.h
-    opengl/legacy/impl_gl20.cpp
     parser/Abbrev.cpp
     parser/Abbrev.h
     parser/AbstractParser-Actions.cpp

--- a/src/display/mapcanvas_gl.cpp
+++ b/src/display/mapcanvas_gl.cpp
@@ -15,6 +15,7 @@
 #include "../opengl/Font.h"
 #include "../opengl/FontFormatFlags.h"
 #include "../opengl/OpenGL.h"
+#include "../opengl/OpenGLConfig.h"
 #include "../opengl/OpenGLTypes.h"
 #include "../opengl/legacy/Meshes.h"
 #include "../src/global/SendToUser.h"
@@ -175,7 +176,7 @@ void MapCanvas::reportGLVersion()
                .toUtf8());
 
     logMsg("Highest Reportable OpenGL:",
-           mmqt::toQByteArrayUtf8(OpenGL::getHighestReportableVersionString()));
+           mmqt::toQByteArrayUtf8(OpenGLConfig::getHighestReportableVersionString()));
 
     logMsg("Display:", QString("%1 DPI").arg(QPaintDevice::devicePixelRatioF()).toUtf8());
 }

--- a/src/global/ConfigConsts.h
+++ b/src/global/ConfigConsts.h
@@ -45,3 +45,15 @@ static inline constexpr const bool NO_QTKEYCHAIN = true;
 #else
 static inline constexpr const bool NO_QTKEYCHAIN = false;
 #endif
+
+#if defined(MMAPPER_NO_OPENGL) && MMAPPER_NO_OPENGL
+static inline constexpr const bool NO_OPENGL = true;
+#else
+static inline constexpr const bool NO_OPENGL = false;
+#endif
+
+#if defined(MMAPPER_NO_GLES) && MMAPPER_NO_GLES
+static inline constexpr const bool NO_GLES = true;
+#else
+static inline constexpr const bool NO_GLES = false;
+#endif

--- a/src/opengl/OpenGL.cpp
+++ b/src/opengl/OpenGL.cpp
@@ -5,15 +5,16 @@
 #include "OpenGL.h"
 
 #include "../global/ConfigConsts.h"
-#include "../global/logging.h"
+#include "./legacy/FunctionsES30.h"
+#include "./legacy/FunctionsGL33.h"
 #include "./legacy/Legacy.h"
 #include "./legacy/Meshes.h"
+#include "OpenGLConfig.h"
+#include "OpenGLProber.h"
 #include "OpenGLTypes.h"
 
 #include <cassert>
 #include <optional>
-#include <sstream>
-#include <string>
 #include <utility>
 #include <vector>
 
@@ -24,284 +25,21 @@
 #include <QOpenGLContext>
 #include <QSurfaceFormat>
 
-#ifdef WIN32
-extern "C" {
-// Prefer discrete nVidia and AMD GPUs by default on Windows
-__declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
-__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
-}
-#endif
-
-static const constexpr auto UNDEFINED_VERSION = "Fallback";
-
-namespace { // anonymous
-
-struct GLVersion
-{
-    int major = 0;
-    int minor = 0;
-
-    NODISCARD bool operator>(const GLVersion &other) const
-    {
-        return (major > other.major) || (major == other.major && minor > other.minor);
-    }
-
-    NODISCARD bool operator<(const GLVersion &other) const
-    {
-        return (major < other.major) || (major == other.major && minor < other.minor);
-    }
-};
-
-inline std::ostream &operator<<(std::ostream &os, const GLVersion &version)
-{
-    os << version.major << "." << version.minor;
-    return os;
-}
-
-struct GLContextCheckResult
-{
-    bool valid = false;
-    GLVersion version = {0, 0};
-    bool isCore = false;
-    bool isCompat = false;
-    bool isDeprecated = false;
-    bool isDebug = false;
-};
-
-NODISCARD GLContextCheckResult checkContext(QSurfaceFormat format,
-                                            GLVersion version,
-                                            QSurfaceFormat::OpenGLContextProfile profile)
-{
-    GLContextCheckResult result;
-    QOpenGLContext context;
-    context.setFormat(format);
-    if (!context.create()) {
-        MMLOG_DEBUG() << "[GL Check] context.create() failed for requested " << version
-                      << (profile == QSurfaceFormat::CoreProfile ? " Core" : " Compat");
-        return result;
-    }
-
-    QSurfaceFormat actualFormat = context.format();
-
-    result.isCore = (actualFormat.profile() & QSurfaceFormat::CoreProfile);
-    result.isCompat = (actualFormat.profile() & QSurfaceFormat::CompatibilityProfile);
-    result.isDeprecated = (actualFormat.options() & QSurfaceFormat::DeprecatedFunctions);
-    result.isDebug = (actualFormat.options() & QSurfaceFormat::DebugContext);
-    result.version = GLVersion{actualFormat.majorVersion(), actualFormat.minorVersion()};
-
-    context.doneCurrent();
-
-    // Check if the actual OpenGL context meets the minimum requirements
-    bool profileOk = false;
-
-    if (version < GLVersion{3, 2}) {
-        if (profile == QSurfaceFormat::CoreProfile) {
-            // Core profile did not exist before GL 3.2
-            profileOk = false;
-        } else {
-            // Must be compatibility-like
-            profileOk = result.isCompat || result.isDeprecated;
-        }
-    } else {
-        // For GL 3.2+
-        if (profile == QSurfaceFormat::CoreProfile) {
-            profileOk = result.isCore;
-        } else if (profile == QSurfaceFormat::CompatibilityProfile) {
-            profileOk = result.isCompat && result.isDeprecated;
-        }
-    }
-
-    // If the profile is ok, we consider the context valid even if the version is lower than requested.
-    if (profileOk) {
-        result.valid = true;
-        MMLOG_DEBUG() << "[GL Probe] GL " << result.version << (result.isCore ? " Core" : " Compat")
-                      << " is valid";
-    }
-    return result;
-}
-
-struct OpenGLProbeResult
-{
-    QSurfaceFormat runningFormat = QSurfaceFormat::defaultFormat();
-    std::string highestVersion = UNDEFINED_VERSION;
-};
-
-NODISCARD std::string formatGLVersionString(const GLContextCheckResult &result)
-{
-    std::ostringstream oss;
-    oss << "GL" << result.version;
-    if (!result.isDeprecated && result.version > GLVersion{3, 1}) {
-        oss << "core";
-    }
-    return oss.str();
-}
-
-NODISCARD std::optional<GLContextCheckResult> probeCore(QSurfaceFormat &testFormat,
-                                                        std::vector<GLVersion> &coreVersions,
-                                                        QSurfaceFormat::FormatOptions optionsCoreOnly)
-{
-    std::optional<GLContextCheckResult> coreResult = std::nullopt;
-    for (auto it = coreVersions.begin(); it != coreVersions.end();) {
-        const auto &version = *it;
-        testFormat.setVersion(version.major, version.minor);
-        testFormat.setProfile(QSurfaceFormat::CoreProfile);
-        testFormat.setOptions(optionsCoreOnly);
-
-        GLContextCheckResult contextCheckResult = checkContext(testFormat,
-                                                               version,
-                                                               QSurfaceFormat::CoreProfile);
-        if (contextCheckResult.valid) {
-            coreResult = contextCheckResult;
-            MMLOG_DEBUG() << "[GL Probe] Found highest supported Core version: "
-                          << contextCheckResult.version;
-            break;
-        } else {
-            it = coreVersions.erase(it);
-        }
-    }
-    return coreResult;
-}
-
-NODISCARD std::optional<GLContextCheckResult> probeCompat(
-    QSurfaceFormat &format,
-    std::vector<GLVersion> versions,
-    QSurfaceFormat::FormatOptions options,
-    std::optional<GLContextCheckResult> coreResult)
-{
-    std::optional<GLContextCheckResult> compatResult = std::nullopt;
-
-    std::vector<GLVersion> compatVersionsToTest = versions;
-    if (coreResult) {
-        // Filter compatVersions to only include versions <= coreResult
-        compatVersionsToTest.erase(std::remove_if(compatVersionsToTest.begin(),
-                                                  compatVersionsToTest.end(),
-                                                  [&](const GLVersion &ver) {
-                                                      return ver > coreResult->version;
-                                                  }),
-                                   compatVersionsToTest.end());
-    }
-
-    for (const auto &version : compatVersionsToTest) {
-        format.setVersion(version.major, version.minor);
-        format.setProfile(QSurfaceFormat::CompatibilityProfile);
-        format.setOptions(options);
-        GLContextCheckResult contextCheckResult = checkContext(format,
-                                                               version,
-                                                               QSurfaceFormat::CompatibilityProfile);
-        if (contextCheckResult.valid) {
-            if (contextCheckResult.valid) {
-                compatResult = contextCheckResult;
-                MMLOG_DEBUG() << "[GL Probe] Found highest supported Compat version: "
-                              << compatResult->version;
-                break;
-            }
-        }
-    }
-    return compatResult;
-}
-
-NODISCARD std::string getHighestGLVersion(std::optional<GLContextCheckResult> coreResult,
-                                          std::optional<GLContextCheckResult> compatResult)
-{
-    std::string highestGLVersion;
-    if (coreResult && compatResult) {
-        if (coreResult->version > compatResult->version) {
-            highestGLVersion = formatGLVersionString(*coreResult);
-        } else {
-            highestGLVersion = formatGLVersionString(*compatResult);
-        }
-    } else if (coreResult) {
-        highestGLVersion = formatGLVersionString(*coreResult);
-    } else if (compatResult) {
-        highestGLVersion = formatGLVersionString(*compatResult);
-    } else {
-        highestGLVersion = UNDEFINED_VERSION;
-    }
-    return highestGLVersion;
-}
-
-NODISCARD QSurfaceFormat getOptimalFormat(std::optional<GLContextCheckResult> result)
-{
-    QSurfaceFormat format;
-    format.setRenderableType(QSurfaceFormat::OpenGL);
-    format.setDepthBufferSize(24);
-    if (result) {
-        if ((false)) {
-            // REVISIT: GL_INVALID_ENUM in glEnable(GL_POINT_SMOOTH) on Mesa if we use this
-            format.setVersion(result->version.major, result->version.minor);
-        } else {
-            format.setVersion(2, 1);
-        }
-        format.setProfile(result->isCore ? QSurfaceFormat::CoreProfile
-                                         : QSurfaceFormat::CompatibilityProfile);
-        QSurfaceFormat::FormatOptions options;
-        if (result->isDebug) {
-            options |= QSurfaceFormat::DebugContext;
-        }
-        if (result->isCompat) {
-            options |= QSurfaceFormat::DeprecatedFunctions;
-        }
-        MMLOG_INFO() << "[GL Probe] Optimal running format determined: GL " << format.majorVersion()
-                     << "." << format.minorVersion()
-                     << " Profile: " << (result->isCore ? "Core" : "Compat")
-                     << (result->isDebug ? " (Debug)" : " (NO Debug)");
-    } else {
-        // Fallback for optimal running format if no context was found at all
-        format.setVersion(2, 1);
-        format.setProfile(QSurfaceFormat::CompatibilityProfile);
-        format.setOptions(QSurfaceFormat::DebugContext | QSurfaceFormat::DeprecatedFunctions);
-        MMLOG_ERROR() << "[GL Probe] No suitable GL context found for running format.";
-    }
-    return format;
-}
-
-NODISCARD OpenGLProbeResult probeOpenGLFormats()
-{
-    QSurfaceFormat format;
-    format.setRenderableType(QSurfaceFormat::OpenGL);
-    format.setDepthBufferSize(24);
-
-    QSurfaceFormat::FormatOptions optionsCompat = QSurfaceFormat::DebugContext
-                                                  | QSurfaceFormat::DeprecatedFunctions;
-    QSurfaceFormat::FormatOptions optionsCore = QSurfaceFormat::DebugContext;
-
-    // Define lists of versions to try.
-    std::vector<GLVersion> coreVersions
-        = {{4, 6}, {4, 5}, {4, 4}, {4, 3}, {4, 2}, {4, 1}, {4, 0}, {3, 3}, {3, 2}};
-    std::vector<GLVersion> compatVersions = coreVersions;
-    compatVersions.insert(compatVersions.end(), {{3, 1}, {3, 0}, {2, 1}}); // Add versions < 3.2
-
-    std::optional<GLContextCheckResult> coreResult = probeCore(format, coreVersions, optionsCore);
-    std::optional<GLContextCheckResult> compatResult = probeCompat(format,
-                                                                   compatVersions,
-                                                                   optionsCompat,
-                                                                   coreResult);
-
-    OpenGLProbeResult result;
-    result.highestVersion = getHighestGLVersion(coreResult, compatResult);
-    result.runningFormat = getOptimalFormat(compatResult);
-    return result;
-}
-
-} // namespace
-
-std::string OpenGL::g_highest_reportable_version_string = UNDEFINED_VERSION;
-
-QSurfaceFormat OpenGL::createDefaultSurfaceFormat()
-{
-    OpenGLProbeResult probeResult = probeOpenGLFormats();
-    OpenGL::g_highest_reportable_version_string = probeResult.highestVersion;
-    return probeResult.runningFormat;
-}
-
-std::string OpenGL::getHighestReportableVersionString()
-{
-    return OpenGL::g_highest_reportable_version_string;
-}
-
 OpenGL::OpenGL()
-    : m_opengl{Legacy::Functions::alloc()}
-{}
+{
+    switch (OpenGLConfig::getBackendType()) {
+    case OpenGLProber::BackendType::GL:
+        m_opengl = Legacy::Functions::alloc<Legacy::FunctionsGL33>();
+        break;
+    case OpenGLProber::BackendType::GLES:
+        m_opengl = Legacy::Functions::alloc<Legacy::FunctionsES30>();
+        break;
+    case OpenGLProber::BackendType::None:
+    default:
+        qFatal("Invalid backend type");
+        break;
+    }
+}
 
 OpenGL::~OpenGL() = default;
 

--- a/src/opengl/OpenGL.h
+++ b/src/opengl/OpenGL.h
@@ -8,7 +8,6 @@
 #include "OpenGLTypes.h"
 
 #include <memory>
-#include <string>
 #include <vector>
 
 #include <glm/glm.hpp>
@@ -24,7 +23,6 @@ class Functions;
 class NODISCARD OpenGL final
 {
 private:
-    static std::string g_highest_reportable_version_string;
     std::shared_ptr<Legacy::Functions> m_opengl;
     bool m_rendererInitialized = false;
 
@@ -34,14 +32,10 @@ private:
     NODISCARD const auto &getSharedFunctions() { return m_opengl; }
 
 public:
-    OpenGL();
+    explicit OpenGL();
     ~OpenGL();
     OpenGL(const OpenGL &) = delete;
     OpenGL &operator=(const OpenGL &) = delete;
-
-public:
-    NODISCARD static QSurfaceFormat createDefaultSurfaceFormat();
-    NODISCARD static std::string getHighestReportableVersionString();
 
 public:
     NODISCARD const auto &getSharedFunctions(Badge<MapCanvas>) { return getSharedFunctions(); }

--- a/src/opengl/OpenGLConfig.cpp
+++ b/src/opengl/OpenGLConfig.cpp
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2025 The MMapper Authors
+
+#include "OpenGLConfig.h"
+
+namespace OpenGLConfig {
+
+static OpenGLProber::BackendType g_backendType;
+static bool g_isCompat;
+static std::string g_versionString;
+
+NODISCARD OpenGLProber::BackendType getBackendType()
+{
+    return g_backendType;
+}
+
+void setBackendType(OpenGLProber::BackendType type)
+{
+    g_backendType = type;
+}
+
+NODISCARD bool getIsCompat()
+{
+    return g_isCompat;
+}
+
+void setIsCompat(bool isCompat)
+{
+    g_isCompat = isCompat;
+}
+
+NODISCARD std::string getHighestReportableVersionString()
+{
+    return g_versionString;
+}
+
+void setHighestReportableVersionString(const std::string &versionString)
+{
+    g_versionString = versionString;
+}
+
+} // namespace OpenGLConfig

--- a/src/opengl/OpenGLConfig.h
+++ b/src/opengl/OpenGLConfig.h
@@ -1,0 +1,20 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2025 The MMapper Authors
+
+#include "OpenGLProber.h"
+
+#include <string>
+
+namespace OpenGLConfig {
+
+NODISCARD extern OpenGLProber::BackendType getBackendType();
+extern void setBackendType(OpenGLProber::BackendType type);
+
+NODISCARD extern bool getIsCompat();
+extern void setIsCompat(bool isCompat);
+
+NODISCARD extern std::string getHighestReportableVersionString();
+extern void setHighestReportableVersionString(const std::string &versionString);
+
+} // namespace OpenGLConfig

--- a/src/opengl/OpenGLProber.cpp
+++ b/src/opengl/OpenGLProber.cpp
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2025 The MMapper Authors
+
+#include "OpenGLProber.h"
+
+#include "../global/ConfigConsts.h"
+#include "../global/logging.h"
+
+#include <optional>
+#include <sstream>
+
+#include <QOpenGLContext>
+
+#ifdef WIN32
+extern "C" {
+// Prefer discrete nVidia and AMD GPUs by default on Windows
+__declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+}
+#endif
+
+namespace { // anonymous
+
+struct GLVersion
+{
+    int major = 0;
+    int minor = 0;
+
+    NODISCARD bool operator>(const GLVersion &other) const
+    {
+        return (major > other.major) || (major == other.major && minor > other.minor);
+    }
+
+    NODISCARD bool operator<(const GLVersion &other) const
+    {
+        return (major < other.major) || (major == other.major && minor < other.minor);
+    }
+};
+
+inline std::ostream &operator<<(std::ostream &os, const GLVersion &version)
+{
+    os << version.major << "." << version.minor;
+    return os;
+}
+
+struct GLContextCheckResult
+{
+    bool valid = false;
+    GLVersion version = {0, 0};
+    bool isCore = false;
+    bool isCompat = false;
+    bool isDeprecated = false;
+    bool isDebug = false;
+};
+
+NODISCARD GLContextCheckResult checkContext(QSurfaceFormat format,
+                                            GLVersion version,
+                                            QSurfaceFormat::OpenGLContextProfile profile)
+{
+    GLContextCheckResult result;
+    QOpenGLContext context;
+    context.setFormat(format);
+    if (!context.create()) {
+        MMLOG_DEBUG() << "[GL Check] context.create() failed for requested " << version
+                      << (profile == QSurfaceFormat::CoreProfile ? " Core" : " Compat");
+        return result;
+    }
+
+    QSurfaceFormat actualFormat = context.format();
+
+    result.isCore = (actualFormat.profile() & QSurfaceFormat::CoreProfile);
+    result.isCompat = (actualFormat.profile() & QSurfaceFormat::CompatibilityProfile);
+    result.isDeprecated = (actualFormat.options() & QSurfaceFormat::DeprecatedFunctions);
+    result.isDebug = (actualFormat.options() & QSurfaceFormat::DebugContext);
+    result.version = GLVersion{actualFormat.majorVersion(), actualFormat.minorVersion()};
+
+    context.doneCurrent();
+
+    // Check if the actual OpenGL context meets the minimum requirements
+    bool profileOk = false;
+
+    if (version < GLVersion{3, 2}) {
+        if (profile == QSurfaceFormat::CoreProfile) {
+            // Core profile did not exist before GL 3.2
+            profileOk = false;
+        } else {
+            // Must be compatibility-like
+            profileOk = result.isCompat || result.isDeprecated;
+        }
+    } else {
+        // For GL 3.2+
+        if (profile == QSurfaceFormat::CoreProfile) {
+            profileOk = result.isCore;
+        } else if (profile == QSurfaceFormat::CompatibilityProfile) {
+            profileOk = result.isCompat && result.isDeprecated;
+        }
+    }
+
+    // If the profile is ok, we consider the context valid even if the version is lower than requested.
+    if (profileOk) {
+        result.valid = true;
+        MMLOG_DEBUG() << "[GL Probe] GL " << result.version << (result.isCore ? " Core" : " Compat")
+                      << " is valid";
+    }
+    return result;
+}
+
+NODISCARD std::string formatGLVersionString(const GLContextCheckResult &result)
+{
+    std::ostringstream oss;
+    oss << "GL" << result.version;
+    if (!result.isDeprecated && result.version > GLVersion{3, 1}) {
+        oss << "core";
+    }
+    return oss.str();
+}
+
+NODISCARD std::optional<GLContextCheckResult> probeCore(QSurfaceFormat &testFormat,
+                                                        std::vector<GLVersion> &coreVersions,
+                                                        QSurfaceFormat::FormatOptions optionsCoreOnly)
+{
+    std::optional<GLContextCheckResult> coreResult = std::nullopt;
+    for (auto it = coreVersions.begin(); it != coreVersions.end();) {
+        const auto &version = *it;
+        testFormat.setVersion(version.major, version.minor);
+        testFormat.setProfile(QSurfaceFormat::CoreProfile);
+        testFormat.setOptions(optionsCoreOnly);
+
+        GLContextCheckResult contextCheckResult = checkContext(testFormat,
+                                                               version,
+                                                               QSurfaceFormat::CoreProfile);
+        if (contextCheckResult.valid) {
+            coreResult = contextCheckResult;
+            MMLOG_DEBUG() << "[GL Probe] Found highest supported Core version: "
+                          << contextCheckResult.version;
+            break;
+        } else {
+            it = coreVersions.erase(it);
+        }
+    }
+    return coreResult;
+}
+
+NODISCARD std::optional<GLContextCheckResult> probeCompat(
+    QSurfaceFormat &format,
+    std::vector<GLVersion> versions,
+    QSurfaceFormat::FormatOptions options,
+    std::optional<GLContextCheckResult> coreResult)
+{
+    std::optional<GLContextCheckResult> compatResult = std::nullopt;
+
+    std::vector<GLVersion> compatVersionsToTest = versions;
+    if (coreResult) {
+        // Filter compatVersions to only include versions <= coreResult
+        compatVersionsToTest.erase(std::remove_if(compatVersionsToTest.begin(),
+                                                  compatVersionsToTest.end(),
+                                                  [&](const GLVersion &ver) {
+                                                      return ver > coreResult->version;
+                                                  }),
+                                   compatVersionsToTest.end());
+    }
+
+    for (const auto &version : compatVersionsToTest) {
+        format.setVersion(version.major, version.minor);
+        format.setProfile(QSurfaceFormat::CompatibilityProfile);
+        format.setOptions(options);
+        GLContextCheckResult contextCheckResult = checkContext(format,
+                                                               version,
+                                                               QSurfaceFormat::CompatibilityProfile);
+        if (contextCheckResult.valid) {
+            if (contextCheckResult.valid) {
+                compatResult = contextCheckResult;
+                MMLOG_DEBUG() << "[GL Probe] Found highest supported Compat version: "
+                              << compatResult->version;
+                break;
+            }
+        }
+    }
+    return compatResult;
+}
+
+NODISCARD std::string getHighestGLVersion(std::optional<GLContextCheckResult> coreResult,
+                                          std::optional<GLContextCheckResult> compatResult)
+{
+    std::string highestGLVersion;
+    if (coreResult && compatResult) {
+        if (coreResult->version > compatResult->version) {
+            highestGLVersion = formatGLVersionString(*coreResult);
+        } else {
+            highestGLVersion = formatGLVersionString(*compatResult);
+        }
+    } else if (coreResult) {
+        highestGLVersion = formatGLVersionString(*coreResult);
+    } else if (compatResult) {
+        highestGLVersion = formatGLVersionString(*compatResult);
+    } else {
+        highestGLVersion = "Fallback";
+    }
+    return highestGLVersion;
+}
+
+NODISCARD QSurfaceFormat getOptimalFormat(std::optional<GLContextCheckResult> result)
+{
+    QSurfaceFormat format;
+    format.setRenderableType(QSurfaceFormat::OpenGL);
+    format.setDepthBufferSize(24);
+    if (result) {
+        if ((false)) {
+            // REVISIT: GL_INVALID_ENUM in glEnable(GL_POINT_SMOOTH) on Mesa if we use this
+            format.setVersion(result->version.major, result->version.minor);
+        } else {
+            format.setVersion(3, 3);
+        }
+        format.setProfile(result->isCore ? QSurfaceFormat::CoreProfile
+                                         : QSurfaceFormat::CompatibilityProfile);
+        QSurfaceFormat::FormatOptions options;
+        if (result->isDebug) {
+            options |= QSurfaceFormat::DebugContext;
+        }
+        if (result->isCompat) {
+            options |= QSurfaceFormat::DeprecatedFunctions;
+        }
+        MMLOG_INFO() << "[GL Probe] Optimal running format determined: GL " << format.majorVersion()
+                     << "." << format.minorVersion()
+                     << " Profile: " << (result->isCore ? "Core" : "Compat")
+                     << (result->isDebug ? " (Debug)" : " (NO Debug)");
+    } else {
+        // Fallback for optimal running format if no context was found at all
+        format.setVersion(3, 3);
+        format.setProfile(QSurfaceFormat::CoreProfile);
+        format.setOptions(QSurfaceFormat::DebugContext);
+        MMLOG_ERROR() << "[GL Probe] No suitable GL context found for running format.";
+    }
+    return format;
+}
+
+OpenGLProber::ProbeResult probeOpenGL()
+{
+    QSurfaceFormat format;
+    format.setRenderableType(QSurfaceFormat::OpenGL);
+    format.setDepthBufferSize(24);
+
+    QSurfaceFormat::FormatOptions optionsCompat = QSurfaceFormat::DebugContext
+                                                  | QSurfaceFormat::DeprecatedFunctions;
+    QSurfaceFormat::FormatOptions optionsCore = QSurfaceFormat::DebugContext;
+
+    // Define lists of versions to try.
+    std::vector<GLVersion> versions
+        = {{4, 6}, {4, 5}, {4, 4}, {4, 3}, {4, 2}, {4, 1}, {4, 0}, {3, 3}, {3, 2}};
+
+    std::optional<GLContextCheckResult> coreResult = probeCore(format, versions, optionsCore);
+    std::optional<GLContextCheckResult> compatResult = probeCompat(format,
+                                                                   versions,
+                                                                   optionsCompat,
+                                                                   coreResult);
+
+    OpenGLProber::ProbeResult result;
+    if (compatResult || coreResult) {
+        result.backendType = OpenGLProber::BackendType::GL;
+        result.highestVersionString = getHighestGLVersion(coreResult, compatResult);
+        result.format = getOptimalFormat(compatResult ? compatResult : coreResult);
+        result.isCompat = (compatResult && compatResult->isCompat);
+    }
+    return result;
+}
+
+OpenGLProber::ProbeResult probeOpenGLES()
+{
+    QSurfaceFormat format;
+    format.setRenderableType(QSurfaceFormat::OpenGLES);
+    format.setVersion(3, 0);
+
+    QOpenGLContext context;
+    context.setFormat(format);
+    if (!context.create()) {
+        MMLOG_DEBUG() << "Failed to create GLES 3.0 context";
+        return {};
+    }
+
+    OpenGLProber::ProbeResult result;
+    result.backendType = OpenGLProber::BackendType::GLES;
+    result.format = format;
+    result.highestVersionString = "ES3.0";
+    return result;
+}
+
+} // namespace
+
+OpenGLProber::ProbeResult OpenGLProber::probe()
+{
+    if constexpr (!NO_OPENGL) {
+        MMLOG_DEBUG() << "Probing for OpenGL support...";
+        auto glResult = probeOpenGL();
+        if (glResult.backendType != BackendType::None) {
+            return glResult;
+        }
+    }
+    if constexpr (!NO_GLES) {
+        MMLOG_DEBUG() << "Probing for OpenGL ES support...";
+        auto glesResult = probeOpenGLES();
+        if (glesResult.backendType != BackendType::None) {
+            return glesResult;
+        }
+    }
+    MMLOG_DEBUG() << "No suitable backend found.";
+    return {};
+}

--- a/src/opengl/OpenGLProber.h
+++ b/src/opengl/OpenGLProber.h
@@ -1,0 +1,31 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2025 The MMapper Authors
+
+#include "../global/RuleOf5.h"
+#include "../global/macros.h"
+
+#include <string>
+
+#include <QSurfaceFormat>
+
+class NODISCARD OpenGLProber final
+{
+public:
+    enum class BackendType { None, GL, GLES };
+
+    struct ProbeResult
+    {
+        BackendType backendType = BackendType::None;
+        QSurfaceFormat format;
+        std::string highestVersionString;
+        bool isCompat = false;
+    };
+
+public:
+    OpenGLProber() = default;
+    DELETE_CTORS_AND_ASSIGN_OPS(OpenGLProber);
+    DTOR(OpenGLProber) = default;
+
+    NODISCARD ProbeResult probe();
+};

--- a/src/opengl/legacy/FunctionsES30.cpp
+++ b/src/opengl/legacy/FunctionsES30.cpp
@@ -1,0 +1,49 @@
+#include "FunctionsES30.h"
+
+namespace Legacy {
+
+FunctionsES30::FunctionsES30(Badge<Functions> badge)
+    : Functions(badge)
+{
+    assert(!OpenGLConfig::getIsCompat());
+}
+
+bool FunctionsES30::virt_canRenderQuads()
+{
+    return false;
+}
+
+std::optional<GLenum> FunctionsES30::virt_toGLenum(const DrawModeEnum mode)
+{
+    switch (mode) {
+    case DrawModeEnum::POINTS:
+        return GL_POINTS;
+    case DrawModeEnum::LINES:
+        return GL_LINES;
+    case DrawModeEnum::TRIANGLES:
+        return GL_TRIANGLES;
+
+    case DrawModeEnum::INVALID:
+    case DrawModeEnum::QUADS:
+        break;
+    }
+
+    return std::nullopt;
+}
+
+const char *FunctionsES30::virt_getShaderVersion() const
+{
+    return "#version 300 es\n\nprecision highp float;\n\n";
+}
+
+void FunctionsES30::virt_enableProgramPointSize(bool /* enable */)
+{
+    // nop
+}
+
+bool FunctionsES30::virt_tryEnableMultisampling(int /* requestedSamples */)
+{
+    return false;
+}
+
+} // namespace Legacy

--- a/src/opengl/legacy/FunctionsES30.h
+++ b/src/opengl/legacy/FunctionsES30.h
@@ -1,0 +1,25 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 The MMapper Authors
+
+#include "Legacy.h"
+
+namespace Legacy {
+
+class FunctionsES30 final : public Functions
+{
+public:
+    explicit FunctionsES30(Badge<Functions>);
+    ~FunctionsES30() override = default;
+
+    DELETE_CTORS_AND_ASSIGN_OPS(FunctionsES30);
+
+private:
+    void virt_enableProgramPointSize(bool enable) override;
+    NODISCARD bool virt_tryEnableMultisampling(int requestedSamples) override;
+    NODISCARD const char *virt_getShaderVersion() const override;
+    NODISCARD bool virt_canRenderQuads() override;
+    NODISCARD std::optional<GLenum> virt_toGLenum(DrawModeEnum mode) override;
+};
+
+} // namespace Legacy

--- a/src/opengl/legacy/FunctionsGL33.cpp
+++ b/src/opengl/legacy/FunctionsGL33.cpp
@@ -1,15 +1,20 @@
-#include "Legacy.h"
+#include "FunctionsGL33.h"
+
+#include "../OpenGLConfig.h"
 
 #include <optional>
 
 namespace Legacy {
 
-bool Functions::canRenderQuads()
+FunctionsGL33::FunctionsGL33(Badge<Functions> badge)
+    : Functions(badge){};
+
+bool FunctionsGL33::virt_canRenderQuads()
 {
-    return true;
+    return OpenGLConfig::getIsCompat();
 }
 
-std::optional<GLenum> Functions::toGLenum(const DrawModeEnum mode)
+std::optional<GLenum> FunctionsGL33::virt_toGLenum(const DrawModeEnum mode)
 {
     switch (mode) {
     case DrawModeEnum::POINTS:
@@ -19,7 +24,9 @@ std::optional<GLenum> Functions::toGLenum(const DrawModeEnum mode)
     case DrawModeEnum::TRIANGLES:
         return GL_TRIANGLES;
     case DrawModeEnum::QUADS:
-        return GL_QUADS;
+#ifndef MMAPPER_NO_OPENGL
+        return canRenderQuads() ? std::make_optional(GL_QUADS) : std::nullopt;
+#endif
     case DrawModeEnum::INVALID:
         break;
     }
@@ -27,22 +34,25 @@ std::optional<GLenum> Functions::toGLenum(const DrawModeEnum mode)
     return std::nullopt;
 }
 
-const char *Functions::getShaderVersion()
+const char *FunctionsGL33::virt_getShaderVersion() const
 {
-    return "#version 110\n\n";
+    return "#version 330\n\n";
 }
 
-void Functions::enableProgramPointSize(const bool enable)
+void FunctionsGL33::virt_enableProgramPointSize(const bool enable)
 {
+#ifndef MMAPPER_NO_OPENGL
     if (enable) {
         Base::glEnable(GL_PROGRAM_POINT_SIZE);
     } else {
         Base::glDisable(GL_PROGRAM_POINT_SIZE);
     }
+#endif
 }
 
-bool Functions::tryEnableMultisampling(const int requestedSamples)
+bool FunctionsGL33::virt_tryEnableMultisampling(const int requestedSamples)
 {
+#ifndef MMAPPER_NO_OPENGL
     const auto getSampleBuffers = [this]() -> GLint {
         GLint buffers;
         Base::glGetIntegerv(GL_SAMPLE_BUFFERS, &buffers);
@@ -56,34 +66,29 @@ bool Functions::tryEnableMultisampling(const int requestedSamples)
     };
 
     const bool hasMultisampling = getSampleBuffers() > 1 || getSamples() > 1;
-
     if (hasMultisampling && requestedSamples > 0) {
         Base::glEnable(GL_MULTISAMPLE);
-
-        Base::glEnable(GL_POINT_SMOOTH);
         Base::glEnable(GL_LINE_SMOOTH);
         Base::glDisable(GL_POLYGON_SMOOTH);
-        Base::glHint(GL_POINT_SMOOTH_HINT, GL_NICEST);
         Base::glHint(GL_LINE_SMOOTH_HINT, GL_NICEST);
-
         return true;
     } else {
         // NOTE: Currently we can use OpenGL 2.1 to fake multisampling with point/line/polygon smoothing.
         // TODO: We can use OpenGL 3.x FBOs to do multisampling even if the default framebuffer doesn't support it.
         if (requestedSamples > 0) {
-            Base::glEnable(GL_POINT_SMOOTH);
             Base::glEnable(GL_LINE_SMOOTH);
             Base::glDisable(GL_POLYGON_SMOOTH);
-            Base::glHint(GL_POINT_SMOOTH_HINT, GL_NICEST);
             Base::glHint(GL_LINE_SMOOTH_HINT, GL_NICEST);
             return true;
         } else {
-            Base::glDisable(GL_POINT_SMOOTH);
             Base::glDisable(GL_LINE_SMOOTH);
             Base::glDisable(GL_POLYGON_SMOOTH);
             return false;
         }
     }
+#else
+    return false;
+#endif
 }
 
 } // namespace Legacy

--- a/src/opengl/legacy/FunctionsGL33.h
+++ b/src/opengl/legacy/FunctionsGL33.h
@@ -1,0 +1,25 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 The MMapper Authors
+
+#include "Legacy.h"
+
+namespace Legacy {
+
+class FunctionsGL33 final : public Functions
+{
+public:
+    explicit FunctionsGL33(Badge<Functions>);
+    ~FunctionsGL33() override = default;
+
+    DELETE_CTORS_AND_ASSIGN_OPS(FunctionsGL33);
+
+private:
+    void virt_enableProgramPointSize(bool enable) override;
+    NODISCARD bool virt_tryEnableMultisampling(int requestedSamples) override;
+    NODISCARD const char *virt_getShaderVersion() const override;
+    NODISCARD bool virt_canRenderQuads() override;
+    NODISCARD std::optional<GLenum> virt_toGLenum(DrawModeEnum mode) override;
+};
+
+} // namespace Legacy

--- a/src/opengl/legacy/Legacy.cpp
+++ b/src/opengl/legacy/Legacy.cpp
@@ -31,6 +31,7 @@
 #include <QDebug>
 #include <QFile>
 #include <QMessageLogContext>
+#include <QOpenGLExtraFunctions>
 #include <QOpenGLTexture>
 
 namespace Legacy {
@@ -281,11 +282,6 @@ StaticVbos &Functions::getStaticVbos()
 TexLookup &Functions::getTexLookup()
 {
     return deref(m_texLookup);
-}
-
-std::shared_ptr<Functions> Functions::alloc()
-{
-    return std::make_shared<Functions>(Badge<Functions>{});
 }
 
 /// This only exists so we can detect errors in contexts that don't support \c glDebugMessageCallback().

--- a/src/opengl/legacy/ShaderUtils.cpp
+++ b/src/opengl/legacy/ShaderUtils.cpp
@@ -211,9 +211,7 @@ NODISCARD static GLuint compileShader(Functions &gl, const GLenum type, const So
     // NOTE: GLES 2.0 required `const char**` instead of `const char*const*`,
     // so Qt uses the least common denominator without the middle const;
     // that's the reason the `ptrs` array below is not `const`.
-    std::array<const char *, 3> ptrs = {Functions::getShaderVersion(),
-                                        "#line 1\n",
-                                        source.source.c_str()};
+    std::array<const char *, 3> ptrs = {gl.getShaderVersion(), "#line 1\n", source.source.c_str()};
     gl.glShaderSource(shaderId, static_cast<GLsizei>(ptrs.size()), ptrs.data(), nullptr);
     gl.glCompileShader(shaderId);
     checkShaderInfo(gl, shaderId);

--- a/src/opengl/legacy/VAO.cpp
+++ b/src/opengl/legacy/VAO.cpp
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2025 The MMapper Authors
+
+#include "VAO.h"
+
+#include <QDebug>
+#include <QOpenGLContext>
+
+namespace Legacy {
+
+bool LOG_VAO_ALLOCATIONS = false;
+
+void VAO::emplace(const SharedFunctions &sharedFunctions)
+{
+    assert(!*this);
+    m_weakFunctions = sharedFunctions;
+    const auto shared = m_weakFunctions.lock();
+    if (shared == nullptr) {
+        throw std::runtime_error("Legacy::Functions is no longer valid");
+    }
+
+    shared->glGenVertexArrays(1, &m_vao);
+    shared->checkError();
+
+    if (LOG_VAO_ALLOCATIONS) {
+        qInfo() << "Allocated VAO" << m_vao;
+    }
+}
+
+void VAO::reset()
+{
+    if (!*this) {
+        return;
+    }
+
+    const auto shared = m_weakFunctions.lock();
+    if (shared != nullptr) {
+        if (LOG_VAO_ALLOCATIONS) {
+            qInfo() << "Deallocating VAO" << m_vao;
+        }
+        shared->glDeleteVertexArrays(1, &m_vao);
+        shared->checkError();
+    } else {
+        qCritical() << "Legacy::Functions is no longer valid, leaking VAO" << m_vao;
+    }
+
+    m_vao = INVALID_VAOID;
+    m_weakFunctions.reset();
+}
+
+GLuint VAO::get() const
+{
+    return m_vao;
+}
+
+} // namespace Legacy

--- a/src/opengl/legacy/VAO.h
+++ b/src/opengl/legacy/VAO.h
@@ -1,0 +1,33 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2025 The MMapper Authors
+
+#include "Legacy.h"
+
+namespace Legacy {
+
+extern bool LOG_VAO_ALLOCATIONS;
+
+class NODISCARD VAO final
+{
+private:
+    static inline constexpr GLuint INVALID_VAOID = 0;
+    WeakFunctions m_weakFunctions;
+    GLuint m_vao = INVALID_VAOID;
+
+public:
+    VAO() = default;
+    ~VAO() { reset(); }
+
+    DELETE_CTORS_AND_ASSIGN_OPS(VAO);
+
+public:
+    void emplace(const SharedFunctions &sharedFunctions);
+    void reset();
+    NODISCARD GLuint get() const;
+
+public:
+    NODISCARD explicit operator bool() const { return m_vao != INVALID_VAOID; }
+};
+
+} // namespace Legacy

--- a/src/proxy/MudTelnet.cpp
+++ b/src/proxy/MudTelnet.cpp
@@ -11,7 +11,7 @@
 #include "../global/TextUtils.h"
 #include "../global/Version.h"
 #include "../global/emojis.h"
-#include "../opengl/OpenGL.h"
+#include "../opengl/OpenGLConfig.h"
 #include "GmcpUtils.h"
 
 #include <charconv>
@@ -76,7 +76,7 @@ NODISCARD TelnetTermTypeBytes addTerminalTypeSuffix(const std::string_view prefi
 
     std::ostringstream ss;
     ss << prefix << "/MMapper-" << getMMapperVersion() << "/"
-       << OpenGL::getHighestReportableVersionString() << "/" << getOs() << "/" << arch;
+       << OpenGLConfig::getHighestReportableVersionString() << "/" << getOs() << "/" << arch;
     auto str = std::move(ss).str();
 
     return TelnetTermTypeBytes{mmqt::toQByteArrayUtf8(str)};

--- a/src/resources/shaders/legacy/font/frag.glsl
+++ b/src/resources/shaders/legacy/font/frag.glsl
@@ -3,10 +3,12 @@
 
 uniform sampler2D uFontTexture;
 
-varying vec4 vColor;
-varying vec2 vTexCoord;
+in vec4 vColor;
+in vec2 vTexCoord;
+
+out vec4 vFragmentColor;
 
 void main()
 {
-    gl_FragColor = vColor * texture2D(uFontTexture, vTexCoord);
+    vFragmentColor = vColor * texture(uFontTexture, vTexCoord);
 }

--- a/src/resources/shaders/legacy/font/vert.glsl
+++ b/src/resources/shaders/legacy/font/vert.glsl
@@ -4,13 +4,13 @@
 uniform mat4 uMVP3D;
 uniform ivec4 uPhysViewport;
 
-attribute vec3 aBase; // address in world space
-attribute vec4 aColor;
-attribute vec2 aTexCoord;
-attribute vec2 aVert; // offset in raw pixels
+layout(location = 0) in vec3 aBase; // address in world space
+layout(location = 1) in vec4 aColor;
+layout(location = 2) in vec2 aTexCoord;
+layout(location = 3) in vec2 aVert; // offset in raw pixels
 
-varying vec4 vColor;
-varying vec2 vTexCoord;
+out vec4 vColor;
+out vec2 vTexCoord;
 
 // [0, 1]^2 to pixels
 vec2 convertScreen01toPhysPixels(vec2 pos)

--- a/src/resources/shaders/legacy/plain/acolor/frag.glsl
+++ b/src/resources/shaders/legacy/plain/acolor/frag.glsl
@@ -3,9 +3,11 @@
 
 uniform vec4 uColor;
 
-varying vec4 vColor;
+in vec4 vColor;
+
+out vec4 vFragmentColor;
 
 void main()
 {
-    gl_FragColor = vColor * uColor;
+    vFragmentColor = vColor * uColor;
 }

--- a/src/resources/shaders/legacy/plain/acolor/vert.glsl
+++ b/src/resources/shaders/legacy/plain/acolor/vert.glsl
@@ -3,10 +3,10 @@
 
 uniform mat4 uMVP;
 
-attribute vec4 aColor;
-attribute vec3 aVert;
+layout(location = 0) in vec4 aColor;
+layout(location = 1) in vec3 aVert;
 
-varying vec4 vColor;
+out vec4 vColor;
 
 void main()
 {

--- a/src/resources/shaders/legacy/plain/ucolor/frag.glsl
+++ b/src/resources/shaders/legacy/plain/ucolor/frag.glsl
@@ -3,7 +3,9 @@
 
 uniform vec4 uColor;
 
+out vec4 vFragmentColor;
+
 void main()
 {
-    gl_FragColor = uColor;
+    vFragmentColor = uColor;
 }

--- a/src/resources/shaders/legacy/plain/ucolor/vert.glsl
+++ b/src/resources/shaders/legacy/plain/ucolor/vert.glsl
@@ -3,7 +3,7 @@
 
 uniform mat4 uMVP;
 
-attribute vec3 aVert;
+layout(location = 0) in vec3 aVert;
 
 void main()
 {

--- a/src/resources/shaders/legacy/point/frag.glsl
+++ b/src/resources/shaders/legacy/point/frag.glsl
@@ -3,9 +3,14 @@
 
 uniform vec4 uColor;
 
-varying vec4 vColor;
+in vec4 vColor;
+
+out vec4 vFragmentColor;
 
 void main()
 {
-    gl_FragColor = vColor * uColor;
+    if (dot(gl_PointCoord-0.5, gl_PointCoord-0.5) > 0.25) {
+        discard;
+    }
+    vFragmentColor = vColor * uColor;
 }

--- a/src/resources/shaders/legacy/point/vert.glsl
+++ b/src/resources/shaders/legacy/point/vert.glsl
@@ -4,10 +4,10 @@
 uniform mat4 uMVP;
 uniform float uPointSize;
 
-attribute vec4 aColor;
-attribute vec3 aVert;
+layout(location = 0) in vec4 aColor;
+layout(location = 1) in vec3 aVert;
 
-varying vec4 vColor;
+out vec4 vColor;
 
 void main()
 {

--- a/src/resources/shaders/legacy/tex/acolor/frag.glsl
+++ b/src/resources/shaders/legacy/tex/acolor/frag.glsl
@@ -4,10 +4,12 @@
 uniform sampler2D uTexture;
 uniform vec4 uColor;
 
-varying vec4 vColor;
-varying vec2 vTexCoord;
+in vec4 vColor;
+in vec2 vTexCoord;
+
+out vec4 vFragmentColor;
 
 void main()
 {
-    gl_FragColor = vColor * uColor * texture2D(uTexture, vTexCoord);
+    vFragmentColor = vColor * uColor * texture(uTexture, vTexCoord);
 }

--- a/src/resources/shaders/legacy/tex/acolor/vert.glsl
+++ b/src/resources/shaders/legacy/tex/acolor/vert.glsl
@@ -3,12 +3,12 @@
 
 uniform mat4 uMVP;
 
-attribute vec4 aColor;
-attribute vec2 aTexCoord;
-attribute vec3 aVert;
+layout(location = 0) in vec4 aColor;
+layout(location = 1) in vec2 aTexCoord;
+layout(location = 2) in vec3 aVert;
 
-varying vec4 vColor;
-varying vec2 vTexCoord;
+out vec4 vColor;
+out vec2 vTexCoord;
 
 void main()
 {

--- a/src/resources/shaders/legacy/tex/ucolor/frag.glsl
+++ b/src/resources/shaders/legacy/tex/ucolor/frag.glsl
@@ -4,9 +4,11 @@
 uniform sampler2D uTexture;
 uniform vec4 uColor;
 
-varying vec2 vTexCoord;
+in vec2 vTexCoord;
+
+out vec4 vFragmentColor;
 
 void main()
 {
-    gl_FragColor = uColor * texture2D(uTexture, vTexCoord);
+    vFragmentColor = uColor * texture(uTexture, vTexCoord);
 }

--- a/src/resources/shaders/legacy/tex/ucolor/vert.glsl
+++ b/src/resources/shaders/legacy/tex/ucolor/vert.glsl
@@ -3,10 +3,10 @@
 
 uniform mat4 uMVP;
 
-attribute vec2 aTexCoord;
-attribute vec3 aVert;
+layout(location = 0) in vec2 aTexCoord;
+layout(location = 1) in vec3 aVert;
 
-varying vec2 vTexCoord;
+out vec2 vTexCoord;
 
 void main()
 {


### PR DESCRIPTION
## Summary by Sourcery

Raise the rendering backend requirements to OpenGL 3.3 core (or OpenGL ES 3.0) and introduce a new probing/configuration layer that selects and configures the appropriate backend at startup.

New Features:
- Add an OpenGLProber utility that detects available GL/GLES backends and determines the optimal QSurfaceFormat.
- Introduce OpenGLConfig as a central store for selected backend type, compatibility mode, and highest reportable GL version.
- Add separate Legacy::FunctionsGL33 and Legacy::FunctionsES30 implementations for desktop OpenGL 3.3 and OpenGL ES 3.0 backends, respectively.
- Add a VAO helper class to manage vertex array object lifetime for legacy meshes.

Bug Fixes:
- Ensure application exits gracefully with a clear error message when no suitable GL or GLES backend is available instead of continuing with an invalid context.

Enhancements:
- Refactor OpenGL initialization so OpenGL selects the appropriate Legacy::Functions implementation based on the probed backend.
- Update legacy rendering to use QOpenGLExtraFunctions, vertex array objects, and per-backend virtual hooks instead of a monolithic GL 2.0/ES 2.0 implementation.
- Modernize legacy GLSL shaders to versions compatible with GL 3.3 core / ES 3.0, using explicit layout locations, in/out varyings, fragment outputs, and updated texture functions.
- Adjust anti-aliasing and multisampling handling to respect backend capabilities and remove deprecated smooth-point usage.
- Update GL version reporting in the Telnet terminal type and map canvas to use the new OpenGLConfig source.

Build:
- Extend CMake to probe Qt6 OpenGL support for GLES 3.0 and OpenGL 3.3 via try_compile and define MMAPPER_NO_GLES/MMAPPER_NO_OPENGL and corresponding NO_GLES/NO_OPENGL config flags.