### PR TITLE
implement MSAA via FBO resolve

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -403,6 +403,8 @@ set(mmapper_SRCS
     opengl/legacy/AbstractShaderProgram.h
     opengl/legacy/Binders.cpp
     opengl/legacy/Binders.h
+    opengl/legacy/FBO.cpp
+    opengl/legacy/FBO.h
     opengl/legacy/FontMesh3d.cpp
     opengl/legacy/FontMesh3d.h
     opengl/legacy/Legacy.cpp

--- a/src/configuration/configuration.cpp
+++ b/src/configuration/configuration.cpp
@@ -629,8 +629,8 @@ void Configuration::CanvasSettings::read(const QSettings &conf)
     connectionNormalColor = lookupColor(KEY_CONNECTION_NORMAL_COLOR, Colors::white.toHex());
     roomDarkColor = lookupColor(KEY_ROOM_DARK_COLOR, DEFAULT_DARK_COLOR);
     roomDarkLitColor = lookupColor(KEY_ROOM_DARK_LIT_COLOR, DEFAULT_NO_SUNDEATH_COLOR);
-    antialiasingSamples = conf.value(KEY_NUMBER_OF_ANTI_ALIASING_SAMPLES, 0).toInt();
-    trilinearFiltering = conf.value(KEY_USE_TRILINEAR_FILTERING, true).toBool();
+    antialiasingSamples.set(conf.value(KEY_NUMBER_OF_ANTI_ALIASING_SAMPLES, 0).toInt());
+    trilinearFiltering.set(conf.value(KEY_USE_TRILINEAR_FILTERING, true).toBool());
     advanced.use3D.set(conf.value(KEY_3D_CANVAS, false).toBool());
     advanced.autoTilt.set(conf.value(KEY_3D_AUTO_TILT, true).toBool());
     advanced.printPerfStats.set(conf.value(KEY_3D_PERFSTATS, IS_DEBUG_BUILD).toBool());
@@ -815,8 +815,8 @@ void Configuration::CanvasSettings::write(QSettings &conf) const
     conf.setValue(KEY_ROOM_DARK_COLOR, getQColorName(roomDarkColor));
     conf.setValue(KEY_ROOM_DARK_LIT_COLOR, getQColorName(roomDarkLitColor));
     conf.setValue(KEY_CONNECTION_NORMAL_COLOR, getQColorName(connectionNormalColor));
-    conf.setValue(KEY_NUMBER_OF_ANTI_ALIASING_SAMPLES, antialiasingSamples);
-    conf.setValue(KEY_USE_TRILINEAR_FILTERING, trilinearFiltering);
+    conf.setValue(KEY_NUMBER_OF_ANTI_ALIASING_SAMPLES, antialiasingSamples.get());
+    conf.setValue(KEY_USE_TRILINEAR_FILTERING, trilinearFiltering.get());
     conf.setValue(KEY_3D_CANVAS, advanced.use3D.get());
     conf.setValue(KEY_3D_AUTO_TILT, advanced.autoTilt.get());
     conf.setValue(KEY_3D_PERFSTATS, advanced.printPerfStats.get());

--- a/src/configuration/configuration.h
+++ b/src/configuration/configuration.h
@@ -159,13 +159,13 @@ public:
 
     struct NODISCARD CanvasSettings final : public CanvasNamedColorOptions
     {
+        NamedConfig<int> antialiasingSamples{"ANTIALIASING_SAMPLES", 0};
+        NamedConfig<bool> trilinearFiltering{"TRILINEAR_FILTERING", true};
         NamedConfig<bool> showMissingMapId{"SHOW_MISSING_MAPID", false};
         NamedConfig<bool> showUnsavedChanges{"SHOW_UNSAVED_CHANGES", false};
         NamedConfig<bool> showUnmappedExits{"SHOW_UNMAPPED_EXITS", false};
         bool drawUpperLayersTextured = false;
         bool drawDoorNames = false;
-        int antialiasingSamples = 0;
-        bool trilinearFiltering = false;
         bool softwareOpenGL = false;
         QString resourcesDirectory;
 

--- a/src/display/Textures.cpp
+++ b/src/display/Textures.cpp
@@ -320,18 +320,12 @@ MapCanvasTexturesProxy getProxy(const MapCanvasTextures &mct)
 
 void MapCanvas::updateTextures()
 {
-    const bool wantTrilinear = getConfig().canvas.trilinearFiltering;
-    std::optional<bool> &activeStatus = m_graphicsOptionsStatus.trilinear;
-    if (activeStatus == wantTrilinear) {
-        return;
-    }
-
+    const bool wantTrilinear = getConfig().canvas.trilinearFiltering.get();
     m_textures.for_each([wantTrilinear](SharedMMTexture &tex) -> void {
         if (tex->canBeUpdated()) {
             ::setTrilinear(tex, wantTrilinear);
         }
     });
-    activeStatus = wantTrilinear;
 
     // called to trigger an early error
     std::ignore = mctp::getProxy(m_textures);

--- a/src/display/mapcanvas.cpp
+++ b/src/display/mapcanvas.cpp
@@ -264,7 +264,7 @@ void MapCanvas::wheelEvent(QWheelEvent *const event)
 
                     emit sig_mapMove(-delta2.x, -delta2.y);
 
-                    // NOTE: caller is expected to call resizeGL() after this function,
+                    // NOTE: caller is expected to call update() after this function,
                     // so we don't have to update the viewport.
                 }
 
@@ -276,7 +276,7 @@ void MapCanvas::wheelEvent(QWheelEvent *const event)
             if (numSteps != 0) {
                 zoomAndMaybeRecenter(numSteps);
                 zoomChanged();
-                resizeGL();
+                update();
             }
         }
         break;
@@ -325,7 +325,7 @@ bool MapCanvas::event(QEvent *const event)
             m_scaleFactor.endPinch();
             zoomChanged(); // might not have actually changed
         }
-        resizeGL();
+        update();
         return true;
     };
 
@@ -951,40 +951,40 @@ QSize MapCanvas::sizeHint() const
 void MapCanvas::slot_setScroll(const glm::vec2 &worldPos)
 {
     m_scroll = worldPos;
-    resizeGL();
+    update();
 }
 
 void MapCanvas::slot_setHorizontalScroll(const float worldX)
 {
     m_scroll.x = worldX;
-    resizeGL();
+    update();
 }
 
 void MapCanvas::slot_setVerticalScroll(const float worldY)
 {
     m_scroll.y = worldY;
-    resizeGL();
+    update();
 }
 
 void MapCanvas::slot_zoomIn()
 {
     m_scaleFactor.logStep(1);
     zoomChanged();
-    resizeGL();
+    update();
 }
 
 void MapCanvas::slot_zoomOut()
 {
     m_scaleFactor.logStep(-1);
     zoomChanged();
-    resizeGL();
+    update();
 }
 
 void MapCanvas::slot_zoomReset()
 {
     m_scaleFactor.set(1.f);
     zoomChanged();
-    resizeGL();
+    update();
 }
 
 void MapCanvas::onMovement()

--- a/src/display/mapcanvas.h
+++ b/src/display/mapcanvas.h
@@ -64,12 +64,6 @@ private:
         bool animating = false;
     };
 
-    struct NODISCARD OptionStatus final
-    {
-        std::optional<int> multisampling;
-        std::optional<bool> trilinear;
-    };
-
     struct NODISCARD Diff final
     {
         struct NODISCARD MaybeDataOrMesh final
@@ -147,7 +141,6 @@ private:
     MapCanvasTextures m_textures;
     MapData &m_data;
     Mmapper2Group &m_groupManager;
-    OptionStatus m_graphicsOptionsStatus;
     Diff m_diff;
     FrameRateController m_frameRateController;
     std::unique_ptr<QOpenGLDebugLogger> m_logger;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -118,7 +118,6 @@ static bool setSurfaceFormat()
     OpenGLConfig::setHighestReportableVersionString(probeResult.highestVersionString);
     OpenGLConfig::setBackendType(probeResult.backendType);
     OpenGLConfig::setIsCompat(probeResult.isCompat);
-    fmt.setSamples(getConfig().canvas.antialiasingSamples);
     QSurfaceFormat::setDefaultFormat(fmt);
     return true;
 }

--- a/src/opengl/OpenGL.cpp
+++ b/src/opengl/OpenGL.cpp
@@ -63,9 +63,24 @@ void OpenGL::setProjectionMatrix(const glm::mat4 &m)
     getFunctions().setProjectionMatrix(m);
 }
 
-bool OpenGL::tryEnableMultisampling(const int requestedSamples)
+void OpenGL::configureFbo(int samples)
 {
-    return getFunctions().tryEnableMultisampling(requestedSamples);
+    getFunctions().configureFbo(samples);
+}
+
+void OpenGL::bindFbo()
+{
+    getFunctions().bindFbo();
+}
+
+void OpenGL::releaseFbo()
+{
+    getFunctions().releaseFbo();
+}
+
+void OpenGL::blitFboToDefault()
+{
+    getFunctions().blitFboToDefault();
 }
 
 UniqueMesh OpenGL::createPointBatch(const std::vector<ColorVert> &batch)
@@ -209,6 +224,12 @@ void OpenGL::cleanup()
 void OpenGL::initializeRenderer(const float devicePixelRatio)
 {
     setDevicePixelRatio(devicePixelRatio);
+
+    // REVISIT: Move this somewhere else?
+    GLint maxSamples = 0;
+    getFunctions().glGetIntegerv(GL_MAX_SAMPLES, &maxSamples);
+    OpenGLConfig::setMaxSamples(maxSamples);
+
     m_rendererInitialized = true;
 }
 

--- a/src/opengl/OpenGL.h
+++ b/src/opengl/OpenGL.h
@@ -15,6 +15,7 @@
 #include <QSurfaceFormat>
 #include <qopengl.h>
 
+class FBO;
 class MapCanvas;
 namespace Legacy {
 class Functions;
@@ -57,7 +58,10 @@ public:
     void glViewport(GLint x, GLint y, GLsizei w, GLsizei h);
 
 public:
-    NODISCARD bool tryEnableMultisampling(int samples);
+    void configureFbo(int samples);
+    void bindFbo();
+    void releaseFbo();
+    void blitFboToDefault();
 
 public:
     NODISCARD UniqueMesh createPointBatch(const std::vector<ColorVert> &verts);
@@ -156,4 +160,7 @@ public:
 public:
     void cleanup();
     void setTextureLookup(MMTextureId, SharedMMTexture);
+
+public:
+    void initArray(const SharedMMTexture &array, const std::vector<SharedMMTexture> &input);
 };

--- a/src/opengl/OpenGLConfig.cpp
+++ b/src/opengl/OpenGLConfig.cpp
@@ -6,8 +6,9 @@
 namespace OpenGLConfig {
 
 static OpenGLProber::BackendType g_backendType;
-static bool g_isCompat;
+static bool g_isCompat = false;
 static std::string g_versionString;
+static int g_maxSamples = 0;
 
 NODISCARD OpenGLProber::BackendType getBackendType()
 {
@@ -37,6 +38,16 @@ NODISCARD std::string getHighestReportableVersionString()
 void setHighestReportableVersionString(const std::string &versionString)
 {
     g_versionString = versionString;
+}
+
+NODISCARD int getMaxSamples()
+{
+    return g_maxSamples;
+}
+
+void setMaxSamples(int maxSamples)
+{
+    g_maxSamples = maxSamples;
 }
 
 } // namespace OpenGLConfig

--- a/src/opengl/OpenGLConfig.h
+++ b/src/opengl/OpenGLConfig.h
@@ -17,4 +17,7 @@ extern void setIsCompat(bool isCompat);
 NODISCARD extern std::string getHighestReportableVersionString();
 extern void setHighestReportableVersionString(const std::string &versionString);
 
+NODISCARD extern int getMaxSamples();
+extern void setMaxSamples(int maxSamples);
+
 } // namespace OpenGLConfig

--- a/src/opengl/legacy/FBO.cpp
+++ b/src/opengl/legacy/FBO.cpp
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2023 The MMapper Authors
+
+#include "FBO.h"
+
+#include "../../global/logging.h"
+#include "../OpenGLConfig.h"
+
+namespace Legacy {
+
+bool LOG_FBO_ALLOCATIONS = true;
+
+void FBO::configure(const Viewport &physicalViewport, int requestedSamples)
+{
+    // Unconditionally release old FBOs to ensure a clean slate.
+    m_multisamplingFbo.reset();
+    m_resolvedFbo.reset();
+
+    const QSize physicalSize(physicalViewport.size.x, physicalViewport.size.y);
+    if (physicalSize.isEmpty()) {
+        if (LOG_FBO_ALLOCATIONS) {
+            MMLOG_INFO() << "FBOs destroyed (size empty)";
+        }
+        return;
+    }
+
+    // Always create the resolved FBO. This is our target for MSAA resolve
+    // and the primary render target if MSAA is disabled.
+    QOpenGLFramebufferObjectFormat resolvedFormat;
+    resolvedFormat.setAttachment(QOpenGLFramebufferObject::CombinedDepthStencil);
+    resolvedFormat.setSamples(0);
+    resolvedFormat.setTextureTarget(GL_TEXTURE_2D);
+    resolvedFormat.setInternalTextureFormat(GL_RGBA8);
+
+    m_resolvedFbo = std::make_unique<QOpenGLFramebufferObject>(physicalSize, resolvedFormat);
+    if (!m_resolvedFbo->isValid()) {
+        m_resolvedFbo.reset();
+        throw std::runtime_error("Failed to create resolved FBO");
+    }
+
+    // Only create the multisampling FBO if requested.
+    if (requestedSamples > 0) {
+        int actualSamples = std::min(requestedSamples, OpenGLConfig::getMaxSamples());
+
+        if (actualSamples > 0) {
+            QOpenGLFramebufferObjectFormat msFormat;
+            msFormat.setAttachment(QOpenGLFramebufferObject::CombinedDepthStencil);
+            msFormat.setSamples(actualSamples);
+            msFormat.setTextureTarget(GL_TEXTURE_2D_MULTISAMPLE);
+            msFormat.setInternalTextureFormat(GL_RGBA8);
+
+            m_multisamplingFbo = std::make_unique<QOpenGLFramebufferObject>(physicalSize, msFormat);
+            if (!m_multisamplingFbo->isValid()) {
+                if (LOG_FBO_ALLOCATIONS) {
+                    MMLOG_ERROR()
+                        << "Failed to create multisampling FBO. Falling back to no multisampling.";
+                }
+                m_multisamplingFbo.reset();
+            } else if (LOG_FBO_ALLOCATIONS) {
+                MMLOG_INFO() << "Created multisampling FBO with " << actualSamples << " samples.";
+            }
+        }
+    }
+}
+
+void FBO::bind()
+{
+    QOpenGLFramebufferObject *fboToBind = m_multisamplingFbo ? m_multisamplingFbo.get()
+                                                             : m_resolvedFbo.get();
+    if (fboToBind) {
+        fboToBind->bind();
+    }
+}
+
+void FBO::release()
+{
+    QOpenGLFramebufferObject *fboToRelease = m_multisamplingFbo ? m_multisamplingFbo.get()
+                                                                : m_resolvedFbo.get();
+    if (fboToRelease) {
+        fboToRelease->release();
+    }
+}
+
+void FBO::blitToDefault()
+{
+    if (!m_resolvedFbo) {
+        return; // Nothing to blit from
+    }
+
+    // If we have a valid multisampling FBO, resolve it to the resolved FBO first.
+    if (m_multisamplingFbo && m_multisamplingFbo->isValid()) {
+        QOpenGLFramebufferObject::blitFramebuffer(m_resolvedFbo.get(),
+                                                  m_multisamplingFbo.get(),
+                                                  GL_COLOR_BUFFER_BIT,
+                                                  GL_LINEAR);
+    }
+
+    // Now blit the (potentially resolved) FBO to the default framebuffer.
+    QOpenGLFramebufferObject::blitFramebuffer(nullptr,
+                                              m_resolvedFbo.get(),
+                                              GL_COLOR_BUFFER_BIT,
+                                              GL_NEAREST);
+}
+
+} // namespace Legacy

--- a/src/opengl/legacy/FBO.h
+++ b/src/opengl/legacy/FBO.h
@@ -1,0 +1,35 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2023 The MMapper Authors
+
+#include "../../global/RuleOf5.h"
+#include "../OpenGLTypes.h"
+
+#include <memory>
+
+#include <QOpenGLFramebufferObject>
+#include <QSize>
+
+namespace Legacy {
+
+extern bool LOG_FBO_ALLOCATIONS;
+
+class FBO final
+{
+public:
+    FBO() = default;
+    ~FBO() = default;
+    DELETE_CTORS_AND_ASSIGN_OPS(FBO);
+
+public:
+    void configure(const Viewport &physicalViewport, int samples);
+    void bind();
+    void release();
+    void blitToDefault();
+
+private:
+    std::unique_ptr<QOpenGLFramebufferObject> m_multisamplingFbo;
+    std::unique_ptr<QOpenGLFramebufferObject> m_resolvedFbo;
+};
+
+} // namespace Legacy

--- a/src/opengl/legacy/FunctionsES30.cpp
+++ b/src/opengl/legacy/FunctionsES30.cpp
@@ -41,9 +41,4 @@ void FunctionsES30::virt_enableProgramPointSize(bool /* enable */)
     // nop
 }
 
-bool FunctionsES30::virt_tryEnableMultisampling(int /* requestedSamples */)
-{
-    return false;
-}
-
 } // namespace Legacy

--- a/src/opengl/legacy/FunctionsES30.h
+++ b/src/opengl/legacy/FunctionsES30.h
@@ -16,7 +16,6 @@ public:
 
 private:
     void virt_enableProgramPointSize(bool enable) override;
-    NODISCARD bool virt_tryEnableMultisampling(int requestedSamples) override;
     NODISCARD const char *virt_getShaderVersion() const override;
     NODISCARD bool virt_canRenderQuads() override;
     NODISCARD std::optional<GLenum> virt_toGLenum(DrawModeEnum mode) override;

--- a/src/opengl/legacy/FunctionsGL33.cpp
+++ b/src/opengl/legacy/FunctionsGL33.cpp
@@ -51,45 +51,4 @@ void FunctionsGL33::virt_enableProgramPointSize(const bool enable)
 #endif
 }
 
-bool FunctionsGL33::virt_tryEnableMultisampling(const int requestedSamples)
-{
-#ifndef MMAPPER_NO_OPENGL
-    const auto getSampleBuffers = [this]() -> GLint {
-        GLint buffers;
-        Base::glGetIntegerv(GL_SAMPLE_BUFFERS, &buffers);
-        return buffers;
-    };
-
-    const auto getSamples = [this]() -> GLint {
-        GLint samples;
-        Base::glGetIntegerv(GL_SAMPLES, &samples);
-        return samples;
-    };
-
-    const bool hasMultisampling = getSampleBuffers() > 1 || getSamples() > 1;
-    if (hasMultisampling && requestedSamples > 0) {
-        Base::glEnable(GL_MULTISAMPLE);
-        Base::glEnable(GL_LINE_SMOOTH);
-        Base::glDisable(GL_POLYGON_SMOOTH);
-        Base::glHint(GL_LINE_SMOOTH_HINT, GL_NICEST);
-        return true;
-    } else {
-        // NOTE: Currently we can use OpenGL 2.1 to fake multisampling with point/line/polygon smoothing.
-        // TODO: We can use OpenGL 3.x FBOs to do multisampling even if the default framebuffer doesn't support it.
-        if (requestedSamples > 0) {
-            Base::glEnable(GL_LINE_SMOOTH);
-            Base::glDisable(GL_POLYGON_SMOOTH);
-            Base::glHint(GL_LINE_SMOOTH_HINT, GL_NICEST);
-            return true;
-        } else {
-            Base::glDisable(GL_LINE_SMOOTH);
-            Base::glDisable(GL_POLYGON_SMOOTH);
-            return false;
-        }
-    }
-#else
-    return false;
-#endif
-}
-
 } // namespace Legacy

--- a/src/opengl/legacy/FunctionsGL33.h
+++ b/src/opengl/legacy/FunctionsGL33.h
@@ -16,7 +16,6 @@ public:
 
 private:
     void virt_enableProgramPointSize(bool enable) override;
-    NODISCARD bool virt_tryEnableMultisampling(int requestedSamples) override;
     NODISCARD const char *virt_getShaderVersion() const override;
     NODISCARD bool virt_canRenderQuads() override;
     NODISCARD std::optional<GLenum> virt_toGLenum(DrawModeEnum mode) override;

--- a/src/opengl/legacy/Legacy.cpp
+++ b/src/opengl/legacy/Legacy.cpp
@@ -237,6 +237,7 @@ Functions::Functions(Badge<Functions>)
     : m_shaderPrograms{std::make_unique<ShaderPrograms>(*this)}
     , m_staticVbos{std::make_unique<StaticVbos>()}
     , m_texLookup{std::make_unique<TexLookup>()}
+    , m_fbo{std::make_unique<FBO>()}
 {}
 
 Functions::~Functions()
@@ -283,6 +284,10 @@ TexLookup &Functions::getTexLookup()
 {
     return deref(m_texLookup);
 }
+FBO &Functions::getFBO()
+{
+    return deref(m_fbo);
+}
 
 /// This only exists so we can detect errors in contexts that don't support \c glDebugMessageCallback().
 void Functions::checkError()
@@ -317,6 +322,26 @@ void Functions::checkError()
     }
 
 #undef CASE
+}
+
+void Functions::configureFbo(int samples)
+{
+    getFBO().configure(getPhysicalViewport(), samples);
+}
+
+void Functions::bindFbo()
+{
+    getFBO().bind();
+}
+
+void Functions::releaseFbo()
+{
+    getFBO().release();
+}
+
+void Functions::blitFboToDefault()
+{
+    getFBO().blitToDefault();
 }
 
 } // namespace Legacy

--- a/src/opengl/legacy/Legacy.h
+++ b/src/opengl/legacy/Legacy.h
@@ -7,6 +7,7 @@
 #include "../../global/utils.h"
 #include "../OpenGLConfig.h"
 #include "../OpenGLTypes.h"
+#include "FBO.h"
 
 #include <cmath>
 #include <memory>
@@ -100,6 +101,7 @@ private:
     std::unique_ptr<ShaderPrograms> m_shaderPrograms;
     std::unique_ptr<StaticVbos> m_staticVbos;
     std::unique_ptr<TexLookup> m_texLookup;
+    std::unique_ptr<FBO> m_fbo;
     std::vector<std::shared_ptr<IRenderable>> m_staticMeshes;
 
 protected:
@@ -239,18 +241,12 @@ public:
 
     NODISCARD TexLookup &getTexLookup();
 
+    NODISCARD FBO &getFBO();
+
 private:
     friend PointSizeBinder;
     /// platform-specific (ES vs GL)
     void enableProgramPointSize(bool enable) { virt_enableProgramPointSize(enable); }
-
-private:
-    friend OpenGL;
-    /// platform-specific (ES vs GL)
-    NODISCARD bool tryEnableMultisampling(int requestedSamples)
-    {
-        return virt_tryEnableMultisampling(requestedSamples);
-    }
 
 public:
     /// platform-specific (ES vs GL)
@@ -260,7 +256,6 @@ protected:
     NODISCARD virtual bool virt_canRenderQuads() = 0;
     NODISCARD virtual std::optional<GLenum> virt_toGLenum(DrawModeEnum mode) = 0;
     virtual void virt_enableProgramPointSize(bool enable) = 0;
-    NODISCARD virtual bool virt_tryEnableMultisampling(int requestedSamples) = 0;
     NODISCARD virtual const char *virt_getShaderVersion() const = 0;
 
 private:
@@ -356,5 +351,11 @@ public:
 
 public:
     void checkError();
+
+public:
+    void configureFbo(int samples);
+    void bindFbo();
+    void releaseFbo();
+    void blitFboToDefault();
 };
 } // namespace Legacy

--- a/src/preferences/graphicspage.h
+++ b/src/preferences/graphicspage.h
@@ -40,8 +40,6 @@ signals:
 
 public slots:
     void slot_loadConfig();
-    void slot_antialiasingSamplesTextChanged(const QString &);
-    void slot_trilinearFilteringStateChanged(int);
     void slot_drawNeedsUpdateStateChanged(int);
     void slot_drawNotMappedExitsStateChanged(int);
     void slot_drawDoorNamesStateChanged(int);


### PR DESCRIPTION
Uses two FBOs—one for multi-sampled color/depth and a second non-sampled FBO for resolving the final image—to implement robust and performant Multi-Sample Anti-Aliasing (MSAA).

## Summary by Sourcery

Implement framebuffer-based multisample anti-aliasing and wire it into the OpenGL rendering and configuration flow.

New Features:
- Add framebuffer object abstraction to support multisampled rendering with resolve to a non-multisampled target.
- Expose runtime configuration of MSAA sample count and trilinear filtering through reactive configuration bindings and UI.
- Query and store the OpenGL maximum supported sample count at renderer initialization to drive MSAA options.

Enhancements:
- Refactor rendering pipeline to render into an offscreen FBO and blit the result to the default framebuffer.
- Simplify graphics options state tracking by removing manual caching of multisampling and trilinear states and relying on configuration change callbacks.
- Adjust zoom and scroll handlers to trigger repaint via update() instead of forcing a resize-based repaint path.

Build:
- Register new FBO source files in the build system.