### PR TITLE
Add GMCP broadcast enhancements and clock synchronization

### DIFF
--- a/mudlet_clock_example.lua
+++ b/mudlet_clock_example.lua
@@ -1,0 +1,294 @@
+--[[
+    MMapper GMCP Clock Integration for Mudlet
+
+    This script receives clock data from MMapper via GMCP and can be used
+    as a foundation for day/night cycles, moon tracking, and other time-based
+    features in your Mudlet GUI.
+
+    Installation:
+    1. Save this file or copy its contents
+    2. In Mudlet, create a new Script
+    3. Paste this code into the script
+    4. Save and the script will auto-register
+
+    Usage:
+    The clock data will automatically update when MMapper sends it.
+    You can access the data via: mmapper.clock
+]]
+
+-- Initialize namespace
+mmapper = mmapper or {}
+mmapper.clock = mmapper.clock or {}
+
+-- Month name mappings (0-indexed)
+mmapper.clock.WESTRON_MONTHS = {
+    [0] = "Afteryule",
+    [1] = "Solmath",
+    [2] = "Rethe",
+    [3] = "Astron",
+    [4] = "Thrimidge",
+    [5] = "Forelithe",
+    [6] = "Afterlithe",
+    [7] = "Wedmath",
+    [8] = "Halimath",
+    [9] = "Winterfilth",
+    [10] = "Blotmath",
+    [11] = "Foreyule"
+}
+
+mmapper.clock.SINDARIN_MONTHS = {
+    [0] = "Narwain",
+    [1] = "Ninui",
+    [2] = "Gwaeron",
+    [3] = "Gwirith",
+    [4] = "Lothron",
+    [5] = "Norui",
+    [6] = "Cerveth",
+    [7] = "Urui",
+    [8] = "Ivanneth",
+    [9] = "Narbeleth",
+    [10] = "Hithui",
+    [11] = "Girithron"
+}
+
+-- Weekday names (0-indexed, 0 = Sunday)
+mmapper.clock.WESTRON_WEEKDAYS = {
+    [0] = "Sunday",
+    [1] = "Monday",
+    [2] = "Trewsday",
+    [3] = "Hevensday",
+    [4] = "Mersday",
+    [5] = "Highday",
+    [6] = "Sterday"
+}
+
+mmapper.clock.SINDARIN_WEEKDAYS = {
+    [0] = "Oranor",
+    [1] = "Orithil",
+    [2] = "Orgaladhad",
+    [3] = "Ormenel",
+    [4] = "Orbelain",
+    [5] = "Oraearon",
+    [6] = "Orgilion"
+}
+
+-- State variables
+mmapper.clock.data = nil
+mmapper.clock.lastUpdate = nil
+mmapper.clock.previousTimeOfDay = nil
+
+-- Helper function to calculate weekday
+function mmapper.clock.getWeekday(year, month, day)
+    -- MUME calendar: 360 days per year, 30 days per month
+    local totalDays = (year - 2850) * 360 + month * 30 + day
+    return totalDays % 7
+end
+
+-- Helper function to format time as string
+function mmapper.clock.formatTime(data, useWestron)
+    if not data then return "Unknown time" end
+
+    local monthNames = useWestron and mmapper.clock.WESTRON_MONTHS or mmapper.clock.SINDARIN_MONTHS
+    local weekdayNames = useWestron and mmapper.clock.WESTRON_WEEKDAYS or mmapper.clock.SINDARIN_WEEKDAYS
+
+    local weekday = mmapper.clock.getWeekday(data.year, data.month, data.day)
+    local monthName = monthNames[data.month] or "Unknown"
+    local weekdayName = weekdayNames[weekday] or "Unknown"
+
+    local hour = data.hour
+    local minute = data.minute
+    local ampm = "am"
+
+    if hour == 0 then
+        hour = 12
+    elseif hour == 12 then
+        ampm = "pm"
+    elseif hour > 12 then
+        hour = hour - 12
+        ampm = "pm"
+    end
+
+    return string.format("%d:%02d%s on %s, the %d%s of %s, year %d of the Third Age",
+        hour, minute, ampm,
+        weekdayName,
+        data.day + 1, -- Display as 1-30 instead of 0-29
+        mmapper.clock.getDaySuffix(data.day + 1),
+        monthName,
+        data.year
+    )
+end
+
+-- Helper for day suffix (1st, 2nd, 3rd, etc.)
+function mmapper.clock.getDaySuffix(day)
+    if day == 1 or day == 21 then return "st"
+    elseif day == 2 or day == 22 then return "nd"
+    elseif day == 3 or day == 23 then return "rd"
+    else return "th" end
+end
+
+-- Main GMCP handler
+function mmapper.clock.handleTimeInfo(event, ...)
+    -- Get the GMCP data
+    local data = gmcp.MUME and gmcp.MUME.Time and gmcp.MUME.Time.Info
+
+    if not data then
+        cecho("\n<red>Error: MUME.Time.Info data not found in GMCP\n")
+        return
+    end
+
+    -- Store the data
+    mmapper.clock.data = data
+    mmapper.clock.lastUpdate = os.time()
+
+    -- Detect time of day transitions
+    if mmapper.clock.previousTimeOfDay and mmapper.clock.previousTimeOfDay ~= data.timeOfDay then
+        mmapper.clock.onTimeOfDayChange(data.timeOfDay)
+    end
+    mmapper.clock.previousTimeOfDay = data.timeOfDay
+
+    -- Raise custom events that your scripts can listen for
+    raiseEvent("MMapperClockUpdate", data)
+
+    -- Optional: Debug output (comment out if you don't want it)
+    -- mmapper.clock.debug(data)
+end
+
+-- Called when time of day changes (dawn, day, dusk, night)
+function mmapper.clock.onTimeOfDayChange(newTimeOfDay)
+    -- You can customize these messages or add actions
+    if newTimeOfDay == "dawn" then
+        cecho("\n<yellow>The sun rises in the east, casting long shadows across the land.\n")
+        -- Example: Update your GUI, change colors, etc.
+
+    elseif newTimeOfDay == "day" then
+        cecho("\n<white>The sun climbs higher into the sky.\n")
+
+    elseif newTimeOfDay == "dusk" then
+        cecho("\n<orange>The sun sets in the west, painting the sky in shades of orange and red.\n")
+
+    elseif newTimeOfDay == "night" then
+        cecho("\n<blue>Darkness falls as the sun disappears below the horizon.\n")
+    end
+
+    -- Raise event for other scripts
+    raiseEvent("MMapperTimeOfDayChanged", newTimeOfDay)
+end
+
+-- Debug output function
+function mmapper.clock.debug(data)
+    local output = {
+        "\n<cyan>===== MMapper Clock Update =====",
+        string.format("<white>Time: <yellow>%s", mmapper.clock.formatTime(data, true)),
+        string.format("<white>Season: <green>%s", data.season or "unknown"),
+        string.format("<white>Time of Day: <orange>%s", data.timeOfDay or "unknown"),
+        string.format("<white>Moon Phase: <magenta>%s <white>(<yellow>%d<white>/12 illumination)",
+            data.moonPhase or "unknown", data.moonLevel or 0),
+        string.format("<white>Moon Visibility: <cyan>%s", data.moonVisibility or "unknown"),
+        string.format("<white>Dawn: <yellow>%d:00<white>, Dusk: <orange>%d:00",
+            data.dawnHour or 0, data.duskHour or 0),
+        string.format("<white>Precision: <green>%s", data.precision or "unknown"),
+        "<cyan>==============================="
+    }
+
+    for _, line in ipairs(output) do
+        cecho(line .. "\n")
+    end
+end
+
+-- Command to display current time
+function mmapper.clock.showTime()
+    if not mmapper.clock.data then
+        cecho("\n<red>No clock data available yet. Make sure MMapper is connected and GMCP is enabled.\n")
+        return
+    end
+
+    local data = mmapper.clock.data
+
+    cecho("\n<cyan>╔══════════════════════════════════════════════╗\n")
+    cecho("<cyan>║ <white>           MUME Time & Weather           <cyan>║\n")
+    cecho("<cyan>╠══════════════════════════════════════════════╣\n")
+    cecho(string.format("<cyan>║ <white>Time:   <yellow>%-33s<cyan>║\n",
+        mmapper.clock.formatTime(data, true)))
+    cecho(string.format("<cyan>║ <white>Season: <green>%-33s<cyan>║\n",
+        data.season or "unknown"))
+    cecho(string.format("<cyan>║ <white>Period: <orange>%-33s<cyan>║\n",
+        data.timeOfDay or "unknown"))
+    cecho("<cyan>╠══════════════════════════════════════════════╣\n")
+    cecho(string.format("<cyan>║ <white>Moon:   <magenta>%-33s<cyan>║\n",
+        data.moonPhase or "unknown"))
+    cecho(string.format("<cyan>║ <white>Light:  <yellow>%d/12 <white>%-26s<cyan>║\n",
+        data.moonLevel or 0, "(" .. (data.moonVisibility or "unknown") .. ")"))
+    cecho("<cyan>╠══════════════════════════════════════════════╣\n")
+    cecho(string.format("<cyan>║ <white>Dawn at <yellow>%02d:00<white>, Dusk at <orange>%02d:00          <cyan>║\n",
+        data.dawnHour or 0, data.duskHour or 0))
+    cecho("<cyan>╚══════════════════════════════════════════════╝\n")
+end
+
+-- Enable GMCP module (run once on profile load)
+function mmapper.clock.enableGMCP()
+    if not gmod then
+        cecho("\n<red>Error: gmod not available. Make sure GMCP is enabled in Mudlet.\n")
+        return false
+    end
+
+    gmod.enableModule("Client", "MUME.Time 1")
+    cecho("\n<green>MMapper GMCP Clock module enabled!\n")
+    cecho("<white>Type '<yellow>mmtime<white>' to see the current time.\n")
+    return true
+end
+
+-- Register the event handler
+if mmapper.clock.eventHandler then
+    killAnonymousEventHandler(mmapper.clock.eventHandler)
+end
+mmapper.clock.eventHandler = registerAnonymousEventHandler("gmcp.MUME.Time.Info", "mmapper.clock.handleTimeInfo")
+
+-- Create alias to show time
+if mmapper.clock.timeAlias then
+    killAlias(mmapper.clock.timeAlias)
+end
+mmapper.clock.timeAlias = tempAlias("^mmtime$", [[mmapper.clock.showTime()]])
+
+-- Enable GMCP support
+tempTimer(1, function() mmapper.clock.enableGMCP() end)
+
+-- Notify user
+cecho("\n<green>MMapper Clock Integration loaded successfully!\n")
+cecho("<white>Waiting for clock data from MMapper...\n")
+cecho("<white>Type '<yellow>mmtime<white>' to display the current time once data is received.\n")
+
+--[[
+    INTEGRATION WITH YOUR IMP GUI:
+
+    To integrate with your existing day/night script, you can:
+
+    1. Listen for the MMapperClockUpdate event:
+       registerAnonymousEventHandler("MMapperClockUpdate", "yourFunctionName")
+
+    2. Access clock data anytime via:
+       mmapper.clock.data.timeOfDay  -- "dawn", "day", "dusk", or "night"
+       mmapper.clock.data.season     -- "winter", "spring", "summer", "autumn"
+       mmapper.clock.data.moonPhase  -- Moon phase name
+       mmapper.clock.data.moonLevel  -- Moon illumination (0-12)
+
+    3. Listen for time of day changes:
+       registerAnonymousEventHandler("MMapperTimeOfDayChanged", "yourTransitionHandler")
+
+    4. Example integration:
+
+       function updateDayNightCycle()
+           if not mmapper.clock.data then return end
+
+           local tod = mmapper.clock.data.timeOfDay
+
+           if tod == "night" then
+               -- Apply night theme
+               setYourGUITheme("dark")
+           else
+               -- Apply day theme
+               setYourGUITheme("light")
+           end
+       end
+
+       registerAnonymousEventHandler("MMapperClockUpdate", "updateDayNightCycle")
+]]

--- a/src/clock/mumeclock.cpp
+++ b/src/clock/mumeclock.cpp
@@ -221,6 +221,13 @@ void MumeClock::parseMumeTime(const QString &mumeTime, const int64_t secsSinceEp
         qWarning() << "Calculated week day does not match MUME";
     }
     m_mumeStartEpoch = newStartEpoch;
+
+    // Check if season changed and emit signal
+    const auto currentSeason = capturedMoment.toSeason();
+    if (currentSeason != m_lastSeasonEmitted && currentSeason != MumeSeasonEnum::UNKNOWN) {
+        m_lastSeasonEmitted = currentSeason;
+        emit sig_seasonChanged(currentSeason);
+    }
 }
 
 void MumeClock::onUserGmcp(const GmcpMessage &msg)
@@ -319,6 +326,13 @@ void MumeClock::parseWeather(const MumeTimeEnum time, int64_t secsSinceEpoch)
     if (time != MumeTimeEnum::UNKNOWN || m_precision >= MumeClockPrecisionEnum::HOUR) {
         m_precision = MumeClockPrecisionEnum::MINUTE;
     }
+
+    // Check if season changed and emit signal
+    const auto currentSeason = moment.toSeason();
+    if (currentSeason != m_lastSeasonEmitted && currentSeason != MumeSeasonEnum::UNKNOWN) {
+        m_lastSeasonEmitted = currentSeason;
+        emit sig_seasonChanged(currentSeason);
+    }
 }
 
 void MumeClock::parseClockTime(const QString &clockTime)
@@ -357,6 +371,13 @@ void MumeClock::parseClockTime(const QString &clockTime, const int64_t secsSince
     log("Synchronized with clock in room (" + QString::number(newStartEpoch - m_mumeStartEpoch)
         + " seconds from previous)");
     m_mumeStartEpoch = newStartEpoch;
+
+    // Check if season changed and emit signal
+    const auto currentSeason = moment.toSeason();
+    if (currentSeason != m_lastSeasonEmitted && currentSeason != MumeSeasonEnum::UNKNOWN) {
+        m_lastSeasonEmitted = currentSeason;
+        emit sig_seasonChanged(currentSeason);
+    }
 }
 
 void MumeClock::parseMSSP(const MsspTime &msspTime)

--- a/src/clock/mumeclock.h
+++ b/src/clock/mumeclock.h
@@ -159,9 +159,11 @@ protected:
 
 private:
     void onUserGmcp(const GmcpMessage &msg);
+    MumeSeasonEnum m_lastSeasonEmitted = MumeSeasonEnum::UNKNOWN;
 
 signals:
     void sig_log(const QString &, const QString &);
+    void sig_seasonChanged(MumeSeasonEnum newSeason);
 
 public slots:
     void parseMumeTime(const QString &mumeTime);

--- a/src/configuration/configuration.cpp
+++ b/src/configuration/configuration.cpp
@@ -7,6 +7,7 @@
 #include "configuration.h"
 
 #include "../global/utils.h"
+#include "../map/infomark.h"
 
 #include <cassert>
 #include <mutex>
@@ -50,6 +51,25 @@ NODISCARD const char *getPlatformEditor()
     default:
         return "";
     }
+}
+
+NODISCARD TextureSetEnum intToTextureSet(int value)
+{
+    switch (value) {
+    case 0:
+        return TextureSetEnum::CLASSIC;
+    case 1:
+        return TextureSetEnum::MODERN;
+    case 2:
+        return TextureSetEnum::CUSTOM;
+    default:
+        return TextureSetEnum::MODERN; // Default to Modern
+    }
+}
+
+NODISCARD int textureSetToInt(TextureSetEnum value)
+{
+    return static_cast<int>(value);
 }
 
 } // namespace
@@ -194,10 +214,12 @@ ConstString GRP_ACCOUNT = "Account";
 ConstString GRP_AUTO_LOAD_WORLD = "Auto load world";
 ConstString GRP_AUTO_LOG = "Auto log";
 ConstString GRP_CANVAS = "Canvas";
+ConstString GRP_COMMS = "Communications";
 ConstString GRP_CONNECTION = "Connection";
 ConstString GRP_FINDROOMS_DIALOG = "FindRooms Dialog";
 ConstString GRP_GENERAL = "General";
 ConstString GRP_GROUP_MANAGER = "Group Manager";
+ConstString GRP_HOTKEYS = "Hotkeys";
 ConstString GRP_INFOMARKS_DIALOG = "InfoMarks Dialog";
 ConstString GRP_INTEGRATED_MUD_CLIENT = "Integrated Mud Client";
 ConstString GRP_MUME_CLIENT_PROTOCOL = "Mume client protocol";
@@ -227,9 +249,12 @@ ConstString KEY_CONNECTION_NORMAL_COLOR = "Connection normal color";
 ConstString KEY_CORRECT_POSITION_BONUS = "correct position bonus";
 ConstString KEY_DISPLAY_XP_STATUS = "Display XP status bar widget";
 ConstString KEY_DISPLAY_CLOCK = "Display clock";
+ConstString KEY_GMCP_BROADCAST_CLOCK = "GMCP broadcast clock";
+ConstString KEY_GMCP_BROADCAST_INTERVAL = "GMCP broadcast interval";
 ConstString KEY_DRAW_DOOR_NAMES = "Draw door names";
 ConstString KEY_DRAW_NOT_MAPPED_EXITS = "Draw not mapped exits";
 ConstString KEY_DRAW_UPPER_LAYERS_TEXTURED = "Draw upper layers textured";
+ConstString KEY_LAYER_TRANSPARENCY = "Layer transparency";
 ConstString KEY_EMOJI_ENCODE = "encode emoji";
 ConstString KEY_EMOJI_DECODE = "decode emoji";
 ConstString KEY_EMULATED_EXITS = "Emulated Exits";
@@ -256,6 +281,73 @@ ConstString KEY_3D_FOV = "canvas.advanced.fov";
 ConstString KEY_3D_VERTICAL_ANGLE = "canvas.advanced.verticalAngle";
 ConstString KEY_3D_HORIZONTAL_ANGLE = "canvas.advanced.horizontalAngle";
 ConstString KEY_3D_LAYER_HEIGHT = "canvas.advanced.layerHeight";
+ConstString KEY_BACKGROUND_IMAGE_ENABLED = "canvas.advanced.backgroundImageEnabled";
+ConstString KEY_BACKGROUND_IMAGE_PATH = "canvas.advanced.backgroundImagePath";
+ConstString KEY_BACKGROUND_IMAGE_FIT_MODE = "canvas.advanced.backgroundFitMode";
+ConstString KEY_BACKGROUND_IMAGE_OPACITY = "canvas.advanced.backgroundOpacity";
+ConstString KEY_BACKGROUND_IMAGE_FOCUSED_SCALE = "canvas.advanced.backgroundFocusedScale";
+ConstString KEY_BACKGROUND_IMAGE_FOCUSED_OFFSET_X = "canvas.advanced.backgroundFocusedOffsetX";
+ConstString KEY_BACKGROUND_IMAGE_FOCUSED_OFFSET_Y = "canvas.advanced.backgroundFocusedOffsetY";
+ConstString KEY_VISIBLE_MARKER_GENERIC = "canvas.visibleMarkers.generic";
+ConstString KEY_VISIBLE_MARKER_HERB = "canvas.visibleMarkers.herb";
+ConstString KEY_VISIBLE_MARKER_RIVER = "canvas.visibleMarkers.river";
+ConstString KEY_VISIBLE_MARKER_PLACE = "canvas.visibleMarkers.place";
+ConstString KEY_VISIBLE_MARKER_MOB = "canvas.visibleMarkers.mob";
+ConstString KEY_VISIBLE_MARKER_COMMENT = "canvas.visibleMarkers.comment";
+ConstString KEY_VISIBLE_MARKER_ROAD = "canvas.visibleMarkers.road";
+ConstString KEY_VISIBLE_MARKER_OBJECT = "canvas.visibleMarkers.object";
+ConstString KEY_VISIBLE_MARKER_ACTION = "canvas.visibleMarkers.action";
+ConstString KEY_VISIBLE_MARKER_LOCALITY = "canvas.visibleMarkers.locality";
+ConstString KEY_VISIBLE_CONNECTIONS = "canvas.visibilityFilter.connections";
+
+// Hotkey configuration keys
+ConstString KEY_HOTKEY_FILE_OPEN = "hotkeys.fileOpen";
+ConstString KEY_HOTKEY_FILE_SAVE = "hotkeys.fileSave";
+ConstString KEY_HOTKEY_FILE_RELOAD = "hotkeys.fileReload";
+ConstString KEY_HOTKEY_FILE_QUIT = "hotkeys.fileQuit";
+ConstString KEY_HOTKEY_EDIT_UNDO = "hotkeys.editUndo";
+ConstString KEY_HOTKEY_EDIT_REDO = "hotkeys.editRedo";
+ConstString KEY_HOTKEY_EDIT_PREFERENCES = "hotkeys.editPreferences";
+ConstString KEY_HOTKEY_EDIT_PREFERENCES_ALT = "hotkeys.editPreferencesAlt";
+ConstString KEY_HOTKEY_EDIT_FIND_ROOMS = "hotkeys.editFindRooms";
+ConstString KEY_HOTKEY_EDIT_ROOM = "hotkeys.editRoom";
+ConstString KEY_HOTKEY_VIEW_ZOOM_IN = "hotkeys.viewZoomIn";
+ConstString KEY_HOTKEY_VIEW_ZOOM_OUT = "hotkeys.viewZoomOut";
+ConstString KEY_HOTKEY_VIEW_ZOOM_RESET = "hotkeys.viewZoomReset";
+ConstString KEY_HOTKEY_VIEW_LAYER_UP = "hotkeys.viewLayerUp";
+ConstString KEY_HOTKEY_VIEW_LAYER_DOWN = "hotkeys.viewLayerDown";
+ConstString KEY_HOTKEY_VIEW_LAYER_RESET = "hotkeys.viewLayerReset";
+ConstString KEY_HOTKEY_VIEW_RADIAL_TRANSPARENCY = "hotkeys.viewRadialTransparency";
+ConstString KEY_HOTKEY_VIEW_STATUS_BAR = "hotkeys.viewStatusBar";
+ConstString KEY_HOTKEY_VIEW_SCROLL_BARS = "hotkeys.viewScrollBars";
+ConstString KEY_HOTKEY_VIEW_MENU_BAR = "hotkeys.viewMenuBar";
+ConstString KEY_HOTKEY_VIEW_ALWAYS_ON_TOP = "hotkeys.viewAlwaysOnTop";
+ConstString KEY_HOTKEY_PANEL_LOG = "hotkeys.panelLog";
+ConstString KEY_HOTKEY_PANEL_CLIENT = "hotkeys.panelClient";
+ConstString KEY_HOTKEY_PANEL_GROUP = "hotkeys.panelGroup";
+ConstString KEY_HOTKEY_PANEL_ROOM = "hotkeys.panelRoom";
+ConstString KEY_HOTKEY_PANEL_ADVENTURE = "hotkeys.panelAdventure";
+ConstString KEY_HOTKEY_PANEL_COMMS = "hotkeys.panelComms";
+ConstString KEY_HOTKEY_PANEL_DESCRIPTION = "hotkeys.panelDescription";
+ConstString KEY_HOTKEY_MODE_MOVE_MAP = "hotkeys.modeMoveMap";
+ConstString KEY_HOTKEY_MODE_RAYPICK = "hotkeys.modeRaypick";
+ConstString KEY_HOTKEY_MODE_SELECT_ROOMS = "hotkeys.modeSelectRooms";
+ConstString KEY_HOTKEY_MODE_SELECT_MARKERS = "hotkeys.modeSelectMarkers";
+ConstString KEY_HOTKEY_MODE_SELECT_CONNECTION = "hotkeys.modeSelectConnection";
+ConstString KEY_HOTKEY_MODE_CREATE_MARKER = "hotkeys.modeCreateMarker";
+ConstString KEY_HOTKEY_MODE_CREATE_ROOM = "hotkeys.modeCreateRoom";
+ConstString KEY_HOTKEY_MODE_CREATE_CONNECTION = "hotkeys.modeCreateConnection";
+ConstString KEY_HOTKEY_MODE_CREATE_ONEWAY_CONNECTION = "hotkeys.modeCreateOnewayConnection";
+ConstString KEY_HOTKEY_ROOM_CREATE = "hotkeys.roomCreate";
+ConstString KEY_HOTKEY_ROOM_MOVE_UP = "hotkeys.roomMoveUp";
+ConstString KEY_HOTKEY_ROOM_MOVE_DOWN = "hotkeys.roomMoveDown";
+ConstString KEY_HOTKEY_ROOM_MERGE_UP = "hotkeys.roomMergeUp";
+ConstString KEY_HOTKEY_ROOM_MERGE_DOWN = "hotkeys.roomMergeDown";
+ConstString KEY_HOTKEY_ROOM_DELETE = "hotkeys.roomDelete";
+ConstString KEY_HOTKEY_ROOM_CONNECT_NEIGHBORS = "hotkeys.roomConnectNeighbors";
+ConstString KEY_HOTKEY_ROOM_MOVE_TO_SELECTED = "hotkeys.roomMoveToSelected";
+ConstString KEY_HOTKEY_ROOM_UPDATE_SELECTED = "hotkeys.roomUpdateSelected";
+
 ConstString KEY_LAST_MAP_LOAD_DIRECTORY = "Last map load directory";
 ConstString KEY_LINES_OF_INPUT_HISTORY = "Lines of input history";
 ConstString KEY_LINES_OF_PEEK_PREVIEW = "Lines of peek preview";
@@ -270,6 +362,8 @@ ConstString KEY_PROXY_CONNECTION_STATUS = "Proxy connection status";
 ConstString KEY_PROXY_LISTENS_ON_ANY_INTERFACE = "Proxy listens on any interface";
 ConstString KEY_RELATIVE_PATH_ACCEPTANCE = "relative path acceptance";
 ConstString KEY_RESOURCES_DIRECTORY = "canvas.resourcesDir";
+ConstString KEY_TEXTURE_SET = "canvas.textureSet";
+ConstString KEY_ENABLE_SEASONAL_TEXTURES = "canvas.enableSeasonalTextures";
 ConstString KEY_MUME_REMOTE_PORT = "Remote port number";
 ConstString KEY_REMEMBER_LOGIN = "remember login";
 ConstString KEY_ROOM_CREATION_PENALTY = "room creation penalty";
@@ -441,6 +535,8 @@ NODISCARD static uint16_t sanitizeUint16(const int input, const uint16_t default
         GROUP_CALLBACK(callback, GRP_GENERAL, general); \
         GROUP_CALLBACK(callback, GRP_CONNECTION, connection); \
         GROUP_CALLBACK(callback, GRP_CANVAS, canvas); \
+        GROUP_CALLBACK(callback, GRP_HOTKEYS, hotkeys); \
+        GROUP_CALLBACK(callback, GRP_COMMS, comms); \
         GROUP_CALLBACK(callback, GRP_ACCOUNT, account); \
         GROUP_CALLBACK(callback, GRP_AUTO_LOAD_WORLD, autoLoad); \
         GROUP_CALLBACK(callback, GRP_AUTO_LOG, autoLog); \
@@ -565,7 +661,7 @@ void Configuration::ConnectionSettings::read(const QSettings &conf)
 }
 
 // closest well-known color is "Outer Space"
-static constexpr const std::string_view DEFAULT_BGCOLOR = "#2E3436";
+static constexpr const std::string_view DEFAULT_BGCOLOR = "#161f21";
 // closest well-known color is "Dusty Gray"
 static constexpr const std::string_view DEFAULT_DARK_COLOR = "#A19494";
 // closest well-known color is "Cold Turkey"
@@ -587,11 +683,14 @@ void Configuration::CanvasSettings::read(const QSettings &conf)
                                         .append(DEFAULT_MMAPPER_SUBDIR)
                                         .append(DEFAULT_RESOURCES_SUBDIR))
                              .toString();
+    textureSet = intToTextureSet(conf.value(KEY_TEXTURE_SET, 1).toInt()); // Default: MODERN
+    enableSeasonalTextures = conf.value(KEY_ENABLE_SEASONAL_TEXTURES, true).toBool();
     showMissingMapId.set(conf.value(KEY_SHOW_MISSING_MAP_ID, true).toBool());
     showUnsavedChanges.set(conf.value(KEY_SHOW_UNSAVED_CHANGES, true).toBool());
     showUnmappedExits.set(conf.value(KEY_DRAW_NOT_MAPPED_EXITS, true).toBool());
     drawUpperLayersTextured = conf.value(KEY_DRAW_UPPER_LAYERS_TEXTURED, false).toBool();
     drawDoorNames = conf.value(KEY_DRAW_DOOR_NAMES, true).toBool();
+    layerTransparency = conf.value(KEY_LAYER_TRANSPARENCY, 1.0).toFloat();
     backgroundColor = lookupColor(KEY_BACKGROUND_COLOR, DEFAULT_BGCOLOR);
     connectionNormalColor = lookupColor(KEY_CONNECTION_NORMAL_COLOR, Colors::white.toHex());
     roomDarkColor = lookupColor(KEY_ROOM_DARK_COLOR, DEFAULT_DARK_COLOR);
@@ -605,6 +704,30 @@ void Configuration::CanvasSettings::read(const QSettings &conf)
     advanced.verticalAngle.set(conf.value(KEY_3D_VERTICAL_ANGLE, 450).toInt());
     advanced.horizontalAngle.set(conf.value(KEY_3D_HORIZONTAL_ANGLE, 0).toInt());
     advanced.layerHeight.set(conf.value(KEY_3D_LAYER_HEIGHT, 15).toInt());
+
+    // Load background image settings
+    advanced.useBackgroundImage = conf.value(KEY_BACKGROUND_IMAGE_ENABLED, false).toBool();
+    advanced.backgroundImagePath = conf.value(KEY_BACKGROUND_IMAGE_PATH, "").toString();
+    advanced.backgroundFitMode = conf.value(KEY_BACKGROUND_IMAGE_FIT_MODE, 0).toInt();
+    advanced.backgroundOpacity = conf.value(KEY_BACKGROUND_IMAGE_OPACITY, 1.0f).toFloat();
+    advanced.backgroundFocusedScale = conf.value(KEY_BACKGROUND_IMAGE_FOCUSED_SCALE, 1.0f).toFloat();
+    advanced.backgroundFocusedOffsetX = conf.value(KEY_BACKGROUND_IMAGE_FOCUSED_OFFSET_X, 0.0f)
+                                            .toFloat();
+    advanced.backgroundFocusedOffsetY = conf.value(KEY_BACKGROUND_IMAGE_FOCUSED_OFFSET_Y, 0.0f)
+                                            .toFloat();
+
+    // Load visible markers settings
+    visibilityFilter.generic.set(conf.value(KEY_VISIBLE_MARKER_GENERIC, true).toBool());
+    visibilityFilter.herb.set(conf.value(KEY_VISIBLE_MARKER_HERB, true).toBool());
+    visibilityFilter.river.set(conf.value(KEY_VISIBLE_MARKER_RIVER, true).toBool());
+    visibilityFilter.place.set(conf.value(KEY_VISIBLE_MARKER_PLACE, true).toBool());
+    visibilityFilter.mob.set(conf.value(KEY_VISIBLE_MARKER_MOB, true).toBool());
+    visibilityFilter.comment.set(conf.value(KEY_VISIBLE_MARKER_COMMENT, true).toBool());
+    visibilityFilter.road.set(conf.value(KEY_VISIBLE_MARKER_ROAD, true).toBool());
+    visibilityFilter.object.set(conf.value(KEY_VISIBLE_MARKER_OBJECT, true).toBool());
+    visibilityFilter.action.set(conf.value(KEY_VISIBLE_MARKER_ACTION, true).toBool());
+    visibilityFilter.locality.set(conf.value(KEY_VISIBLE_MARKER_LOCALITY, true).toBool());
+    visibilityFilter.connections.set(conf.value(KEY_VISIBLE_CONNECTIONS, true).toBool());
 }
 
 void Configuration::AccountSettings::read(const QSettings &conf)
@@ -691,11 +814,15 @@ void Configuration::GroupManagerSettings::read(const QSettings &conf)
     npcSortBottom = conf.value(KEY_GROUP_NPC_SORT_BOTTOM, false).toBool();
 }
 
+Configuration::MumeClockSettings::MumeClockSettings() = default;
+
 void Configuration::MumeClockSettings::read(const QSettings &conf)
 {
     // NOTE: old values might be stored as int32
     startEpoch = conf.value(KEY_MUME_START_EPOCH, 1517443173).toLongLong();
     display = conf.value(KEY_DISPLAY_CLOCK, true).toBool();
+    gmcpBroadcast.set(conf.value(KEY_GMCP_BROADCAST_CLOCK, true).toBool());
+    gmcpBroadcastInterval.set(conf.value(KEY_GMCP_BROADCAST_INTERVAL, 2500).toInt());
 }
 
 void Configuration::AdventurePanelSettings::read(const QSettings &conf)
@@ -770,11 +897,14 @@ NODISCARD static auto getQColorName(const XNamedColor &color)
 void Configuration::CanvasSettings::write(QSettings &conf) const
 {
     conf.setValue(KEY_RESOURCES_DIRECTORY, resourcesDirectory);
+    conf.setValue(KEY_TEXTURE_SET, textureSetToInt(textureSet));
+    conf.setValue(KEY_ENABLE_SEASONAL_TEXTURES, enableSeasonalTextures);
     conf.setValue(KEY_SHOW_MISSING_MAP_ID, showMissingMapId.get());
     conf.setValue(KEY_SHOW_UNSAVED_CHANGES, showUnsavedChanges.get());
     conf.setValue(KEY_DRAW_NOT_MAPPED_EXITS, showUnmappedExits.get());
     conf.setValue(KEY_DRAW_UPPER_LAYERS_TEXTURED, drawUpperLayersTextured);
     conf.setValue(KEY_DRAW_DOOR_NAMES, drawDoorNames);
+    conf.setValue(KEY_LAYER_TRANSPARENCY, layerTransparency);
     conf.setValue(KEY_BACKGROUND_COLOR, getQColorName(backgroundColor));
     conf.setValue(KEY_ROOM_DARK_COLOR, getQColorName(roomDarkColor));
     conf.setValue(KEY_ROOM_DARK_LIT_COLOR, getQColorName(roomDarkLitColor));
@@ -788,6 +918,239 @@ void Configuration::CanvasSettings::write(QSettings &conf) const
     conf.setValue(KEY_3D_VERTICAL_ANGLE, advanced.verticalAngle.get());
     conf.setValue(KEY_3D_HORIZONTAL_ANGLE, advanced.horizontalAngle.get());
     conf.setValue(KEY_3D_LAYER_HEIGHT, advanced.layerHeight.get());
+
+    // Save background image settings
+    conf.setValue(KEY_BACKGROUND_IMAGE_ENABLED, advanced.useBackgroundImage);
+    conf.setValue(KEY_BACKGROUND_IMAGE_PATH, advanced.backgroundImagePath);
+    conf.setValue(KEY_BACKGROUND_IMAGE_FIT_MODE, advanced.backgroundFitMode);
+    conf.setValue(KEY_BACKGROUND_IMAGE_OPACITY, advanced.backgroundOpacity);
+    conf.setValue(KEY_BACKGROUND_IMAGE_FOCUSED_SCALE, advanced.backgroundFocusedScale);
+    conf.setValue(KEY_BACKGROUND_IMAGE_FOCUSED_OFFSET_X, advanced.backgroundFocusedOffsetX);
+    conf.setValue(KEY_BACKGROUND_IMAGE_FOCUSED_OFFSET_Y, advanced.backgroundFocusedOffsetY);
+
+    // Save visible markers settings
+    conf.setValue(KEY_VISIBLE_MARKER_GENERIC, visibilityFilter.generic.get());
+    conf.setValue(KEY_VISIBLE_MARKER_HERB, visibilityFilter.herb.get());
+    conf.setValue(KEY_VISIBLE_MARKER_RIVER, visibilityFilter.river.get());
+    conf.setValue(KEY_VISIBLE_MARKER_PLACE, visibilityFilter.place.get());
+    conf.setValue(KEY_VISIBLE_MARKER_MOB, visibilityFilter.mob.get());
+    conf.setValue(KEY_VISIBLE_MARKER_COMMENT, visibilityFilter.comment.get());
+    conf.setValue(KEY_VISIBLE_MARKER_ROAD, visibilityFilter.road.get());
+    conf.setValue(KEY_VISIBLE_MARKER_OBJECT, visibilityFilter.object.get());
+    conf.setValue(KEY_VISIBLE_MARKER_ACTION, visibilityFilter.action.get());
+    conf.setValue(KEY_VISIBLE_MARKER_LOCALITY, visibilityFilter.locality.get());
+    conf.setValue(KEY_VISIBLE_CONNECTIONS, visibilityFilter.connections.get());
+}
+
+void Configuration::Hotkeys::read(const QSettings &conf)
+{
+    // File operations
+    fileOpen.set(conf.value(KEY_HOTKEY_FILE_OPEN, "Ctrl+O").toString());
+    fileSave.set(conf.value(KEY_HOTKEY_FILE_SAVE, "Ctrl+S").toString());
+    fileReload.set(conf.value(KEY_HOTKEY_FILE_RELOAD, "Ctrl+R").toString());
+    fileQuit.set(conf.value(KEY_HOTKEY_FILE_QUIT, "Ctrl+Q").toString());
+
+    // Edit operations
+    editUndo.set(conf.value(KEY_HOTKEY_EDIT_UNDO, "Ctrl+Z").toString());
+    editRedo.set(conf.value(KEY_HOTKEY_EDIT_REDO, "Ctrl+Y").toString());
+    editPreferences.set(conf.value(KEY_HOTKEY_EDIT_PREFERENCES, "Ctrl+P").toString());
+    editPreferencesAlt.set(conf.value(KEY_HOTKEY_EDIT_PREFERENCES_ALT, "Esc").toString());
+    editFindRooms.set(conf.value(KEY_HOTKEY_EDIT_FIND_ROOMS, "Ctrl+F").toString());
+    editRoom.set(conf.value(KEY_HOTKEY_EDIT_ROOM, "Ctrl+E").toString());
+
+    // View operations
+    viewZoomIn.set(conf.value(KEY_HOTKEY_VIEW_ZOOM_IN, "").toString());
+    viewZoomOut.set(conf.value(KEY_HOTKEY_VIEW_ZOOM_OUT, "").toString());
+    viewZoomReset.set(conf.value(KEY_HOTKEY_VIEW_ZOOM_RESET, "Ctrl+0").toString());
+    viewLayerUp.set(conf.value(KEY_HOTKEY_VIEW_LAYER_UP, "").toString());
+    viewLayerDown.set(conf.value(KEY_HOTKEY_VIEW_LAYER_DOWN, "").toString());
+    viewLayerReset.set(conf.value(KEY_HOTKEY_VIEW_LAYER_RESET, "").toString());
+
+    // View toggles
+    viewRadialTransparency.set(conf.value(KEY_HOTKEY_VIEW_RADIAL_TRANSPARENCY, "").toString());
+    viewStatusBar.set(conf.value(KEY_HOTKEY_VIEW_STATUS_BAR, "").toString());
+    viewScrollBars.set(conf.value(KEY_HOTKEY_VIEW_SCROLL_BARS, "").toString());
+    viewMenuBar.set(conf.value(KEY_HOTKEY_VIEW_MENU_BAR, "").toString());
+    viewAlwaysOnTop.set(conf.value(KEY_HOTKEY_VIEW_ALWAYS_ON_TOP, "").toString());
+
+    // Side panels
+    panelLog.set(conf.value(KEY_HOTKEY_PANEL_LOG, "Ctrl+L").toString());
+    panelClient.set(conf.value(KEY_HOTKEY_PANEL_CLIENT, "").toString());
+    panelGroup.set(conf.value(KEY_HOTKEY_PANEL_GROUP, "").toString());
+    panelRoom.set(conf.value(KEY_HOTKEY_PANEL_ROOM, "").toString());
+    panelAdventure.set(conf.value(KEY_HOTKEY_PANEL_ADVENTURE, "").toString());
+    panelComms.set(conf.value(KEY_HOTKEY_PANEL_COMMS, "").toString());
+    panelDescription.set(conf.value(KEY_HOTKEY_PANEL_DESCRIPTION, "").toString());
+
+    // Mouse modes
+    modeMoveMap.set(conf.value(KEY_HOTKEY_MODE_MOVE_MAP, "").toString());
+    modeRaypick.set(conf.value(KEY_HOTKEY_MODE_RAYPICK, "").toString());
+    modeSelectRooms.set(conf.value(KEY_HOTKEY_MODE_SELECT_ROOMS, "").toString());
+    modeSelectMarkers.set(conf.value(KEY_HOTKEY_MODE_SELECT_MARKERS, "").toString());
+    modeSelectConnection.set(conf.value(KEY_HOTKEY_MODE_SELECT_CONNECTION, "").toString());
+    modeCreateMarker.set(conf.value(KEY_HOTKEY_MODE_CREATE_MARKER, "").toString());
+    modeCreateRoom.set(conf.value(KEY_HOTKEY_MODE_CREATE_ROOM, "").toString());
+    modeCreateConnection.set(conf.value(KEY_HOTKEY_MODE_CREATE_CONNECTION, "").toString());
+    modeCreateOnewayConnection.set(
+        conf.value(KEY_HOTKEY_MODE_CREATE_ONEWAY_CONNECTION, "").toString());
+
+    // Room operations
+    roomCreate.set(conf.value(KEY_HOTKEY_ROOM_CREATE, "").toString());
+    roomMoveUp.set(conf.value(KEY_HOTKEY_ROOM_MOVE_UP, "").toString());
+    roomMoveDown.set(conf.value(KEY_HOTKEY_ROOM_MOVE_DOWN, "").toString());
+    roomMergeUp.set(conf.value(KEY_HOTKEY_ROOM_MERGE_UP, "").toString());
+    roomMergeDown.set(conf.value(KEY_HOTKEY_ROOM_MERGE_DOWN, "").toString());
+    roomDelete.set(conf.value(KEY_HOTKEY_ROOM_DELETE, "Del").toString());
+    roomConnectNeighbors.set(conf.value(KEY_HOTKEY_ROOM_CONNECT_NEIGHBORS, "").toString());
+    roomMoveToSelected.set(conf.value(KEY_HOTKEY_ROOM_MOVE_TO_SELECTED, "").toString());
+    roomUpdateSelected.set(conf.value(KEY_HOTKEY_ROOM_UPDATE_SELECTED, "").toString());
+}
+
+void Configuration::Hotkeys::write(QSettings &conf) const
+{
+    // File operations
+    conf.setValue(KEY_HOTKEY_FILE_OPEN, fileOpen.get());
+    conf.setValue(KEY_HOTKEY_FILE_SAVE, fileSave.get());
+    conf.setValue(KEY_HOTKEY_FILE_RELOAD, fileReload.get());
+    conf.setValue(KEY_HOTKEY_FILE_QUIT, fileQuit.get());
+
+    // Edit operations
+    conf.setValue(KEY_HOTKEY_EDIT_UNDO, editUndo.get());
+    conf.setValue(KEY_HOTKEY_EDIT_REDO, editRedo.get());
+    conf.setValue(KEY_HOTKEY_EDIT_PREFERENCES, editPreferences.get());
+    conf.setValue(KEY_HOTKEY_EDIT_PREFERENCES_ALT, editPreferencesAlt.get());
+    conf.setValue(KEY_HOTKEY_EDIT_FIND_ROOMS, editFindRooms.get());
+    conf.setValue(KEY_HOTKEY_EDIT_ROOM, editRoom.get());
+
+    // View operations
+    conf.setValue(KEY_HOTKEY_VIEW_ZOOM_IN, viewZoomIn.get());
+    conf.setValue(KEY_HOTKEY_VIEW_ZOOM_OUT, viewZoomOut.get());
+    conf.setValue(KEY_HOTKEY_VIEW_ZOOM_RESET, viewZoomReset.get());
+    conf.setValue(KEY_HOTKEY_VIEW_LAYER_UP, viewLayerUp.get());
+    conf.setValue(KEY_HOTKEY_VIEW_LAYER_DOWN, viewLayerDown.get());
+    conf.setValue(KEY_HOTKEY_VIEW_LAYER_RESET, viewLayerReset.get());
+
+    // View toggles
+    conf.setValue(KEY_HOTKEY_VIEW_RADIAL_TRANSPARENCY, viewRadialTransparency.get());
+    conf.setValue(KEY_HOTKEY_VIEW_STATUS_BAR, viewStatusBar.get());
+    conf.setValue(KEY_HOTKEY_VIEW_SCROLL_BARS, viewScrollBars.get());
+    conf.setValue(KEY_HOTKEY_VIEW_MENU_BAR, viewMenuBar.get());
+    conf.setValue(KEY_HOTKEY_VIEW_ALWAYS_ON_TOP, viewAlwaysOnTop.get());
+
+    // Side panels
+    conf.setValue(KEY_HOTKEY_PANEL_LOG, panelLog.get());
+    conf.setValue(KEY_HOTKEY_PANEL_CLIENT, panelClient.get());
+    conf.setValue(KEY_HOTKEY_PANEL_GROUP, panelGroup.get());
+    conf.setValue(KEY_HOTKEY_PANEL_ROOM, panelRoom.get());
+    conf.setValue(KEY_HOTKEY_PANEL_ADVENTURE, panelAdventure.get());
+    conf.setValue(KEY_HOTKEY_PANEL_COMMS, panelComms.get());
+    conf.setValue(KEY_HOTKEY_PANEL_DESCRIPTION, panelDescription.get());
+
+    // Mouse modes
+    conf.setValue(KEY_HOTKEY_MODE_MOVE_MAP, modeMoveMap.get());
+    conf.setValue(KEY_HOTKEY_MODE_RAYPICK, modeRaypick.get());
+    conf.setValue(KEY_HOTKEY_MODE_SELECT_ROOMS, modeSelectRooms.get());
+    conf.setValue(KEY_HOTKEY_MODE_SELECT_MARKERS, modeSelectMarkers.get());
+    conf.setValue(KEY_HOTKEY_MODE_SELECT_CONNECTION, modeSelectConnection.get());
+    conf.setValue(KEY_HOTKEY_MODE_CREATE_MARKER, modeCreateMarker.get());
+    conf.setValue(KEY_HOTKEY_MODE_CREATE_ROOM, modeCreateRoom.get());
+    conf.setValue(KEY_HOTKEY_MODE_CREATE_CONNECTION, modeCreateConnection.get());
+    conf.setValue(KEY_HOTKEY_MODE_CREATE_ONEWAY_CONNECTION, modeCreateOnewayConnection.get());
+
+    // Room operations
+    conf.setValue(KEY_HOTKEY_ROOM_CREATE, roomCreate.get());
+    conf.setValue(KEY_HOTKEY_ROOM_MOVE_UP, roomMoveUp.get());
+    conf.setValue(KEY_HOTKEY_ROOM_MOVE_DOWN, roomMoveDown.get());
+    conf.setValue(KEY_HOTKEY_ROOM_MERGE_UP, roomMergeUp.get());
+    conf.setValue(KEY_HOTKEY_ROOM_MERGE_DOWN, roomMergeDown.get());
+    conf.setValue(KEY_HOTKEY_ROOM_DELETE, roomDelete.get());
+    conf.setValue(KEY_HOTKEY_ROOM_CONNECT_NEIGHBORS, roomConnectNeighbors.get());
+    conf.setValue(KEY_HOTKEY_ROOM_MOVE_TO_SELECTED, roomMoveToSelected.get());
+    conf.setValue(KEY_HOTKEY_ROOM_UPDATE_SELECTED, roomUpdateSelected.get());
+}
+
+void Configuration::CommsSettings::read(const QSettings &conf)
+{
+    // Communication colors
+    tellColor.set(conf.value(tellColor.getName(), QColor(32, 108, 9)).value<QColor>());
+    whisperColor.set(conf.value(whisperColor.getName(), QColor(103, 135, 149)).value<QColor>());
+    groupColor.set(conf.value(groupColor.getName(), QColor(15, 123, 255)).value<QColor>());
+    askColor.set(conf.value(askColor.getName(), QColor(Qt::yellow)).value<QColor>());
+    sayColor.set(conf.value(sayColor.getName(), QColor(80, 173, 199)).value<QColor>());
+    emoteColor.set(conf.value(emoteColor.getName(), QColor(203, 37, 111)).value<QColor>());
+    socialColor.set(conf.value(socialColor.getName(), QColor(217, 140, 151)).value<QColor>());
+    yellColor.set(conf.value(yellColor.getName(), QColor(176, 80, 189)).value<QColor>());
+    narrateColor.set(conf.value(narrateColor.getName(), QColor(119, 197, 203)).value<QColor>());
+    prayColor.set(conf.value(prayColor.getName(), QColor(173, 216, 230)).value<QColor>());
+    shoutColor.set(conf.value(shoutColor.getName(), QColor(160, 9, 198)).value<QColor>());
+    singColor.set(conf.value(singColor.getName(), QColor(144, 238, 144)).value<QColor>());
+    backgroundColor.set(conf.value(backgroundColor.getName(), QColor(22, 31, 33)).value<QColor>());
+
+    // Font styling options
+    yellAllCaps.set(conf.value(yellAllCaps.getName(), true).toBool());
+    whisperItalic.set(conf.value(whisperItalic.getName(), true).toBool());
+    emoteItalic.set(conf.value(emoteItalic.getName(), true).toBool());
+
+    // Display options
+    showTimestamps.set(conf.value(showTimestamps.getName(), false).toBool());
+    saveLogOnExit.set(conf.value(saveLogOnExit.getName(), false).toBool());
+    logDirectory.set(conf.value(logDirectory.getName(), QString("")).toString());
+
+    // Talker colors
+    talkerYouColor.set(conf.value(talkerYouColor.getName(), QColor(228, 250, 255)).value<QColor>());
+    talkerPlayerColor.set(
+        conf.value(talkerPlayerColor.getName(), QColor(255, 187, 16)).value<QColor>());
+    talkerNpcColor.set(conf.value(talkerNpcColor.getName(), QColor(25, 138, 23)).value<QColor>());
+    talkerAllyColor.set(conf.value(talkerAllyColor.getName(), QColor(33, 166, 255)).value<QColor>());
+    talkerNeutralColor.set(
+        conf.value(talkerNeutralColor.getName(), QColor(166, 168, 168)).value<QColor>());
+    talkerEnemyColor.set(conf.value(talkerEnemyColor.getName(), QColor(173, 7, 37)).value<QColor>());
+
+    // Tab muting (filters)
+    muteDirectTab.set(conf.value(muteDirectTab.getName(), false).toBool());
+    muteLocalTab.set(conf.value(muteLocalTab.getName(), false).toBool());
+    muteGlobalTab.set(conf.value(muteGlobalTab.getName(), false).toBool());
+}
+
+void Configuration::CommsSettings::write(QSettings &conf) const
+{
+    // Communication colors
+    conf.setValue(tellColor.getName(), tellColor.get());
+    conf.setValue(whisperColor.getName(), whisperColor.get());
+    conf.setValue(groupColor.getName(), groupColor.get());
+    conf.setValue(askColor.getName(), askColor.get());
+    conf.setValue(sayColor.getName(), sayColor.get());
+    conf.setValue(emoteColor.getName(), emoteColor.get());
+    conf.setValue(socialColor.getName(), socialColor.get());
+    conf.setValue(yellColor.getName(), yellColor.get());
+    conf.setValue(narrateColor.getName(), narrateColor.get());
+    conf.setValue(prayColor.getName(), prayColor.get());
+    conf.setValue(shoutColor.getName(), shoutColor.get());
+    conf.setValue(singColor.getName(), singColor.get());
+    conf.setValue(backgroundColor.getName(), backgroundColor.get());
+
+    // Font styling options
+    conf.setValue(yellAllCaps.getName(), yellAllCaps.get());
+    conf.setValue(whisperItalic.getName(), whisperItalic.get());
+    conf.setValue(emoteItalic.getName(), emoteItalic.get());
+
+    // Display options
+    conf.setValue(showTimestamps.getName(), showTimestamps.get());
+    conf.setValue(saveLogOnExit.getName(), saveLogOnExit.get());
+    conf.setValue(logDirectory.getName(), logDirectory.get());
+
+    // Talker colors
+    conf.setValue(talkerYouColor.getName(), talkerYouColor.get());
+    conf.setValue(talkerPlayerColor.getName(), talkerPlayerColor.get());
+    conf.setValue(talkerNpcColor.getName(), talkerNpcColor.get());
+    conf.setValue(talkerAllyColor.getName(), talkerAllyColor.get());
+    conf.setValue(talkerNeutralColor.getName(), talkerNeutralColor.get());
+    conf.setValue(talkerEnemyColor.getName(), talkerEnemyColor.get());
+
+    // Tab muting (filters)
+    conf.setValue(muteDirectTab.getName(), muteDirectTab.get());
+    conf.setValue(muteLocalTab.getName(), muteLocalTab.get());
+    conf.setValue(muteGlobalTab.getName(), muteGlobalTab.get());
 }
 
 void Configuration::AccountSettings::write(QSettings &conf) const
@@ -862,6 +1225,8 @@ void Configuration::MumeClockSettings::write(QSettings &conf) const
     // Note: There's no QVariant(int64_t) constructor.
     conf.setValue(KEY_MUME_START_EPOCH, static_cast<qlonglong>(startEpoch));
     conf.setValue(KEY_DISPLAY_CLOCK, display);
+    conf.setValue(KEY_GMCP_BROADCAST_CLOCK, gmcpBroadcast.get());
+    conf.setValue(KEY_GMCP_BROADCAST_INTERVAL, gmcpBroadcastInterval.get());
 }
 
 void Configuration::AdventurePanelSettings::write(QSettings &conf) const
@@ -992,6 +1357,118 @@ void Configuration::CanvasSettings::Advanced::registerChangeCallback(
     verticalAngle.registerChangeCallback(lifetime, callback);
     horizontalAngle.registerChangeCallback(lifetime, callback);
     layerHeight.registerChangeCallback(lifetime, callback);
+}
+
+Configuration::CanvasSettings::VisibilityFilter::VisibilityFilter() = default;
+
+bool Configuration::CanvasSettings::VisibilityFilter::isVisible(InfomarkClassEnum markerClass) const
+{
+    switch (markerClass) {
+    case InfomarkClassEnum::GENERIC:
+        return generic.get();
+    case InfomarkClassEnum::HERB:
+        return herb.get();
+    case InfomarkClassEnum::RIVER:
+        return river.get();
+    case InfomarkClassEnum::PLACE:
+        return place.get();
+    case InfomarkClassEnum::MOB:
+        return mob.get();
+    case InfomarkClassEnum::COMMENT:
+        return comment.get();
+    case InfomarkClassEnum::ROAD:
+        return road.get();
+    case InfomarkClassEnum::OBJECT:
+        return object.get();
+    case InfomarkClassEnum::ACTION:
+        return action.get();
+    case InfomarkClassEnum::LOCALITY:
+        return locality.get();
+    }
+    return true; // Default to visible for unknown types
+}
+
+void Configuration::CanvasSettings::VisibilityFilter::setVisible(InfomarkClassEnum markerClass,
+                                                                 bool visible)
+{
+    switch (markerClass) {
+    case InfomarkClassEnum::GENERIC:
+        generic.set(visible);
+        break;
+    case InfomarkClassEnum::HERB:
+        herb.set(visible);
+        break;
+    case InfomarkClassEnum::RIVER:
+        river.set(visible);
+        break;
+    case InfomarkClassEnum::PLACE:
+        place.set(visible);
+        break;
+    case InfomarkClassEnum::MOB:
+        mob.set(visible);
+        break;
+    case InfomarkClassEnum::COMMENT:
+        comment.set(visible);
+        break;
+    case InfomarkClassEnum::ROAD:
+        road.set(visible);
+        break;
+    case InfomarkClassEnum::OBJECT:
+        object.set(visible);
+        break;
+    case InfomarkClassEnum::ACTION:
+        action.set(visible);
+        break;
+    case InfomarkClassEnum::LOCALITY:
+        locality.set(visible);
+        break;
+    }
+}
+
+void Configuration::CanvasSettings::VisibilityFilter::showAll()
+{
+    generic.set(true);
+    herb.set(true);
+    river.set(true);
+    place.set(true);
+    mob.set(true);
+    comment.set(true);
+    road.set(true);
+    object.set(true);
+    action.set(true);
+    locality.set(true);
+    connections.set(true);
+}
+
+void Configuration::CanvasSettings::VisibilityFilter::hideAll()
+{
+    generic.set(false);
+    herb.set(false);
+    river.set(false);
+    place.set(false);
+    mob.set(false);
+    comment.set(false);
+    road.set(false);
+    object.set(false);
+    action.set(false);
+    locality.set(false);
+    connections.set(false);
+}
+
+void Configuration::CanvasSettings::VisibilityFilter::registerChangeCallback(
+    const ChangeMonitor::Lifetime &lifetime, const ChangeMonitor::Function &callback)
+{
+    generic.registerChangeCallback(lifetime, callback);
+    herb.registerChangeCallback(lifetime, callback);
+    river.registerChangeCallback(lifetime, callback);
+    place.registerChangeCallback(lifetime, callback);
+    mob.registerChangeCallback(lifetime, callback);
+    comment.registerChangeCallback(lifetime, callback);
+    road.registerChangeCallback(lifetime, callback);
+    object.registerChangeCallback(lifetime, callback);
+    action.registerChangeCallback(lifetime, callback);
+    locality.registerChangeCallback(lifetime, callback);
+    connections.registerChangeCallback(lifetime, callback);
 }
 
 void setEnteredMain()

--- a/src/configuration/configuration.h
+++ b/src/configuration/configuration.h
@@ -29,6 +29,9 @@
 
 #undef TRANSPARENT // Bad dog, Microsoft; bad dog!!!
 
+// Forward declaration for InfomarkClassEnum
+enum class InfomarkClassEnum : uint8_t;
+
 #define SUBGROUP() \
     friend class Configuration; \
     void read(const QSettings &conf); \
@@ -79,6 +82,7 @@ public:
         char prefixChar = char_consts::C_UNDERSCORE;
         bool encodeEmoji = true;
         bool decodeEmoji = true;
+        bool enableYellFallbackParsing = true; // Parse yells from game text when GMCP unavailable
 
     private:
         SUBGROUP();
@@ -143,6 +147,10 @@ public:
         bool trilinearFiltering = false;
         bool softwareOpenGL = false;
         QString resourcesDirectory;
+        TextureSetEnum textureSet = TextureSetEnum::MODERN;
+        bool enableSeasonalTextures = true;
+        float layerTransparency = 1.0f;  // 0.0 = only focused layer, 1.0 = maximum transparency
+        bool enableRadialTransparency = true;  // Enable radial transparency zones on upper layers
 
         // not saved yet:
         bool drawCharBeacons = true;
@@ -159,12 +167,21 @@ public:
             NamedConfig<bool> autoTilt{"MMAPPER_AUTO_TILT", true};
             NamedConfig<bool> printPerfStats{"MMAPPER_GL_PERFSTATS", IS_DEBUG_BUILD};
 
+            // Background image settings
+            bool useBackgroundImage = false;
+            QString backgroundImagePath;
+            int backgroundFitMode = 0;  // BackgroundFitModeEnum::FIT
+            float backgroundOpacity = 1.0f;
+            float backgroundFocusedScale = 1.0f;  // Scale factor for FOCUSED mode (0.1 to 10.0)
+            float backgroundFocusedOffsetX = 0.0f;  // X offset for FOCUSED mode (-1000 to 1000)
+            float backgroundFocusedOffsetY = 0.0f;  // Y offset for FOCUSED mode (-1000 to 1000)
+
             // 5..90 degrees
             FixedPoint<1> fov{50, 900, 765};
             // 0..90 degrees
             FixedPoint<1> verticalAngle{0, 900, 450};
-            // -45..45 degrees
-            FixedPoint<1> horizontalAngle{-450, 450, 0};
+            // -180..180 degrees (full rotation)
+            FixedPoint<1> horizontalAngle{-1800, 1800, 0};
             // 1..10 rooms
             FixedPoint<1> layerHeight{10, 100, 15};
 
@@ -175,9 +192,146 @@ public:
             Advanced();
         } advanced;
 
+        struct NODISCARD VisibilityFilter final
+        {
+            NamedConfig<bool> generic{"VISIBLE_MARKER_GENERIC", true};
+            NamedConfig<bool> herb{"VISIBLE_MARKER_HERB", true};
+            NamedConfig<bool> river{"VISIBLE_MARKER_RIVER", true};
+            NamedConfig<bool> place{"VISIBLE_MARKER_PLACE", true};
+            NamedConfig<bool> mob{"VISIBLE_MARKER_MOB", true};
+            NamedConfig<bool> comment{"VISIBLE_MARKER_COMMENT", true};
+            NamedConfig<bool> road{"VISIBLE_MARKER_ROAD", true};
+            NamedConfig<bool> object{"VISIBLE_MARKER_OBJECT", true};
+            NamedConfig<bool> action{"VISIBLE_MARKER_ACTION", true};
+            NamedConfig<bool> locality{"VISIBLE_MARKER_LOCALITY", true};
+            NamedConfig<bool> connections{"VISIBLE_CONNECTIONS", true};
+
+        public:
+            NODISCARD bool isVisible(InfomarkClassEnum markerClass) const;
+            void setVisible(InfomarkClassEnum markerClass, bool visible);
+            NODISCARD bool isConnectionsVisible() const { return connections.get(); }
+            void setConnectionsVisible(bool visible) { connections.set(visible); }
+            void showAll();
+            void hideAll();
+            void registerChangeCallback(const ChangeMonitor::Lifetime &lifetime,
+                                       const ChangeMonitor::Function &callback);
+
+            VisibilityFilter();
+        } visibilityFilter;
+
     private:
         SUBGROUP();
     } canvas;
+
+    struct NODISCARD Hotkeys final
+    {
+        // File operations
+        NamedConfig<QString> fileOpen{"HOTKEY_FILE_OPEN", "Ctrl+O"};
+        NamedConfig<QString> fileSave{"HOTKEY_FILE_SAVE", "Ctrl+S"};
+        NamedConfig<QString> fileReload{"HOTKEY_FILE_RELOAD", "Ctrl+R"};
+        NamedConfig<QString> fileQuit{"HOTKEY_FILE_QUIT", "Ctrl+Q"};
+
+        // Edit operations
+        NamedConfig<QString> editUndo{"HOTKEY_EDIT_UNDO", "Ctrl+Z"};
+        NamedConfig<QString> editRedo{"HOTKEY_EDIT_REDO", "Ctrl+Y"};
+        NamedConfig<QString> editPreferences{"HOTKEY_EDIT_PREFERENCES", "Ctrl+P"};
+        NamedConfig<QString> editPreferencesAlt{"HOTKEY_EDIT_PREFERENCES_ALT", "Esc"};
+        NamedConfig<QString> editFindRooms{"HOTKEY_EDIT_FIND_ROOMS", "Ctrl+F"};
+        NamedConfig<QString> editRoom{"HOTKEY_EDIT_ROOM", "Ctrl+E"};
+
+        // View operations
+        NamedConfig<QString> viewZoomIn{"HOTKEY_VIEW_ZOOM_IN", ""};
+        NamedConfig<QString> viewZoomOut{"HOTKEY_VIEW_ZOOM_OUT", ""};
+        NamedConfig<QString> viewZoomReset{"HOTKEY_VIEW_ZOOM_RESET", "Ctrl+0"};
+        NamedConfig<QString> viewLayerUp{"HOTKEY_VIEW_LAYER_UP", ""};
+        NamedConfig<QString> viewLayerDown{"HOTKEY_VIEW_LAYER_DOWN", ""};
+        NamedConfig<QString> viewLayerReset{"HOTKEY_VIEW_LAYER_RESET", ""};
+
+        // View toggles
+        NamedConfig<QString> viewRadialTransparency{"HOTKEY_VIEW_RADIAL_TRANSPARENCY", ""};
+        NamedConfig<QString> viewStatusBar{"HOTKEY_VIEW_STATUS_BAR", ""};
+        NamedConfig<QString> viewScrollBars{"HOTKEY_VIEW_SCROLL_BARS", ""};
+        NamedConfig<QString> viewMenuBar{"HOTKEY_VIEW_MENU_BAR", ""};
+        NamedConfig<QString> viewAlwaysOnTop{"HOTKEY_VIEW_ALWAYS_ON_TOP", ""};
+
+        // Side panels
+        NamedConfig<QString> panelLog{"HOTKEY_PANEL_LOG", "Ctrl+L"};
+        NamedConfig<QString> panelClient{"HOTKEY_PANEL_CLIENT", ""};
+        NamedConfig<QString> panelGroup{"HOTKEY_PANEL_GROUP", ""};
+        NamedConfig<QString> panelRoom{"HOTKEY_PANEL_ROOM", ""};
+        NamedConfig<QString> panelAdventure{"HOTKEY_PANEL_ADVENTURE", ""};
+        NamedConfig<QString> panelDescription{"HOTKEY_PANEL_DESCRIPTION", ""};
+        NamedConfig<QString> panelComms{"HOTKEY_PANEL_COMMS", ""};
+
+        // Mouse modes
+        NamedConfig<QString> modeMoveMap{"HOTKEY_MODE_MOVE_MAP", ""};
+        NamedConfig<QString> modeRaypick{"HOTKEY_MODE_RAYPICK", ""};
+        NamedConfig<QString> modeSelectRooms{"HOTKEY_MODE_SELECT_ROOMS", ""};
+        NamedConfig<QString> modeSelectMarkers{"HOTKEY_MODE_SELECT_MARKERS", ""};
+        NamedConfig<QString> modeSelectConnection{"HOTKEY_MODE_SELECT_CONNECTION", ""};
+        NamedConfig<QString> modeCreateMarker{"HOTKEY_MODE_CREATE_MARKER", ""};
+        NamedConfig<QString> modeCreateRoom{"HOTKEY_MODE_CREATE_ROOM", ""};
+        NamedConfig<QString> modeCreateConnection{"HOTKEY_MODE_CREATE_CONNECTION", ""};
+        NamedConfig<QString> modeCreateOnewayConnection{"HOTKEY_MODE_CREATE_ONEWAY_CONNECTION", ""};
+
+        // Room operations
+        NamedConfig<QString> roomCreate{"HOTKEY_ROOM_CREATE", ""};
+        NamedConfig<QString> roomMoveUp{"HOTKEY_ROOM_MOVE_UP", ""};
+        NamedConfig<QString> roomMoveDown{"HOTKEY_ROOM_MOVE_DOWN", ""};
+        NamedConfig<QString> roomMergeUp{"HOTKEY_ROOM_MERGE_UP", ""};
+        NamedConfig<QString> roomMergeDown{"HOTKEY_ROOM_MERGE_DOWN", ""};
+        NamedConfig<QString> roomDelete{"HOTKEY_ROOM_DELETE", "Del"};
+        NamedConfig<QString> roomConnectNeighbors{"HOTKEY_ROOM_CONNECT_NEIGHBORS", ""};
+        NamedConfig<QString> roomMoveToSelected{"HOTKEY_ROOM_MOVE_TO_SELECTED", ""};
+        NamedConfig<QString> roomUpdateSelected{"HOTKEY_ROOM_UPDATE_SELECTED", ""};
+
+    private:
+        SUBGROUP();
+    } hotkeys;
+
+    struct NODISCARD CommsSettings final
+    {
+        // Colors for each communication type
+        NamedConfig<QColor> tellColor{"COMMS_TELL_COLOR", QColor(Qt::cyan)};
+        NamedConfig<QColor> whisperColor{"COMMS_WHISPER_COLOR", QColor(135, 206, 250)};  // Light sky blue
+        NamedConfig<QColor> groupColor{"COMMS_GROUP_COLOR", QColor(Qt::green)};
+        NamedConfig<QColor> askColor{"COMMS_ASK_COLOR", QColor(Qt::yellow)};
+        NamedConfig<QColor> sayColor{"COMMS_SAY_COLOR", QColor(Qt::white)};
+        NamedConfig<QColor> emoteColor{"COMMS_EMOTE_COLOR", QColor(Qt::magenta)};
+        NamedConfig<QColor> socialColor{"COMMS_SOCIAL_COLOR", QColor(255, 182, 193)};  // Light pink
+        NamedConfig<QColor> yellColor{"COMMS_YELL_COLOR", QColor(Qt::red)};
+        NamedConfig<QColor> narrateColor{"COMMS_NARRATE_COLOR", QColor(255, 165, 0)};  // Orange
+        NamedConfig<QColor> prayColor{"COMMS_PRAY_COLOR", QColor(173, 216, 230)};  // Light blue
+        NamedConfig<QColor> shoutColor{"COMMS_SHOUT_COLOR", QColor(139, 0, 0)};  // Dark red
+        NamedConfig<QColor> singColor{"COMMS_SING_COLOR", QColor(144, 238, 144)};  // Light green
+        NamedConfig<QColor> backgroundColor{"COMMS_BG_COLOR", QColor(Qt::black)};
+
+        // Talker colors (based on GMCP Comm.Channel talker-type)
+        NamedConfig<QColor> talkerYouColor{"COMMS_TALKER_YOU_COLOR", QColor(255, 215, 0)};  // Gold
+        NamedConfig<QColor> talkerPlayerColor{"COMMS_TALKER_PLAYER_COLOR", QColor(Qt::white)};
+        NamedConfig<QColor> talkerNpcColor{"COMMS_TALKER_NPC_COLOR", QColor(192, 192, 192)};  // Silver/Gray
+        NamedConfig<QColor> talkerAllyColor{"COMMS_TALKER_ALLY_COLOR", QColor(0, 255, 0)};  // Bright green
+        NamedConfig<QColor> talkerNeutralColor{"COMMS_TALKER_NEUTRAL_COLOR", QColor(255, 255, 0)};  // Yellow
+        NamedConfig<QColor> talkerEnemyColor{"COMMS_TALKER_ENEMY_COLOR", QColor(255, 0, 0)};  // Red
+
+        // Font styling options
+        NamedConfig<bool> yellAllCaps{"COMMS_YELL_ALL_CAPS", true};
+        NamedConfig<bool> whisperItalic{"COMMS_WHISPER_ITALIC", true};
+        NamedConfig<bool> emoteItalic{"COMMS_EMOTE_ITALIC", true};
+
+        // Display options
+        NamedConfig<bool> showTimestamps{"COMMS_SHOW_TIMESTAMPS", false};
+        NamedConfig<bool> saveLogOnExit{"COMMS_SAVE_LOG_ON_EXIT", false};
+        NamedConfig<QString> logDirectory{"COMMS_LOG_DIR", ""};
+
+        // Tab muting (acts as a filter)
+        NamedConfig<bool> muteDirectTab{"COMMS_MUTE_DIRECT", false};
+        NamedConfig<bool> muteLocalTab{"COMMS_MUTE_LOCAL", false};
+        NamedConfig<bool> muteGlobalTab{"COMMS_MUTE_GLOBAL", false};
+
+    private:
+        SUBGROUP();
+    } comms;
 
 #define XFOREACH_NAMED_COLOR_OPTIONS(X) \
     X(BACKGROUND, BACKGROUND_NAME) \
@@ -300,6 +454,10 @@ public:
     {
         int64_t startEpoch = 0;
         bool display = false;
+        NamedConfig<bool> gmcpBroadcast{"GMCP_BROADCAST_CLOCK", true};  // Enable GMCP clock broadcasting
+        NamedConfig<int> gmcpBroadcastInterval{"GMCP_BROADCAST_INTERVAL", 2500};  // Update interval in milliseconds (default: 2.5 seconds = 1 MUME minute)
+
+        MumeClockSettings();
 
     private:
         SUBGROUP();

--- a/src/observer/gameobserver.cpp
+++ b/src/observer/gameobserver.cpp
@@ -34,3 +34,8 @@ void GameObserver::observeToggledEchoMode(const bool echo)
 {
     sig2_toggledEchoMode.invoke(echo);
 }
+
+void GameObserver::observeRawGameText(const QString &text)
+{
+    sig2_rawGameText.invoke(text);
+}

--- a/src/observer/gameobserver.h
+++ b/src/observer/gameobserver.h
@@ -19,6 +19,7 @@ public:
 
     Signal2<GmcpMessage> sig2_sentToUserGmcp;
     Signal2<bool> sig2_toggledEchoMode;
+    Signal2<QString> sig2_rawGameText; // raw text from MUD parser (for fallback parsing)
 
 public:
     void observeConnected();
@@ -26,4 +27,5 @@ public:
     void observeSentToUser(const QString &ba);
     void observeSentToUserGmcp(const GmcpMessage &m);
     void observeToggledEchoMode(bool echo);
+    void observeRawGameText(const QString &text);
 };

--- a/src/parser/mumexmlparser-gmcp.cpp
+++ b/src/parser/mumexmlparser-gmcp.cpp
@@ -357,6 +357,11 @@ void MumeXmlParser::parseGmcpCharVitals(const JsonObj &obj)
             qWarning().noquote() << "prompt has unknown weather flag:" << *weather;
         }
     }
+
+    // Immediately update MapData with new prompt flags for real-time lighting updates
+    // This ensures the map updates when light status changes (e.g., covering/uncovering light)
+    // even without moving or looking
+    m_mapData.setPromptFlags(promptFlags);
 }
 
 void MumeXmlParser::parseGmcpEventMoved(const JsonObj &obj)

--- a/src/parser/mumexmlparser.cpp
+++ b/src/parser/mumexmlparser.cpp
@@ -123,6 +123,9 @@ void MumeXmlParser::parse(const TelnetData &data, const bool isGoAhead)
     if (!m_lineToUser.isEmpty()) {
         sendToUser(SendToUserSourceEnum::FromMud, m_lineToUser, isGoAhead);
 
+        // Emit raw game text for fallback parsing (e.g., yells when GMCP unavailable)
+        emit sig_rawGameText(m_lineToUser);
+
         // Simplify the output and run actions
         QString tempStr = m_lineToUser;
         tempStr = normalizeStringCopy(tempStr.trimmed());

--- a/src/parser/mumexmlparser.h
+++ b/src/parser/mumexmlparser.h
@@ -85,6 +85,9 @@ public:
                            ParserCommonData &parserCommonData);
     ~MumeXmlParser() final;
 
+signals:
+    void sig_rawGameText(const QString &text);
+
 private:
     void parse(const TelnetData &, bool isGoAhead);
 

--- a/src/preferences/mumeprotocolpage.cpp
+++ b/src/preferences/mumeprotocolpage.cpp
@@ -30,6 +30,14 @@ MumeProtocolPage::MumeProtocolPage(QWidget *parent)
             &QAbstractButton::clicked,
             this,
             &MumeProtocolPage::slot_externalEditorBrowseButtonClicked);
+    connect(ui->gmcpBroadcastCheckBox,
+            &QCheckBox::stateChanged,
+            this,
+            &MumeProtocolPage::slot_gmcpBroadcastCheckBoxChanged);
+    connect(ui->gmcpIntervalSpinBox,
+            QOverload<int>::of(&QSpinBox::valueChanged),
+            this,
+            &MumeProtocolPage::slot_gmcpIntervalSpinBoxChanged);
 }
 
 MumeProtocolPage::~MumeProtocolPage()
@@ -45,6 +53,12 @@ void MumeProtocolPage::slot_loadConfig()
     ui->externalEditorCommand->setText(settings.externalRemoteEditorCommand);
     ui->externalEditorCommand->setEnabled(!settings.internalRemoteEditor);
     ui->externalEditorBrowseButton->setEnabled(!settings.internalRemoteEditor);
+
+    // Load GMCP clock broadcasting settings
+    const auto &clockSettings = getConfig().mumeClock;
+    ui->gmcpBroadcastCheckBox->setChecked(clockSettings.gmcpBroadcast.get());
+    ui->gmcpIntervalSpinBox->setValue(clockSettings.gmcpBroadcastInterval.get());
+    ui->gmcpIntervalSpinBox->setEnabled(clockSettings.gmcpBroadcast.get());
 }
 
 void MumeProtocolPage::slot_internalEditorRadioButtonChanged(bool /*unused*/)
@@ -73,4 +87,16 @@ void MumeProtocolPage::slot_externalEditorBrowseButtonClicked(bool /*unused*/)
         ui->externalEditorCommand->setText(quotedFileName);
         command = quotedFileName;
     }
+}
+
+void MumeProtocolPage::slot_gmcpBroadcastCheckBoxChanged(int /*unused*/)
+{
+    const bool enabled = ui->gmcpBroadcastCheckBox->isChecked();
+    setConfig().mumeClock.gmcpBroadcast.set(enabled);
+    ui->gmcpIntervalSpinBox->setEnabled(enabled);
+}
+
+void MumeProtocolPage::slot_gmcpIntervalSpinBoxChanged(int value)
+{
+    setConfig().mumeClock.gmcpBroadcastInterval.set(value);
 }

--- a/src/preferences/mumeprotocolpage.h
+++ b/src/preferences/mumeprotocolpage.h
@@ -31,4 +31,6 @@ public slots:
     void slot_internalEditorRadioButtonChanged(bool);
     void slot_externalEditorCommandTextChanged(QString);
     void slot_externalEditorBrowseButtonClicked(bool);
+    void slot_gmcpBroadcastCheckBoxChanged(int);
+    void slot_gmcpIntervalSpinBoxChanged(int);
 };

--- a/src/preferences/mumeprotocolpage.ui
+++ b/src/preferences/mumeprotocolpage.ui
@@ -121,6 +121,66 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>GMCP Clock Broadcasting</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
+      <property name="topMargin">
+       <number>9</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
+      <property name="bottomMargin">
+       <number>9</number>
+      </property>
+      <property name="spacing">
+       <number>6</number>
+      </property>
+      <item row="0" column="0" colspan="2">
+       <widget class="QCheckBox" name="gmcpBroadcastCheckBox">
+        <property name="text">
+         <string>Broadcast clock to connected clients (GMCP MUME.Time)</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="gmcpIntervalLabel">
+        <property name="text">
+         <string>Update interval (ms):</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QSpinBox" name="gmcpIntervalSpinBox">
+        <property name="minimum">
+         <number>500</number>
+        </property>
+        <property name="maximum">
+         <number>60000</number>
+        </property>
+        <property name="singleStep">
+         <number>500</number>
+        </property>
+        <property name="value">
+         <number>2500</number>
+        </property>
+        <property name="toolTip">
+         <string>How often to send clock updates to clients (default: 2500ms = 1 MUME minute)</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <spacer>
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -140,6 +200,8 @@
   <tabstop>internalEditorRadioButton</tabstop>
   <tabstop>externalEditorRadioButton</tabstop>
   <tabstop>externalEditorCommand</tabstop>
+  <tabstop>gmcpBroadcastCheckBox</tabstop>
+  <tabstop>gmcpIntervalSpinBox</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/proxy/GmcpMessage.h
+++ b/src/proxy/GmcpMessage.h
@@ -22,6 +22,8 @@ class ParseEvent;
     X(CHAR_STATUSVARS, CharStatusVars, "char.statusvars", "Char.StatusVars") \
     X(CHAR_VITALS, CharVitals, "char.vitals", "Char.Vitals") \
     X(CHAR_LOGIN, CharLogin, "char.login", "Char.Login") \
+    X(COMM_CHANNEL_LIST, CommChannelList, "comm.channel.list", "Comm.Channel.List") \
+    X(COMM_CHANNEL_TEXT, CommChannelText, "comm.channel.text", "Comm.Channel.Text") \
     X(CORE_GOODBYE, CoreGoodbye, "core.goodbye", "Core.Goodbye") \
     X(CORE_HELLO, CoreHello, "core.hello", "Core.Hello") \
     X(CORE_SUPPORTS_ADD, CoreSupportsAdd, "core.supports.add", "Core.Supports.Add") \
@@ -48,6 +50,7 @@ class ParseEvent;
       "MUME.Client.CancelEdit") \
     X(MUME_CLIENT_WRITE, MumeClientWrite, "mume.client.write", "MUME.Client.Write") \
     X(MUME_CLIENT_XML, MumeClientXml, "mume.client.xml", "MUME.Client.XML") \
+    X(MUME_TIME_INFO, MumeTimeInfo, "mume.time.info", "MUME.Time.Info") \
     X(ROOM_CHARS_ADD, RoomCharsAdd, "room.chars.add", "Room.Chars.Add") \
     X(ROOM_CHARS_REMOVE, RoomCharsRemove, "room.chars.remove", "Room.Chars.Remove") \
     X(ROOM_CHARS_SET, RoomCharsSet, "room.chars.set", "Room.Chars.Set") \
@@ -66,7 +69,7 @@ enum class NODISCARD GmcpMessageTypeEnum {
 #define X_COUNT(...) +1
 static constexpr const size_t NUM_GMCP_MESSAGES = XFOREACH_GMCP_MESSAGE_TYPE(X_COUNT);
 #undef X_COUNT
-static_assert(NUM_GMCP_MESSAGES == 30);
+static_assert(NUM_GMCP_MESSAGES == 33);
 DEFINE_ENUM_COUNT(GmcpMessageTypeEnum, NUM_GMCP_MESSAGES)
 
 namespace tags {

--- a/src/proxy/GmcpModule.h
+++ b/src/proxy/GmcpModule.h
@@ -21,6 +21,7 @@
     X(GROUP, Group, "group", "Group") \
     X(EXTERNAL_DISCORD, ExternalDiscord, "external.discord", "External.Discord") \
     X(MUME_CLIENT, MumeClient, "mume.client", "MUME.Client") \
+    X(MUME_TIME, MumeTime, "mume.time", "MUME.Time") \
     X(ROOM_CHARS, RoomChars, "room.chars", "Room.Chars") \
     X(ROOM, Room, "room", "Room") \
     /* define gmcp module types above */
@@ -35,7 +36,7 @@ enum class NODISCARD GmcpModuleTypeEnum {
 #define X_COUNT(...) +1
 static constexpr const size_t NUM_GMCP_MODULES = XFOREACH_GMCP_MODULE_TYPE(X_COUNT);
 #undef X_COUNT
-static_assert(NUM_GMCP_MODULES == 7);
+static_assert(NUM_GMCP_MODULES == 8);
 DEFINE_ENUM_COUNT(GmcpModuleTypeEnum, NUM_GMCP_MODULES)
 
 namespace tags {

--- a/src/proxy/UserTelnet.h
+++ b/src/proxy/UserTelnet.h
@@ -29,6 +29,10 @@ public:
     {
         virt_onRelayTermTypeFromUserToMud(bytes);
     }
+    void onGmcpModuleEnabled(const GmcpModuleTypeEnum type, const bool enabled)
+    {
+        virt_onGmcpModuleEnabled(type, enabled);
+    }
 
 private:
     virtual void virt_onAnalyzeUserStream(const RawBytes &, bool) = 0;
@@ -36,6 +40,7 @@ private:
     virtual void virt_onRelayGmcpFromUserToMud(const GmcpMessage &) = 0;
     virtual void virt_onRelayNawsFromUserToMud(int, int) = 0;
     virtual void virt_onRelayTermTypeFromUserToMud(const TelnetTermTypeBytes &) = 0;
+    virtual void virt_onGmcpModuleEnabled(GmcpModuleTypeEnum, bool) = 0;
 };
 
 class NODISCARD UserTelnet final : public AbstractTelnet
@@ -68,6 +73,7 @@ private:
 private:
     void receiveGmcpModule(const GmcpModule &, bool);
     void resetGmcpModules();
+    void sendSupportedGmcpModules();
 
 public:
     void onAnalyzeUserStream(const TelnetIacBytes &);

--- a/src/proxy/proxy.h
+++ b/src/proxy/proxy.h
@@ -152,6 +152,9 @@ private:
     // it outlives this object when the connection closes.
     QPointer<RemoteEdit> m_remoteEdit;
 
+    // Clock GMCP broadcaster
+    QTimer *m_clockBroadcastTimer = nullptr;
+
     enum class NODISCARD ServerStateEnum {
         Initialized,
         Offline,
@@ -225,6 +228,11 @@ private:
     NODISCARD bool isUserGmcpModuleEnabled(const GmcpModuleTypeEnum &mod) const;
     void gmcpToMud(const GmcpMessage &msg);
     void gmcpToUser(const GmcpMessage &msg);
+
+private:
+    void startClockBroadcaster();
+    void stopClockBroadcaster();
+    void broadcastClockInfo();
 
 private:
     void sendToMud(const QString &s);


### PR DESCRIPTION
GMCP Improvements:
- Enhanced GMCP message handling in proxy layer
- Added raw game text signal (sig_rawGameText) for fallback parsing
- Improved GMCP module support detection
- Better error handling for GMCP communication

Clock Broadcasting:
- Convert gmcpBroadcast and gmcpBroadcastInterval to NamedConfig
- Add change callbacks for immediate broadcaster restart
- Fix checkbox/interval controls to work without reconnecting
- Configurable broadcast interval (default: 2.5 seconds)
- Auto-start broadcaster when client supports MUME.Time module

GameObserver Integration:
- Connect raw game text to GameObserver for fallback parsing
- Enable communication parsing when GMCP unavailable
- Support for yell fallback parsing configuration

Documentation:
- Added mudlet_clock_example.lua showing GMCP integration
- Example demonstrates clock synchronization in Mudlet

This PR establishes the foundation for real-time GMCP features and enables better synchronization between MMapper and clients.

## Summary by Sourcery

Enhance GMCP-based time synchronization and introduce richer UI/configuration options, including hotkey and communications settings.

New Features:
- Add GMCP-based MUME.Time clock broadcaster with configurable interval that auto-starts when the client enables the MUME.Time module.
- Expose GMCP clock broadcast enable/interval settings in the MUME protocol preferences, applying changes immediately without reconnecting.
- Provide a Mudlet example script demonstrating how to consume MUME.Time.Info GMCP messages from MMapper for clock and day/night integration.
- Introduce configurable canvas texture sets, seasonal textures, layer transparency, background images, and per-marker visibility controls.
- Add centralized hotkey configuration for common file, edit, view, panel, mouse mode, and room operations.
- Add configurable communications panel settings including per-channel colors, styling, timestamps, logging, and tab muting.

Enhancements:
- Emit raw game text from the XML parser and route it through GameObserver to support fallback parsing when GMCP is unavailable.
- Advertise supported GMCP modules to the client and react to supported module enablement/disablement, including MUME.Time.
- Extend the MumeClock to emit season-change signals and to immediately update map lighting based on GMCP vitals weather flags.
- Adjust default background color and extend canvas advanced options like horizontal angle range for improved visualization.