### PR TITLE
add optional command separator to integrated client

### DIFF
--- a/src/configuration/configuration.cpp
+++ b/src/configuration/configuration.cpp
@@ -295,6 +295,8 @@ ConstString KEY_WINDOW_GEOMETRY = "Window Geometry";
 ConstString KEY_WINDOW_STATE = "Window State";
 ConstString KEY_BELL_AUDIBLE = "Bell audible";
 ConstString KEY_BELL_VISUAL = "Bell visual";
+ConstString KEY_USE_COMMAND_SEPARATOR = "Use command separator";
+ConstString KEY_COMMAND_SEPARATOR = "Command separator";
 
 void Settings::tryCopyOldSettings()
 {
@@ -751,6 +753,9 @@ void Configuration::IntegratedMudClientSettings::read(const QSettings &conf)
     linesOfPeekPreview = conf.value(KEY_LINES_OF_PEEK_PREVIEW, 7).toInt();
     audibleBell = conf.value(KEY_BELL_AUDIBLE, true).toBool();
     visualBell = conf.value(KEY_BELL_VISUAL, (CURRENT_PLATFORM == PlatformEnum::Wasm)).toBool();
+    useCommandSeparator = conf.value(KEY_USE_COMMAND_SEPARATOR, false).toBool();
+    commandSeparator = conf.value(KEY_COMMAND_SEPARATOR, QString(char_consts::C_SEMICOLON))
+                           .toString();
 }
 
 void Configuration::RoomPanelSettings::read(const QSettings &conf)
@@ -920,6 +925,8 @@ void Configuration::IntegratedMudClientSettings::write(QSettings &conf) const
     conf.setValue(KEY_LINES_OF_PEEK_PREVIEW, linesOfPeekPreview);
     conf.setValue(KEY_BELL_AUDIBLE, audibleBell);
     conf.setValue(KEY_BELL_VISUAL, visualBell);
+    conf.setValue(KEY_USE_COMMAND_SEPARATOR, useCommandSeparator);
+    conf.setValue(KEY_COMMAND_SEPARATOR, commandSeparator);
 }
 
 void Configuration::RoomPanelSettings::write(QSettings &conf) const

--- a/src/configuration/configuration.h
+++ b/src/configuration/configuration.h
@@ -364,6 +364,7 @@ public:
         QString font;
         QColor foregroundColor;
         QColor backgroundColor;
+        QString commandSeparator;
         int columns = 0;
         int rows = 0;
         int linesOfScrollback = 0;
@@ -374,6 +375,7 @@ public:
         int linesOfPeekPreview = 0;
         bool audibleBell = false;
         bool visualBell = false;
+        bool useCommandSeparator = false;
 
     private:
         SUBGROUP();

--- a/src/preferences/clientpage.ui
+++ b/src/preferences/clientpage.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>303</width>
-    <height>534</height>
+    <width>331</width>
+    <height>687</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -236,32 +236,6 @@
       <string>Input</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Tab word completion dictionary size:</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-        <property name="buddy">
-         <cstring>tabDictionarySpinBox</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_8">
-        <property name="text">
-         <string>Lines of input history:</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-        <property name="buddy">
-         <cstring>inputHistorySpinBox</cstring>
-        </property>
-       </widget>
-      </item>
       <item row="2" column="1">
        <widget class="QSpinBox" name="tabDictionarySpinBox">
         <property name="showGroupSeparator" stdset="0">
@@ -294,14 +268,27 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
+      <item row="4" column="0">
        <widget class="QCheckBox" name="clearInputCheckBox">
         <property name="text">
          <string>Clear input on send</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Tab word completion dictionary size:</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="buddy">
+         <cstring>tabDictionarySpinBox</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
        <spacer name="horizontalSpacer_2">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
@@ -313,6 +300,43 @@
          </size>
         </property>
        </spacer>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_8">
+        <property name="text">
+         <string>Lines of input history:</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="buddy">
+         <cstring>inputHistorySpinBox</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0" colspan="2">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QCheckBox" name="commandSeparatorCheckBox">
+          <property name="text">
+           <string>Command separator</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="commandSeparatorLineEdit">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="maxLength">
+           <number>1</number>
+          </property>
+          <property name="placeholderText">
+           <string>;</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>
@@ -336,13 +360,17 @@
   <tabstop>fontPushButton</tabstop>
   <tabstop>fgColorPushButton</tabstop>
   <tabstop>bgColorPushButton</tabstop>
-  <tabstop>columnsSpinBox</tabstop>
   <tabstop>rowsSpinBox</tabstop>
+  <tabstop>columnsSpinBox</tabstop>
   <tabstop>scrollbackSpinBox</tabstop>
   <tabstop>previewSpinBox</tabstop>
   <tabstop>autoResizeTerminalCheckBox</tabstop>
+  <tabstop>audibleBellCheckBox</tabstop>
+  <tabstop>visualBellCheckBox</tabstop>
   <tabstop>inputHistorySpinBox</tabstop>
   <tabstop>tabDictionarySpinBox</tabstop>
+  <tabstop>commandSeparatorCheckBox</tabstop>
+  <tabstop>commandSeparatorLineEdit</tabstop>
   <tabstop>clearInputCheckBox</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
## Summary by Sourcery

Add support for an optional custom newline separator in the integrated client input handling and preferences.

New Features:
- Allow configuring and toggling a custom single-character newline separator for the integrated client, persisted in settings and exposed in the preferences UI.

Enhancements:
- Validate the custom newline separator input to ensure it is a single printable, non-space, non-backslash Latin-1 character and transliterate unsupported characters in-place.