### PR TITLE
Add Communications Manager with GMCP and text-based parsing

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,10 @@ set(mmapper_SRCS
     clock/mumeclockwidget.h
     clock/mumemoment.cpp
     clock/mumemoment.h
+    comms/CommsManager.cpp
+    comms/CommsManager.h
+    comms/CommsWidget.cpp
+    comms/CommsWidget.h
     configuration/NamedConfig.h
     configuration/PasswordConfig.cpp
     configuration/PasswordConfig.h
@@ -226,6 +230,8 @@ set(mmapper_SRCS
     mainwindow/MapZoomSlider.h
     mainwindow/UpdateDialog.cpp
     mainwindow/UpdateDialog.h
+    mainwindow/VisibilityFilterWidget.cpp
+    mainwindow/VisibilityFilterWidget.h
     mainwindow/WinDarkMode.cpp
     mainwindow/WinDarkMode.h
     mainwindow/aboutdialog.cpp
@@ -466,12 +472,16 @@ set(mmapper_SRCS
     preferences/autologpage.h
     preferences/clientpage.cpp
     preferences/clientpage.h
+    preferences/commspage.cpp
+    preferences/commspage.h
     preferences/configdialog.cpp
     preferences/configdialog.h
     preferences/generalpage.cpp
     preferences/generalpage.h
     preferences/graphicspage.cpp
     preferences/graphicspage.h
+    preferences/hotkeyspage.cpp
+    preferences/hotkeyspage.h
     preferences/grouppage.cpp
     preferences/grouppage.h
     preferences/mumeprotocolpage.cpp

--- a/src/comms/CommsManager.cpp
+++ b/src/comms/CommsManager.cpp
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2025 The MMapper Authors
+// Author: originally MuMeM for Mudlet Client (adapted for mMapper: Shimrod with Claude)
+
+#include "CommsManager.h"
+
+#include "../configuration/configuration.h"
+#include "../global/AnsiTextUtils.h"
+#include "../proxy/GmcpMessage.h"
+
+#include <QDateTime>
+#include <QRegularExpression>
+
+CommsManager::CommsManager(QObject *parent)
+    : QObject(parent)
+{}
+
+CommsManager::~CommsManager() = default;
+
+void CommsManager::slot_parseGmcpInput(const GmcpMessage &msg)
+{
+    if (msg.isCommChannelText()) {
+        parseCommChannelText(msg);
+    }
+}
+
+void CommsManager::parseCommChannelText(const GmcpMessage &msg)
+{
+    const auto optDoc = msg.getJsonDocument();
+    if (!optDoc.has_value()) {
+        return;
+    }
+
+    const auto optObj = optDoc->getObject();
+    if (!optObj.has_value()) {
+        return;
+    }
+
+    const auto &obj = optObj.value();
+
+    // Extract fields from GMCP message
+    // Structure: { "channel": "tells", "talker": "Name", "talker-type": "npc", "text": "..." }
+    const auto channelOpt = obj.getString("channel");
+    const auto talkerOpt = obj.getString("talker");
+    const auto textOpt = obj.getString("text");
+    const auto talkerTypeOpt = obj.getString("talker-type");
+
+    if (!channelOpt.has_value() || !talkerOpt.has_value() || !textOpt.has_value()) {
+        return;
+    }
+
+    const QString channel = channelOpt.value();
+    const QString talker = talkerOpt.value();
+    const QString text = textOpt.value();
+
+    // Determine talker type based on talker name and talker-type field
+    TalkerType talkerType = TalkerType::PLAYER; // Default
+
+    if (talker == "you") {
+        talkerType = TalkerType::YOU;
+    } else if (talkerTypeOpt.has_value()) {
+        const QString talkerTypeStr = talkerTypeOpt.value();
+        if (talkerTypeStr == "npc") {
+            talkerType = TalkerType::NPC;
+        } else if (talkerTypeStr == "ally") {
+            talkerType = TalkerType::ALLY;
+        } else if (talkerTypeStr == "neutral") {
+            talkerType = TalkerType::NEUTRAL;
+        } else if (talkerTypeStr == "enemy") {
+            talkerType = TalkerType::ENEMY;
+        }
+    }
+
+    // Note: Text may contain ANSI codes, but we'll display it as-is for now
+    // ANSI stripping can be added later if needed
+
+    // Map channel name to CommType
+    CommType type = getCommTypeFromChannel(channel);
+    CommCategory category = getCategoryFromType(type);
+
+    // Track yells from GMCP to avoid fallback duplicates
+    if (type == CommType::YELL) {
+        trackYellMessage(talker, text);
+    }
+
+    // Create and emit the message
+    CommMessage commMsg;
+    commMsg.type = type;
+    commMsg.category = category;
+    commMsg.sender = talker;
+    commMsg.message = text;
+    commMsg.timestamp = QDateTime::currentDateTime().toString("HH:mm:ss");
+    commMsg.talkerType = talkerType;
+
+    emit sig_newMessage(commMsg);
+}
+
+CommType CommsManager::getCommTypeFromChannel(const QString &channel)
+{
+    // Map GMCP channel names to CommType (support both singular and plural forms)
+    if (channel == "tells" || channel == "tell") {
+        return CommType::TELL;
+    } else if (channel == "whispers" || channel == "whisper") {
+        return CommType::WHISPER;
+    } else if (channel == "groups" || channel == "group") {
+        return CommType::GROUP;
+    } else if (channel == "says" || channel == "say") {
+        return CommType::SAY;
+    } else if (channel == "emotes" || channel == "emote") {
+        return CommType::EMOTE;
+    } else if (channel == "tales" || channel == "narrates" || channel == "narrate") {
+        return CommType::NARRATE;
+    } else if (channel == "yells" || channel == "yell") {
+        return CommType::YELL;
+    } else if (channel == "prayers" || channel == "prayer" || channel == "pray") {
+        return CommType::PRAY;
+    } else if (channel == "shouts" || channel == "shout") {
+        return CommType::SHOUT;
+    } else if (channel == "songs" || channel == "song" || channel == "sing") {
+        return CommType::SING;
+    } else if (channel == "questions" || channel == "question" || channel == "ask") {
+        return CommType::ASK;
+    } else if (channel == "socials" || channel == "social") {
+        return CommType::SOCIAL;
+    }
+
+    // Default to SAY for unknown channels
+    return CommType::SAY;
+}
+
+CommCategory CommsManager::getCategoryFromType(CommType type)
+{
+    switch (type) {
+    case CommType::TELL:
+    case CommType::WHISPER:
+    case CommType::GROUP:
+        return CommCategory::DIRECT;
+
+    case CommType::SAY:
+    case CommType::EMOTE:
+    case CommType::SOCIAL:
+        return CommCategory::LOCAL;
+
+    case CommType::NARRATE:
+    case CommType::YELL:
+    case CommType::PRAY:
+    case CommType::SHOUT:
+    case CommType::SING:
+    case CommType::ASK:
+        return CommCategory::GLOBAL;
+
+    default:
+        return CommCategory::LOCAL;
+    }
+}
+
+void CommsManager::slot_parseRawGameText(const QString &rawText)
+{
+    // Check if fallback parsing is enabled
+    if (!getConfig().parser.enableYellFallbackParsing) {
+        return;
+    }
+
+    parseFallbackYell(rawText);
+}
+
+void CommsManager::parseFallbackYell(const QString &rawText)
+{
+    // Pattern to match yell messages:
+    // "Name yells [from direction] 'message'"
+    // Examples:
+    //   Círdan the Shipwright yells from below 'Come here if you want to speak with me!'
+    //   A thief yells 'HELP! *Shimrod the Elf* is trying to kill me in the Robbers Haven!'
+    //   You yell 'Hello!'
+
+    // Strip ANSI codes from the text before pattern matching
+    QString cleanText = rawText.trimmed();
+
+    // Remove ANSI codes using regex
+    static const QRegularExpression ansiPattern(R"(\x1B\[[0-9;]*[a-zA-Z])");
+    cleanText.remove(ansiPattern);
+
+    // Pattern: Name yells [anything] 'message' [optional text after quote]
+    // Captures everything between "yells" and the opening quote as the qualifier
+    // Examples: "Name yells 'msg'", "Name yells loudly 'msg'",
+    //          "Name yells faintly from below 'msg'", "Name yells loudly from far to the east 'msg'"
+    static const QRegularExpression yellPattern(R"(^(.+?) yells?(?: (.+?))? '(.+?)')",
+                                                QRegularExpression::CaseInsensitiveOption);
+
+    auto match = yellPattern.match(cleanText);
+    if (!match.hasMatch()) {
+        return;
+    }
+
+    QString sender = match.captured(1).trimmed();
+    QString qualifier = match.captured(2).trimmed(); // Everything between "yells" and "'" (optional)
+    QString message = match.captured(3);
+
+    // Check if this is a duplicate from GMCP (within last 2 seconds)
+    if (isRecentYellDuplicate(sender, message)) {
+        return; // Skip this fallback yell, already got it from GMCP
+    }
+
+    // Determine talker type based on sender name
+    TalkerType talkerType = TalkerType::NPC; // Default to NPC
+
+    if (sender.startsWith("You", Qt::CaseInsensitive)) {
+        talkerType = TalkerType::YOU;
+    } else if (!sender.startsWith("A ", Qt::CaseInsensitive)
+               && !sender.startsWith("An ", Qt::CaseInsensitive)
+               && !sender.startsWith("The ", Qt::CaseInsensitive) && !sender.contains(" the ")) {
+        // If name doesn't start with article, likely a player
+        talkerType = TalkerType::PLAYER;
+    }
+
+    // Add qualifier (direction/volume info) to message if present
+    QString fullMessage = message;
+    if (!qualifier.isEmpty()) {
+        fullMessage = QString("[%1] %2").arg(qualifier, message);
+    }
+
+    // Create and emit the comm message
+    CommMessage commMsg;
+    commMsg.type = CommType::YELL;
+    commMsg.category = CommCategory::GLOBAL;
+    commMsg.sender = sender;
+    commMsg.message = fullMessage;
+    commMsg.timestamp = QDateTime::currentDateTime().toString("HH:mm:ss");
+    commMsg.talkerType = talkerType;
+
+    // Track this yell to avoid future duplicates
+    trackYellMessage(sender, message);
+
+    emit sig_newMessage(commMsg);
+}
+
+void CommsManager::trackYellMessage(const QString &sender, const QString &message)
+{
+    // Create a unique key for this yell
+    const QString key = QString("%1|%2").arg(sender, message);
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+
+    // Store the timestamp
+    m_recentYells[key] = now;
+
+    // Clean up old entries (older than 5 seconds)
+    const qint64 cutoff = now - 5000;
+    auto it = m_recentYells.begin();
+    while (it != m_recentYells.end()) {
+        if (it.value() < cutoff) {
+            it = m_recentYells.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+bool CommsManager::isRecentYellDuplicate(const QString &sender, const QString &message) const
+{
+    const QString key = QString("%1|%2").arg(sender, message);
+
+    if (!m_recentYells.contains(key)) {
+        return false;
+    }
+
+    // Check if it's recent (within last 2 seconds)
+    const qint64 timestamp = m_recentYells[key];
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    const qint64 age = now - timestamp;
+
+    return age < 2000; // 2 second window
+}

--- a/src/comms/CommsManager.h
+++ b/src/comms/CommsManager.h
@@ -1,0 +1,83 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2025 The MMapper Authors
+
+#include <QString>
+#include <QObject>
+#include <QSet>
+#include <QPair>
+
+#include "../global/utils.h"
+
+class GmcpMessage;
+
+enum class NODISCARD CommType {
+    TELL,
+    WHISPER,
+    GROUP,
+    SAY,
+    EMOTE,
+    NARRATE,
+    YELL,
+    PRAY,
+    SHOUT,
+    SING,
+    ASK,
+    SOCIAL
+};
+
+enum class NODISCARD CommCategory {
+    DIRECT,  // tells, whispers
+    LOCAL,   // say, emote, social
+    GLOBAL   // narrate, yell, pray, shout, sing, ask (questions)
+};
+
+enum class NODISCARD TalkerType {
+    YOU,      // Messages sent by the player (talker: "you")
+    PLAYER,   // Regular player (no talker-type specified)
+    NPC,      // NPC (talker-type: "npc")
+    ALLY,     // Ally (talker-type: "ally")
+    NEUTRAL,  // Neutral (talker-type: "neutral")
+    ENEMY     // Enemy (talker-type: "enemy")
+};
+
+struct NODISCARD CommMessage final
+{
+    CommType type = CommType::SAY;
+    CommCategory category = CommCategory::LOCAL;
+    QString sender;
+    QString message;
+    QString timestamp;
+    TalkerType talkerType = TalkerType::PLAYER;
+};
+
+class CommsManager final : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit CommsManager(QObject *parent);
+    ~CommsManager() override;
+
+    DELETE_CTORS_AND_ASSIGN_OPS(CommsManager);
+
+public slots:
+    void slot_parseGmcpInput(const GmcpMessage &msg);
+    void slot_parseRawGameText(const QString &rawText);
+
+signals:
+    void sig_newMessage(const CommMessage &msg);
+    void sig_log(const QString &module, const QString &message);
+
+private:
+    void parseCommChannelText(const GmcpMessage &msg);
+    void parseFallbackYell(const QString &rawText);
+    CommType getCommTypeFromChannel(const QString &channel);
+    CommCategory getCategoryFromType(CommType type);
+    void trackYellMessage(const QString &sender, const QString &message);
+    bool isRecentYellDuplicate(const QString &sender, const QString &message) const;
+
+    // Track recent GMCP yells to avoid duplicates from fallback parsing
+    // Format: "sender|message" -> timestamp (in msecs since epoch)
+    QHash<QString, qint64> m_recentYells;
+};

--- a/src/comms/CommsWidget.cpp
+++ b/src/comms/CommsWidget.cpp
@@ -1,0 +1,599 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2025 The MMapper Authors
+
+#include "CommsWidget.h"
+
+#include <algorithm>
+#include <QTextCursor>
+#include <QTextCharFormat>
+#include <QScrollBar>
+#include <QLabel>
+#include <QGroupBox>
+#include <QRegularExpression>
+#include <QFileDialog>
+#include <QFile>
+#include <QDateTime>
+#include <QDir>
+#include <QMessageBox>
+
+#include "../configuration/configuration.h"
+#include "../logger/autologger.h"
+#include "../global/TextUtils.h"
+
+CommsWidget::CommsWidget(CommsManager &commsManager, AutoLogger *autoLogger, QWidget *parent)
+    : QWidget(parent)
+    , m_commsManager{commsManager}
+    , m_autoLogger{autoLogger}
+{
+    // Initialize all filter states to enabled (not muted)
+    m_filterStates[CommType::TELL] = true;
+    m_filterStates[CommType::WHISPER] = true;
+    m_filterStates[CommType::GROUP] = true;
+    m_filterStates[CommType::ASK] = true;
+    m_filterStates[CommType::EMOTE] = true;
+    m_filterStates[CommType::SOCIAL] = true;
+    m_filterStates[CommType::SAY] = true;
+    m_filterStates[CommType::YELL] = true;
+    m_filterStates[CommType::NARRATE] = true;
+    m_filterStates[CommType::SING] = true;
+    m_filterStates[CommType::PRAY] = true;
+
+    setupUI();
+    connectSignals();
+    slot_loadSettings();
+}
+
+CommsWidget::~CommsWidget() = default;
+
+void CommsWidget::setupUI()
+{
+    auto *mainLayout = new QVBoxLayout(this);
+    mainLayout->setContentsMargins(2, 2, 2, 2);
+    mainLayout->setSpacing(4);
+
+    // Top row: Filter buttons and C&M toggle
+    auto *topLayout = new QHBoxLayout();
+    topLayout->setSpacing(4);
+
+    // Helper to create a filter button
+    auto createFilterButton = [this](const QString &fullLabel, const QString &shortLabel, CommType type) {
+        auto *btn = new QPushButton(fullLabel);
+        btn->setToolTip(fullLabel);
+        btn->setProperty("shortLabel", shortLabel);
+        btn->setProperty("fullLabel", fullLabel);
+        btn->setCheckable(true);
+        btn->setChecked(true); // Initially not muted
+        btn->setMaximumHeight(24);
+        btn->setMinimumWidth(40);
+        m_filterButtons[type] = btn;
+
+        connect(btn, &QPushButton::toggled, this, [this, type](bool checked) {
+            slot_onFilterToggled(type, checked);
+        });
+
+        return btn;
+    };
+
+    // Direct group
+    auto *directGroup = new QWidget();
+    auto *directLayout = new QVBoxLayout(directGroup);
+    directLayout->setContentsMargins(0, 0, 0, 0);
+    directLayout->setSpacing(2);
+
+    auto *directLabel = new QLabel("<b>Direct</b>");
+    directLabel->setAlignment(Qt::AlignCenter);
+    directLayout->addWidget(directLabel);
+
+    auto *directButtonsLayout = new QHBoxLayout();
+    directButtonsLayout->setSpacing(2);
+    directButtonsLayout->addWidget(createFilterButton("Tells", "Te", CommType::TELL));
+    directButtonsLayout->addWidget(createFilterButton("Qtions", "Qt", CommType::ASK));
+    directButtonsLayout->addWidget(createFilterButton("Whispers", "Wh", CommType::WHISPER));
+    directButtonsLayout->addWidget(createFilterButton("Group", "Gr", CommType::GROUP));
+    directLayout->addLayout(directButtonsLayout);
+
+    // Local group
+    auto *localGroup = new QWidget();
+    auto *localLayout = new QVBoxLayout(localGroup);
+    localLayout->setContentsMargins(0, 0, 0, 0);
+    localLayout->setSpacing(2);
+
+    auto *localLabel = new QLabel("<b>Local</b>");
+    localLabel->setAlignment(Qt::AlignCenter);
+    localLayout->addWidget(localLabel);
+
+    auto *localButtonsLayout = new QHBoxLayout();
+    localButtonsLayout->setSpacing(2);
+    localButtonsLayout->addWidget(createFilterButton("Emotes", "Em", CommType::EMOTE));
+    localButtonsLayout->addWidget(createFilterButton("Socials", "So", CommType::SOCIAL));
+    localButtonsLayout->addWidget(createFilterButton("Says", "Sa", CommType::SAY));
+    localButtonsLayout->addWidget(createFilterButton("Yells", "Ye", CommType::YELL));
+    localLayout->addLayout(localButtonsLayout);
+
+    // Global group
+    auto *globalGroup = new QWidget();
+    auto *globalLayout = new QVBoxLayout(globalGroup);
+    globalLayout->setContentsMargins(0, 0, 0, 0);
+    globalLayout->setSpacing(2);
+
+    auto *globalLabel = new QLabel("<b>Global</b>");
+    globalLabel->setAlignment(Qt::AlignCenter);
+    globalLayout->addWidget(globalLabel);
+
+    auto *globalButtonsLayout = new QHBoxLayout();
+    globalButtonsLayout->setSpacing(2);
+    globalButtonsLayout->addWidget(createFilterButton("Tales", "Ta", CommType::NARRATE));
+    globalButtonsLayout->addWidget(createFilterButton("Songs", "Sn", CommType::SING));
+    globalButtonsLayout->addWidget(createFilterButton("Prayers", "Pr", CommType::PRAY));
+    globalLayout->addLayout(globalButtonsLayout);
+
+    // Add groups to top layout
+    topLayout->addWidget(directGroup);
+    topLayout->addWidget(localGroup);
+    topLayout->addWidget(globalGroup);
+    topLayout->addStretch();
+
+    // C&M toggle button (Characters and Mobs)
+    m_charMobToggle = new QToolButton();
+    m_charMobToggle->setText("C&M");
+    m_charMobToggle->setToolTip("Toggle between Characters, Mobs, or All");
+    m_charMobToggle->setMaximumSize(32, 24);
+    connect(m_charMobToggle, &QToolButton::clicked, this, &CommsWidget::slot_onCharMobToggle);
+    updateCharMobButtonAppearance();
+    topLayout->addWidget(m_charMobToggle);
+
+    mainLayout->addLayout(topLayout);
+
+    // Main text display
+    m_textDisplay = new QTextEdit();
+    m_textDisplay->setReadOnly(true);
+    m_textDisplay->setLineWrapMode(QTextEdit::WidgetWidth);
+    m_textDisplay->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
+    mainLayout->addWidget(m_textDisplay);
+
+    setLayout(mainLayout);
+}
+
+void CommsWidget::connectSignals()
+{
+    // Connect to CommsManager signals
+    connect(&m_commsManager,
+            &CommsManager::sig_newMessage,
+            this,
+            &CommsWidget::slot_onNewMessage);
+}
+
+void CommsWidget::slot_loadSettings()
+{
+    const auto &comms = getConfig().comms;
+
+    // Apply background color
+    QPalette palette = m_textDisplay->palette();
+    palette.setColor(QPalette::Base, comms.backgroundColor.get());
+    m_textDisplay->setPalette(palette);
+
+    // Refresh display to apply any color/style changes
+    rebuildDisplay();
+}
+
+void CommsWidget::resizeEvent(QResizeEvent *event)
+{
+    QWidget::resizeEvent(event);
+    updateButtonLabels();
+}
+
+void CommsWidget::updateButtonLabels()
+{
+    const int availableWidth = width();
+    const bool useShortLabels = availableWidth < 600;  // Threshold for switching to short labels
+
+    for (auto it = m_filterButtons.constBegin(); it != m_filterButtons.constEnd(); ++it) {
+        auto *btn = it.value();
+        const QString fullLabel = btn->property("fullLabel").toString();
+        const QString shortLabel = btn->property("shortLabel").toString();
+        btn->setText(useShortLabels ? shortLabel : fullLabel);
+    }
+}
+
+void CommsWidget::slot_onFilterToggled(CommType type, bool enabled)
+{
+    m_filterStates[type] = enabled;
+    updateFilterButtonAppearance(m_filterButtons[type], enabled);
+    rebuildDisplay();
+}
+
+void CommsWidget::slot_onCharMobToggle()
+{
+    // Cycle through: C&M -> C -> M -> C&M
+    switch (m_charMobFilter) {
+    case CharMobFilterEnum::BOTH:
+        m_charMobFilter = CharMobFilterEnum::CHAR_ONLY;
+        break;
+    case CharMobFilterEnum::CHAR_ONLY:
+        m_charMobFilter = CharMobFilterEnum::MOB_ONLY;
+        break;
+    case CharMobFilterEnum::MOB_ONLY:
+        m_charMobFilter = CharMobFilterEnum::BOTH;
+        break;
+    }
+
+    updateCharMobButtonAppearance();
+    rebuildDisplay();
+}
+
+void CommsWidget::rebuildDisplay()
+{
+    m_textDisplay->clear();
+    for (const auto &cached : m_messageCache) {
+        if (!isMessageFiltered(cached.msg)) {
+            appendFormattedMessage(cached.msg);
+        }
+    }
+}
+
+void CommsWidget::slot_onNewMessage(const CommMessage &msg)
+{
+    // Cache the message (always with timestamp)
+    m_messageCache.append({msg});
+
+    // Limit cache size
+    while (m_messageCache.size() > MAX_MESSAGES) {
+        m_messageCache.removeFirst();
+    }
+
+    // Only display if not filtered
+    if (!isMessageFiltered(msg)) {
+        appendFormattedMessage(msg);
+    }
+}
+
+void CommsWidget::appendFormattedMessage(const CommMessage &msg)
+{
+    QTextCursor cursor(m_textDisplay->document());
+    cursor.movePosition(QTextCursor::End);
+
+    // Add timestamp if enabled
+    if (getConfig().comms.showTimestamps.get()) {
+        QTextCharFormat timestampFormat;
+        timestampFormat.setForeground(QColor(128, 128, 128)); // Gray
+        cursor.setCharFormat(timestampFormat);
+        cursor.insertText(QString("[%1] ").arg(msg.timestamp));
+    }
+
+    // Strip ANSI codes first
+    QString originalSender = stripAnsiCodes(msg.sender);
+    QString message = stripAnsiCodes(msg.message);
+
+    // Clean sender name (remove articles, capitalize)
+    QString cleanedSender = cleanSenderName(originalSender);
+
+    // Check if message already contains formatting (double caption issue)
+    // Check against ORIGINAL sender name before cleaning
+    if (message.startsWith(originalSender, Qt::CaseInsensitive)) {
+        // Message already contains the full formatted text
+        // We need to replace the original sender with cleaned sender and use that
+        QTextCharFormat nameFormat;
+        nameFormat.setForeground(getColorForTalker(msg.talkerType));  // Use talker color for names
+        nameFormat.setFontWeight(QFont::Bold);
+
+        QTextCharFormat textFormat;
+        textFormat.setForeground(getColorForType(msg.type));
+        textFormat.setFontWeight(QFont::Normal);
+
+        // Apply italic for whispers/emotes/socials if configured
+        if ((msg.type == CommType::WHISPER && getConfig().comms.whisperItalic.get())
+            || ((msg.type == CommType::EMOTE || msg.type == CommType::SOCIAL) && getConfig().comms.emoteItalic.get())) {
+            textFormat.setFontItalic(true);
+            nameFormat.setFontItalic(true);  // Name also italic for emotes/socials
+        }
+
+        // Insert cleaned sender name in bold
+        cursor.setCharFormat(nameFormat);
+        cursor.insertText(cleanedSender);
+
+        // Insert rest of message (skip original sender part)
+        cursor.setCharFormat(textFormat);
+        cursor.insertText(message.mid(originalSender.length()) + "\n");
+    } else {
+        // Format the message ourselves
+        formatAndInsertMessage(cursor, msg, cleanedSender, message);
+    }
+
+    // Auto-scroll to bottom
+    m_textDisplay->verticalScrollBar()->setValue(m_textDisplay->verticalScrollBar()->maximum());
+}
+
+void CommsWidget::formatAndInsertMessage(QTextCursor &cursor, const CommMessage &msg, const QString &sender, const QString &message)
+{
+    // Apply transformations
+    QString finalMessage = message;
+    if (msg.type == CommType::YELL && getConfig().comms.yellAllCaps.get()) {
+        // Only uppercase the message text, not qualifier prefix like "[faintly from below]"
+        static const QRegularExpression qualifierPrefix(R"(^(\[.+?\] )(.*)$)");
+        auto match = qualifierPrefix.match(finalMessage);
+        if (match.hasMatch()) {
+            // Keep prefix lowercase, uppercase the message
+            finalMessage = match.captured(1) + match.captured(2).toUpper();
+        } else {
+            // No prefix, uppercase everything
+            finalMessage = finalMessage.toUpper();
+        }
+    }
+
+    // Format: [Bold Name] verb: 'message'
+    QTextCharFormat nameFormat;
+    nameFormat.setForeground(getColorForTalker(msg.talkerType));  // Use talker color for name
+    nameFormat.setFontWeight(QFont::Bold);  // Only name is bold
+
+    QTextCharFormat textFormat;
+    textFormat.setForeground(getColorForType(msg.type));
+    textFormat.setFontWeight(QFont::Normal);  // Rest is normal
+
+    // Apply italic for whispers/emotes if configured
+    if ((msg.type == CommType::WHISPER && getConfig().comms.whisperItalic.get())
+        || ((msg.type == CommType::EMOTE || msg.type == CommType::SOCIAL) && getConfig().comms.emoteItalic.get())) {
+        textFormat.setFontItalic(true);
+    }
+
+    // Simplified format: "Name: 'message'" for all types
+    if (msg.type == CommType::PRAY) {
+        // Special case for prayer (no sender from others)
+        cursor.setCharFormat(nameFormat);
+        cursor.insertText("You");
+        cursor.setCharFormat(textFormat);
+        cursor.insertText(QString(": %1\n").arg(finalMessage));
+    } else {
+        // Standard format
+        cursor.setCharFormat(nameFormat);
+        cursor.insertText(sender);
+        cursor.setCharFormat(textFormat);
+
+        // For emotes and socials, no colon (just "Name message")
+        if (msg.type == CommType::EMOTE || msg.type == CommType::SOCIAL) {
+            cursor.insertText(QString(" %1\n").arg(finalMessage));
+        } else {
+            // All other types: "Name: 'message'"
+            cursor.insertText(QString(": %1\n").arg(finalMessage));
+        }
+    }
+}
+
+QString CommsWidget::stripAnsiCodes(const QString &text)
+{
+    // ANSI escape sequence pattern: \x1b[...m or similar
+    static const QRegularExpression ansiPattern(R"(\x1b\[[0-9;]*m)");
+    QString cleaned = text;
+    cleaned.remove(ansiPattern);
+
+    // Also handle the ∂[ format seen in the screenshot
+    static const QRegularExpression altAnsiPattern(R"(∂\[[0-9;]*m?)");
+    cleaned.remove(altAnsiPattern);
+
+    return cleaned;
+}
+
+QString CommsWidget::cleanSenderName(const QString &sender)
+{
+    QString cleaned = sender;
+
+    // Remove leading articles (case insensitive)
+    static const QRegularExpression articlePattern(R"(^(an?)\s+)", QRegularExpression::CaseInsensitiveOption);
+    cleaned.remove(articlePattern);
+
+    // Capitalize first letter
+    if (!cleaned.isEmpty() && cleaned[0].isLetter()) {
+        cleaned[0] = cleaned[0].toUpper();
+    }
+
+    return cleaned;
+}
+
+QColor CommsWidget::getColorForType(CommType type)
+{
+    const auto &comms = getConfig().comms;
+
+    switch (type) {
+    case CommType::TELL:
+        return comms.tellColor.get();
+    case CommType::WHISPER:
+        return comms.whisperColor.get();
+    case CommType::GROUP:
+        return comms.groupColor.get();
+    case CommType::ASK:
+        return comms.askColor.get();
+    case CommType::SAY:
+        return comms.sayColor.get();
+    case CommType::EMOTE:
+        return comms.emoteColor.get();
+    case CommType::SOCIAL:
+        return comms.socialColor.get();
+    case CommType::YELL:
+        return comms.yellColor.get();
+    case CommType::NARRATE:
+        return comms.narrateColor.get();
+    case CommType::PRAY:
+        return comms.prayColor.get();
+    case CommType::SHOUT:
+        return comms.shoutColor.get();
+    case CommType::SING:
+        return comms.singColor.get();
+    default:
+        return Qt::white;
+    }
+}
+
+QColor CommsWidget::getColorForTalker(TalkerType talkerType)
+{
+    const auto &comms = getConfig().comms;
+
+    switch (talkerType) {
+    case TalkerType::YOU:
+        return comms.talkerYouColor.get();
+    case TalkerType::PLAYER:
+        return comms.talkerPlayerColor.get();
+    case TalkerType::NPC:
+        return comms.talkerNpcColor.get();
+    case TalkerType::ALLY:
+        return comms.talkerAllyColor.get();
+    case TalkerType::NEUTRAL:
+        return comms.talkerNeutralColor.get();
+    case TalkerType::ENEMY:
+        return comms.talkerEnemyColor.get();
+    default:
+        return Qt::white;
+    }
+}
+
+bool CommsWidget::isMessageFiltered(const CommMessage &msg) const
+{
+    // Check type filter
+    if (!m_filterStates.value(msg.type, true)) {
+        return true; // Filtered out (muted)
+    }
+
+    // Check character/mob filter
+    switch (m_charMobFilter) {
+    case CharMobFilterEnum::CHAR_ONLY:
+        if (msg.talkerType == TalkerType::NPC) {
+            return true; // Filter out NPCs
+        }
+        break;
+    case CharMobFilterEnum::MOB_ONLY:
+        if (msg.talkerType != TalkerType::NPC) {
+            return true; // Filter out characters
+        }
+        break;
+    case CharMobFilterEnum::BOTH:
+        // Show all
+        break;
+    }
+
+    return false;
+}
+
+void CommsWidget::updateFilterButtonAppearance(QPushButton *button, bool enabled)
+{
+    if (enabled) {
+        // Normal appearance (not muted)
+        button->setStyleSheet("");
+    } else {
+        // Red appearance (muted)
+        button->setStyleSheet("QPushButton { background-color: #8B0000; color: white; }");
+    }
+}
+
+void CommsWidget::updateCharMobButtonAppearance()
+{
+    switch (m_charMobFilter) {
+    case CharMobFilterEnum::BOTH:
+        m_charMobToggle->setText("C&M");
+        m_charMobToggle->setToolTip("Showing both Characters and Mobs");
+        break;
+    case CharMobFilterEnum::CHAR_ONLY:
+        m_charMobToggle->setText("C");
+        m_charMobToggle->setToolTip("Showing Characters only");
+        break;
+    case CharMobFilterEnum::MOB_ONLY:
+        m_charMobToggle->setText("M");
+        m_charMobToggle->setToolTip("Showing Mobs only");
+        break;
+    }
+}
+
+void CommsWidget::slot_saveLog()
+{
+    struct NODISCARD Result
+    {
+        QStringList filenames;
+        bool isHtml = false;
+    };
+    const auto getFileNames = [this]() -> Result {
+        auto save = std::make_unique<QFileDialog>(this, "Choose communications log file name ...");
+        save->setFileMode(QFileDialog::AnyFile);
+        save->setDirectory(QDir::current());
+        save->setNameFilters(QStringList() << "Text log (*.log *.txt)"
+                                           << "HTML log (*.htm *.html)");
+        save->setDefaultSuffix("txt");
+        save->setAcceptMode(QFileDialog::AcceptSave);
+
+        if (save->exec() == QDialog::Accepted) {
+            const QString nameFilter = save->selectedNameFilter().toLower();
+            const bool isHtml = nameFilter.endsWith(".htm") || nameFilter.endsWith(".html");
+            return Result{save->selectedFiles(), isHtml};
+        }
+
+        return Result{};
+    };
+
+    const auto result = getFileNames();
+    const auto &fileNames = result.filenames;
+
+    if (fileNames.isEmpty()) {
+        return;
+    }
+
+    QFile document(fileNames[0]);
+    if (!document.open(QFile::WriteOnly | QFile::Text)) {
+        QMessageBox::warning(this,
+                           tr("Save Error"),
+                           tr("Error occurred while opening %1").arg(document.fileName()));
+        return;
+    }
+
+    const auto getDocStringUtf8 = [](const QTextDocument *const pDoc,
+                                     const bool isHtml) -> QByteArray {
+        const QString string = isHtml ? pDoc->toHtml() : pDoc->toPlainText();
+        return string.toUtf8();
+    };
+    document.write(getDocStringUtf8(m_textDisplay->document(), result.isHtml));
+    document.close();
+}
+
+void CommsWidget::slot_saveLogOnExit()
+{
+    const auto &comms = getConfig().comms;
+    if (!comms.saveLogOnExit.get()) {
+        return;
+    }
+
+    // Use the same directory as AutoLogger
+    const auto &autoLogConfig = getConfig().autoLog;
+    QString logDir = autoLogConfig.autoLogDirectory;
+    if (logDir.isEmpty()) {
+        logDir = QDir::current().path();
+    }
+
+    // Create directory if it doesn't exist
+    QDir dir(logDir);
+    if (!dir.exists()) {
+        dir.mkpath(".");
+    }
+
+    // Generate filename matching AutoLogger format: Comms_Log_{date}_{filenum}_{runId}.txt
+    QString fileName;
+    if (m_autoLogger) {
+        // Note: getCurrentFileNumber() returns the NEXT file number, so we subtract 1
+        // to get the current file number that matches the active MMapper log
+        const int currentFileNum = std::max(0, m_autoLogger->getCurrentFileNumber() - 1);
+        fileName = QString("Comms_Log_%1_%2_%3.txt")
+                       .arg(QDate::currentDate().toString("yyyy_MM_dd"))
+                       .arg(QString::number(currentFileNum))
+                       .arg(mmqt::toQStringUtf8(m_autoLogger->getRunId()));
+    } else {
+        // Fallback if AutoLogger is not available
+        const QString timestamp = QDateTime::currentDateTime().toString("yyyy_MM_dd_HH_mm_ss");
+        fileName = QString("Comms_Log_%1.txt").arg(timestamp);
+    }
+
+    const QString fullPath = dir.filePath(fileName);
+    QFile document(fullPath);
+    if (!document.open(QFile::WriteOnly | QFile::Text)) {
+        qWarning() << "Failed to save communications log to" << fullPath;
+        return;
+    }
+
+    const QString plainText = m_textDisplay->document()->toPlainText();
+    document.write(plainText.toUtf8());
+    document.close();
+    qInfo() << "Communications log saved to" << fullPath;
+}

--- a/src/comms/CommsWidget.h
+++ b/src/comms/CommsWidget.h
@@ -1,0 +1,81 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2025 The MMapper Authors
+
+#include <QWidget>
+#include <QTextEdit>
+#include <QPushButton>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QToolButton>
+#include <QMap>
+#include <QResizeEvent>
+
+#include "../global/utils.h"
+#include "CommsManager.h"
+
+class AutoLogger;
+
+enum class NODISCARD CharMobFilterEnum : uint8_t { BOTH, CHAR_ONLY, MOB_ONLY };
+
+class CommsWidget final : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit CommsWidget(CommsManager &commsManager, AutoLogger *autoLogger, QWidget *parent);
+    ~CommsWidget() override;
+
+    DELETE_CTORS_AND_ASSIGN_OPS(CommsWidget);
+
+public slots:
+    void slot_onNewMessage(const CommMessage &msg);
+    void slot_loadSettings();
+    void slot_saveLog();
+    void slot_saveLogOnExit();
+
+protected:
+    void resizeEvent(QResizeEvent *event) override;
+
+private slots:
+    void slot_onFilterToggled(CommType type, bool enabled);
+    void slot_onCharMobToggle();
+
+private:
+    void setupUI();
+    void connectSignals();
+    void appendFormattedMessage(const CommMessage &msg);
+    void formatAndInsertMessage(QTextCursor &cursor, const CommMessage &msg, const QString &sender, const QString &message);
+    QString stripAnsiCodes(const QString &text);
+    QString cleanSenderName(const QString &sender);
+    QColor getColorForType(CommType type);
+    QColor getColorForTalker(TalkerType talkerType);
+    bool isMessageFiltered(const CommMessage &msg) const;
+    void updateFilterButtonAppearance(QPushButton *button, bool enabled);
+    void updateCharMobButtonAppearance();
+    void rebuildDisplay();
+    void updateButtonLabels();
+
+    // Reference to data source
+    CommsManager &m_commsManager;
+    AutoLogger *m_autoLogger = nullptr;
+
+    // UI components
+    QTextEdit *m_textDisplay = nullptr;
+    QToolButton *m_charMobToggle = nullptr;
+
+    // Filter buttons by type
+    QMap<CommType, QPushButton*> m_filterButtons;
+    QMap<CommType, bool> m_filterStates; // true = show, false = muted/filtered
+
+    CharMobFilterEnum m_charMobFilter = CharMobFilterEnum::BOTH;
+
+    // Message cache for re-filtering
+    struct CachedMessage {
+        CommMessage msg;
+    };
+    QList<CachedMessage> m_messageCache;
+
+    // Maximum messages to keep in cache
+    static constexpr int MAX_MESSAGES = 1024;
+};

--- a/src/configuration/configuration.cpp
+++ b/src/configuration/configuration.cpp
@@ -7,6 +7,7 @@
 #include "configuration.h"
 
 #include "../global/utils.h"
+#include "../map/infomark.h"
 
 #include <cassert>
 #include <mutex>
@@ -50,6 +51,25 @@ NODISCARD const char *getPlatformEditor()
     default:
         return "";
     }
+}
+
+NODISCARD TextureSetEnum intToTextureSet(int value)
+{
+    switch (value) {
+    case 0:
+        return TextureSetEnum::CLASSIC;
+    case 1:
+        return TextureSetEnum::MODERN;
+    case 2:
+        return TextureSetEnum::CUSTOM;
+    default:
+        return TextureSetEnum::MODERN; // Default to Modern
+    }
+}
+
+NODISCARD int textureSetToInt(TextureSetEnum value)
+{
+    return static_cast<int>(value);
 }
 
 } // namespace
@@ -194,10 +214,12 @@ ConstString GRP_ACCOUNT = "Account";
 ConstString GRP_AUTO_LOAD_WORLD = "Auto load world";
 ConstString GRP_AUTO_LOG = "Auto log";
 ConstString GRP_CANVAS = "Canvas";
+ConstString GRP_COMMS = "Communications";
 ConstString GRP_CONNECTION = "Connection";
 ConstString GRP_FINDROOMS_DIALOG = "FindRooms Dialog";
 ConstString GRP_GENERAL = "General";
 ConstString GRP_GROUP_MANAGER = "Group Manager";
+ConstString GRP_HOTKEYS = "Hotkeys";
 ConstString GRP_INFOMARKS_DIALOG = "InfoMarks Dialog";
 ConstString GRP_INTEGRATED_MUD_CLIENT = "Integrated Mud Client";
 ConstString GRP_MUME_CLIENT_PROTOCOL = "Mume client protocol";
@@ -227,9 +249,12 @@ ConstString KEY_CONNECTION_NORMAL_COLOR = "Connection normal color";
 ConstString KEY_CORRECT_POSITION_BONUS = "correct position bonus";
 ConstString KEY_DISPLAY_XP_STATUS = "Display XP status bar widget";
 ConstString KEY_DISPLAY_CLOCK = "Display clock";
+ConstString KEY_GMCP_BROADCAST_CLOCK = "GMCP broadcast clock";
+ConstString KEY_GMCP_BROADCAST_INTERVAL = "GMCP broadcast interval";
 ConstString KEY_DRAW_DOOR_NAMES = "Draw door names";
 ConstString KEY_DRAW_NOT_MAPPED_EXITS = "Draw not mapped exits";
 ConstString KEY_DRAW_UPPER_LAYERS_TEXTURED = "Draw upper layers textured";
+ConstString KEY_LAYER_TRANSPARENCY = "Layer transparency";
 ConstString KEY_EMOJI_ENCODE = "encode emoji";
 ConstString KEY_EMOJI_DECODE = "decode emoji";
 ConstString KEY_EMULATED_EXITS = "Emulated Exits";
@@ -256,6 +281,73 @@ ConstString KEY_3D_FOV = "canvas.advanced.fov";
 ConstString KEY_3D_VERTICAL_ANGLE = "canvas.advanced.verticalAngle";
 ConstString KEY_3D_HORIZONTAL_ANGLE = "canvas.advanced.horizontalAngle";
 ConstString KEY_3D_LAYER_HEIGHT = "canvas.advanced.layerHeight";
+ConstString KEY_BACKGROUND_IMAGE_ENABLED = "canvas.advanced.backgroundImageEnabled";
+ConstString KEY_BACKGROUND_IMAGE_PATH = "canvas.advanced.backgroundImagePath";
+ConstString KEY_BACKGROUND_IMAGE_FIT_MODE = "canvas.advanced.backgroundFitMode";
+ConstString KEY_BACKGROUND_IMAGE_OPACITY = "canvas.advanced.backgroundOpacity";
+ConstString KEY_BACKGROUND_IMAGE_FOCUSED_SCALE = "canvas.advanced.backgroundFocusedScale";
+ConstString KEY_BACKGROUND_IMAGE_FOCUSED_OFFSET_X = "canvas.advanced.backgroundFocusedOffsetX";
+ConstString KEY_BACKGROUND_IMAGE_FOCUSED_OFFSET_Y = "canvas.advanced.backgroundFocusedOffsetY";
+ConstString KEY_VISIBLE_MARKER_GENERIC = "canvas.visibleMarkers.generic";
+ConstString KEY_VISIBLE_MARKER_HERB = "canvas.visibleMarkers.herb";
+ConstString KEY_VISIBLE_MARKER_RIVER = "canvas.visibleMarkers.river";
+ConstString KEY_VISIBLE_MARKER_PLACE = "canvas.visibleMarkers.place";
+ConstString KEY_VISIBLE_MARKER_MOB = "canvas.visibleMarkers.mob";
+ConstString KEY_VISIBLE_MARKER_COMMENT = "canvas.visibleMarkers.comment";
+ConstString KEY_VISIBLE_MARKER_ROAD = "canvas.visibleMarkers.road";
+ConstString KEY_VISIBLE_MARKER_OBJECT = "canvas.visibleMarkers.object";
+ConstString KEY_VISIBLE_MARKER_ACTION = "canvas.visibleMarkers.action";
+ConstString KEY_VISIBLE_MARKER_LOCALITY = "canvas.visibleMarkers.locality";
+ConstString KEY_VISIBLE_CONNECTIONS = "canvas.visibilityFilter.connections";
+
+// Hotkey configuration keys
+ConstString KEY_HOTKEY_FILE_OPEN = "hotkeys.fileOpen";
+ConstString KEY_HOTKEY_FILE_SAVE = "hotkeys.fileSave";
+ConstString KEY_HOTKEY_FILE_RELOAD = "hotkeys.fileReload";
+ConstString KEY_HOTKEY_FILE_QUIT = "hotkeys.fileQuit";
+ConstString KEY_HOTKEY_EDIT_UNDO = "hotkeys.editUndo";
+ConstString KEY_HOTKEY_EDIT_REDO = "hotkeys.editRedo";
+ConstString KEY_HOTKEY_EDIT_PREFERENCES = "hotkeys.editPreferences";
+ConstString KEY_HOTKEY_EDIT_PREFERENCES_ALT = "hotkeys.editPreferencesAlt";
+ConstString KEY_HOTKEY_EDIT_FIND_ROOMS = "hotkeys.editFindRooms";
+ConstString KEY_HOTKEY_EDIT_ROOM = "hotkeys.editRoom";
+ConstString KEY_HOTKEY_VIEW_ZOOM_IN = "hotkeys.viewZoomIn";
+ConstString KEY_HOTKEY_VIEW_ZOOM_OUT = "hotkeys.viewZoomOut";
+ConstString KEY_HOTKEY_VIEW_ZOOM_RESET = "hotkeys.viewZoomReset";
+ConstString KEY_HOTKEY_VIEW_LAYER_UP = "hotkeys.viewLayerUp";
+ConstString KEY_HOTKEY_VIEW_LAYER_DOWN = "hotkeys.viewLayerDown";
+ConstString KEY_HOTKEY_VIEW_LAYER_RESET = "hotkeys.viewLayerReset";
+ConstString KEY_HOTKEY_VIEW_RADIAL_TRANSPARENCY = "hotkeys.viewRadialTransparency";
+ConstString KEY_HOTKEY_VIEW_STATUS_BAR = "hotkeys.viewStatusBar";
+ConstString KEY_HOTKEY_VIEW_SCROLL_BARS = "hotkeys.viewScrollBars";
+ConstString KEY_HOTKEY_VIEW_MENU_BAR = "hotkeys.viewMenuBar";
+ConstString KEY_HOTKEY_VIEW_ALWAYS_ON_TOP = "hotkeys.viewAlwaysOnTop";
+ConstString KEY_HOTKEY_PANEL_LOG = "hotkeys.panelLog";
+ConstString KEY_HOTKEY_PANEL_CLIENT = "hotkeys.panelClient";
+ConstString KEY_HOTKEY_PANEL_GROUP = "hotkeys.panelGroup";
+ConstString KEY_HOTKEY_PANEL_ROOM = "hotkeys.panelRoom";
+ConstString KEY_HOTKEY_PANEL_ADVENTURE = "hotkeys.panelAdventure";
+ConstString KEY_HOTKEY_PANEL_COMMS = "hotkeys.panelComms";
+ConstString KEY_HOTKEY_PANEL_DESCRIPTION = "hotkeys.panelDescription";
+ConstString KEY_HOTKEY_MODE_MOVE_MAP = "hotkeys.modeMoveMap";
+ConstString KEY_HOTKEY_MODE_RAYPICK = "hotkeys.modeRaypick";
+ConstString KEY_HOTKEY_MODE_SELECT_ROOMS = "hotkeys.modeSelectRooms";
+ConstString KEY_HOTKEY_MODE_SELECT_MARKERS = "hotkeys.modeSelectMarkers";
+ConstString KEY_HOTKEY_MODE_SELECT_CONNECTION = "hotkeys.modeSelectConnection";
+ConstString KEY_HOTKEY_MODE_CREATE_MARKER = "hotkeys.modeCreateMarker";
+ConstString KEY_HOTKEY_MODE_CREATE_ROOM = "hotkeys.modeCreateRoom";
+ConstString KEY_HOTKEY_MODE_CREATE_CONNECTION = "hotkeys.modeCreateConnection";
+ConstString KEY_HOTKEY_MODE_CREATE_ONEWAY_CONNECTION = "hotkeys.modeCreateOnewayConnection";
+ConstString KEY_HOTKEY_ROOM_CREATE = "hotkeys.roomCreate";
+ConstString KEY_HOTKEY_ROOM_MOVE_UP = "hotkeys.roomMoveUp";
+ConstString KEY_HOTKEY_ROOM_MOVE_DOWN = "hotkeys.roomMoveDown";
+ConstString KEY_HOTKEY_ROOM_MERGE_UP = "hotkeys.roomMergeUp";
+ConstString KEY_HOTKEY_ROOM_MERGE_DOWN = "hotkeys.roomMergeDown";
+ConstString KEY_HOTKEY_ROOM_DELETE = "hotkeys.roomDelete";
+ConstString KEY_HOTKEY_ROOM_CONNECT_NEIGHBORS = "hotkeys.roomConnectNeighbors";
+ConstString KEY_HOTKEY_ROOM_MOVE_TO_SELECTED = "hotkeys.roomMoveToSelected";
+ConstString KEY_HOTKEY_ROOM_UPDATE_SELECTED = "hotkeys.roomUpdateSelected";
+
 ConstString KEY_LAST_MAP_LOAD_DIRECTORY = "Last map load directory";
 ConstString KEY_LINES_OF_INPUT_HISTORY = "Lines of input history";
 ConstString KEY_LINES_OF_PEEK_PREVIEW = "Lines of peek preview";
@@ -270,6 +362,8 @@ ConstString KEY_PROXY_CONNECTION_STATUS = "Proxy connection status";
 ConstString KEY_PROXY_LISTENS_ON_ANY_INTERFACE = "Proxy listens on any interface";
 ConstString KEY_RELATIVE_PATH_ACCEPTANCE = "relative path acceptance";
 ConstString KEY_RESOURCES_DIRECTORY = "canvas.resourcesDir";
+ConstString KEY_TEXTURE_SET = "canvas.textureSet";
+ConstString KEY_ENABLE_SEASONAL_TEXTURES = "canvas.enableSeasonalTextures";
 ConstString KEY_MUME_REMOTE_PORT = "Remote port number";
 ConstString KEY_REMEMBER_LOGIN = "remember login";
 ConstString KEY_ROOM_CREATION_PENALTY = "room creation penalty";
@@ -441,6 +535,8 @@ NODISCARD static uint16_t sanitizeUint16(const int input, const uint16_t default
         GROUP_CALLBACK(callback, GRP_GENERAL, general); \
         GROUP_CALLBACK(callback, GRP_CONNECTION, connection); \
         GROUP_CALLBACK(callback, GRP_CANVAS, canvas); \
+        GROUP_CALLBACK(callback, GRP_HOTKEYS, hotkeys); \
+        GROUP_CALLBACK(callback, GRP_COMMS, comms); \
         GROUP_CALLBACK(callback, GRP_ACCOUNT, account); \
         GROUP_CALLBACK(callback, GRP_AUTO_LOAD_WORLD, autoLoad); \
         GROUP_CALLBACK(callback, GRP_AUTO_LOG, autoLog); \
@@ -565,7 +661,7 @@ void Configuration::ConnectionSettings::read(const QSettings &conf)
 }
 
 // closest well-known color is "Outer Space"
-static constexpr const std::string_view DEFAULT_BGCOLOR = "#2E3436";
+static constexpr const std::string_view DEFAULT_BGCOLOR = "#161f21";
 // closest well-known color is "Dusty Gray"
 static constexpr const std::string_view DEFAULT_DARK_COLOR = "#A19494";
 // closest well-known color is "Cold Turkey"
@@ -587,11 +683,14 @@ void Configuration::CanvasSettings::read(const QSettings &conf)
                                         .append(DEFAULT_MMAPPER_SUBDIR)
                                         .append(DEFAULT_RESOURCES_SUBDIR))
                              .toString();
+    textureSet = intToTextureSet(conf.value(KEY_TEXTURE_SET, 1).toInt()); // Default: MODERN
+    enableSeasonalTextures = conf.value(KEY_ENABLE_SEASONAL_TEXTURES, true).toBool();
     showMissingMapId.set(conf.value(KEY_SHOW_MISSING_MAP_ID, true).toBool());
     showUnsavedChanges.set(conf.value(KEY_SHOW_UNSAVED_CHANGES, true).toBool());
     showUnmappedExits.set(conf.value(KEY_DRAW_NOT_MAPPED_EXITS, true).toBool());
     drawUpperLayersTextured = conf.value(KEY_DRAW_UPPER_LAYERS_TEXTURED, false).toBool();
     drawDoorNames = conf.value(KEY_DRAW_DOOR_NAMES, true).toBool();
+    layerTransparency = conf.value(KEY_LAYER_TRANSPARENCY, 1.0).toFloat();
     backgroundColor = lookupColor(KEY_BACKGROUND_COLOR, DEFAULT_BGCOLOR);
     connectionNormalColor = lookupColor(KEY_CONNECTION_NORMAL_COLOR, Colors::white.toHex());
     roomDarkColor = lookupColor(KEY_ROOM_DARK_COLOR, DEFAULT_DARK_COLOR);
@@ -605,6 +704,30 @@ void Configuration::CanvasSettings::read(const QSettings &conf)
     advanced.verticalAngle.set(conf.value(KEY_3D_VERTICAL_ANGLE, 450).toInt());
     advanced.horizontalAngle.set(conf.value(KEY_3D_HORIZONTAL_ANGLE, 0).toInt());
     advanced.layerHeight.set(conf.value(KEY_3D_LAYER_HEIGHT, 15).toInt());
+
+    // Load background image settings
+    advanced.useBackgroundImage = conf.value(KEY_BACKGROUND_IMAGE_ENABLED, false).toBool();
+    advanced.backgroundImagePath = conf.value(KEY_BACKGROUND_IMAGE_PATH, "").toString();
+    advanced.backgroundFitMode = conf.value(KEY_BACKGROUND_IMAGE_FIT_MODE, 0).toInt();
+    advanced.backgroundOpacity = conf.value(KEY_BACKGROUND_IMAGE_OPACITY, 1.0f).toFloat();
+    advanced.backgroundFocusedScale = conf.value(KEY_BACKGROUND_IMAGE_FOCUSED_SCALE, 1.0f).toFloat();
+    advanced.backgroundFocusedOffsetX = conf.value(KEY_BACKGROUND_IMAGE_FOCUSED_OFFSET_X, 0.0f)
+                                            .toFloat();
+    advanced.backgroundFocusedOffsetY = conf.value(KEY_BACKGROUND_IMAGE_FOCUSED_OFFSET_Y, 0.0f)
+                                            .toFloat();
+
+    // Load visible markers settings
+    visibilityFilter.generic.set(conf.value(KEY_VISIBLE_MARKER_GENERIC, true).toBool());
+    visibilityFilter.herb.set(conf.value(KEY_VISIBLE_MARKER_HERB, true).toBool());
+    visibilityFilter.river.set(conf.value(KEY_VISIBLE_MARKER_RIVER, true).toBool());
+    visibilityFilter.place.set(conf.value(KEY_VISIBLE_MARKER_PLACE, true).toBool());
+    visibilityFilter.mob.set(conf.value(KEY_VISIBLE_MARKER_MOB, true).toBool());
+    visibilityFilter.comment.set(conf.value(KEY_VISIBLE_MARKER_COMMENT, true).toBool());
+    visibilityFilter.road.set(conf.value(KEY_VISIBLE_MARKER_ROAD, true).toBool());
+    visibilityFilter.object.set(conf.value(KEY_VISIBLE_MARKER_OBJECT, true).toBool());
+    visibilityFilter.action.set(conf.value(KEY_VISIBLE_MARKER_ACTION, true).toBool());
+    visibilityFilter.locality.set(conf.value(KEY_VISIBLE_MARKER_LOCALITY, true).toBool());
+    visibilityFilter.connections.set(conf.value(KEY_VISIBLE_CONNECTIONS, true).toBool());
 }
 
 void Configuration::AccountSettings::read(const QSettings &conf)
@@ -691,11 +814,15 @@ void Configuration::GroupManagerSettings::read(const QSettings &conf)
     npcSortBottom = conf.value(KEY_GROUP_NPC_SORT_BOTTOM, false).toBool();
 }
 
+Configuration::MumeClockSettings::MumeClockSettings() = default;
+
 void Configuration::MumeClockSettings::read(const QSettings &conf)
 {
     // NOTE: old values might be stored as int32
     startEpoch = conf.value(KEY_MUME_START_EPOCH, 1517443173).toLongLong();
     display = conf.value(KEY_DISPLAY_CLOCK, true).toBool();
+    gmcpBroadcast.set(conf.value(KEY_GMCP_BROADCAST_CLOCK, true).toBool());
+    gmcpBroadcastInterval.set(conf.value(KEY_GMCP_BROADCAST_INTERVAL, 2500).toInt());
 }
 
 void Configuration::AdventurePanelSettings::read(const QSettings &conf)
@@ -770,11 +897,14 @@ NODISCARD static auto getQColorName(const XNamedColor &color)
 void Configuration::CanvasSettings::write(QSettings &conf) const
 {
     conf.setValue(KEY_RESOURCES_DIRECTORY, resourcesDirectory);
+    conf.setValue(KEY_TEXTURE_SET, textureSetToInt(textureSet));
+    conf.setValue(KEY_ENABLE_SEASONAL_TEXTURES, enableSeasonalTextures);
     conf.setValue(KEY_SHOW_MISSING_MAP_ID, showMissingMapId.get());
     conf.setValue(KEY_SHOW_UNSAVED_CHANGES, showUnsavedChanges.get());
     conf.setValue(KEY_DRAW_NOT_MAPPED_EXITS, showUnmappedExits.get());
     conf.setValue(KEY_DRAW_UPPER_LAYERS_TEXTURED, drawUpperLayersTextured);
     conf.setValue(KEY_DRAW_DOOR_NAMES, drawDoorNames);
+    conf.setValue(KEY_LAYER_TRANSPARENCY, layerTransparency);
     conf.setValue(KEY_BACKGROUND_COLOR, getQColorName(backgroundColor));
     conf.setValue(KEY_ROOM_DARK_COLOR, getQColorName(roomDarkColor));
     conf.setValue(KEY_ROOM_DARK_LIT_COLOR, getQColorName(roomDarkLitColor));
@@ -788,6 +918,239 @@ void Configuration::CanvasSettings::write(QSettings &conf) const
     conf.setValue(KEY_3D_VERTICAL_ANGLE, advanced.verticalAngle.get());
     conf.setValue(KEY_3D_HORIZONTAL_ANGLE, advanced.horizontalAngle.get());
     conf.setValue(KEY_3D_LAYER_HEIGHT, advanced.layerHeight.get());
+
+    // Save background image settings
+    conf.setValue(KEY_BACKGROUND_IMAGE_ENABLED, advanced.useBackgroundImage);
+    conf.setValue(KEY_BACKGROUND_IMAGE_PATH, advanced.backgroundImagePath);
+    conf.setValue(KEY_BACKGROUND_IMAGE_FIT_MODE, advanced.backgroundFitMode);
+    conf.setValue(KEY_BACKGROUND_IMAGE_OPACITY, advanced.backgroundOpacity);
+    conf.setValue(KEY_BACKGROUND_IMAGE_FOCUSED_SCALE, advanced.backgroundFocusedScale);
+    conf.setValue(KEY_BACKGROUND_IMAGE_FOCUSED_OFFSET_X, advanced.backgroundFocusedOffsetX);
+    conf.setValue(KEY_BACKGROUND_IMAGE_FOCUSED_OFFSET_Y, advanced.backgroundFocusedOffsetY);
+
+    // Save visible markers settings
+    conf.setValue(KEY_VISIBLE_MARKER_GENERIC, visibilityFilter.generic.get());
+    conf.setValue(KEY_VISIBLE_MARKER_HERB, visibilityFilter.herb.get());
+    conf.setValue(KEY_VISIBLE_MARKER_RIVER, visibilityFilter.river.get());
+    conf.setValue(KEY_VISIBLE_MARKER_PLACE, visibilityFilter.place.get());
+    conf.setValue(KEY_VISIBLE_MARKER_MOB, visibilityFilter.mob.get());
+    conf.setValue(KEY_VISIBLE_MARKER_COMMENT, visibilityFilter.comment.get());
+    conf.setValue(KEY_VISIBLE_MARKER_ROAD, visibilityFilter.road.get());
+    conf.setValue(KEY_VISIBLE_MARKER_OBJECT, visibilityFilter.object.get());
+    conf.setValue(KEY_VISIBLE_MARKER_ACTION, visibilityFilter.action.get());
+    conf.setValue(KEY_VISIBLE_MARKER_LOCALITY, visibilityFilter.locality.get());
+    conf.setValue(KEY_VISIBLE_CONNECTIONS, visibilityFilter.connections.get());
+}
+
+void Configuration::Hotkeys::read(const QSettings &conf)
+{
+    // File operations
+    fileOpen.set(conf.value(KEY_HOTKEY_FILE_OPEN, "Ctrl+O").toString());
+    fileSave.set(conf.value(KEY_HOTKEY_FILE_SAVE, "Ctrl+S").toString());
+    fileReload.set(conf.value(KEY_HOTKEY_FILE_RELOAD, "Ctrl+R").toString());
+    fileQuit.set(conf.value(KEY_HOTKEY_FILE_QUIT, "Ctrl+Q").toString());
+
+    // Edit operations
+    editUndo.set(conf.value(KEY_HOTKEY_EDIT_UNDO, "Ctrl+Z").toString());
+    editRedo.set(conf.value(KEY_HOTKEY_EDIT_REDO, "Ctrl+Y").toString());
+    editPreferences.set(conf.value(KEY_HOTKEY_EDIT_PREFERENCES, "Ctrl+P").toString());
+    editPreferencesAlt.set(conf.value(KEY_HOTKEY_EDIT_PREFERENCES_ALT, "Esc").toString());
+    editFindRooms.set(conf.value(KEY_HOTKEY_EDIT_FIND_ROOMS, "Ctrl+F").toString());
+    editRoom.set(conf.value(KEY_HOTKEY_EDIT_ROOM, "Ctrl+E").toString());
+
+    // View operations
+    viewZoomIn.set(conf.value(KEY_HOTKEY_VIEW_ZOOM_IN, "").toString());
+    viewZoomOut.set(conf.value(KEY_HOTKEY_VIEW_ZOOM_OUT, "").toString());
+    viewZoomReset.set(conf.value(KEY_HOTKEY_VIEW_ZOOM_RESET, "Ctrl+0").toString());
+    viewLayerUp.set(conf.value(KEY_HOTKEY_VIEW_LAYER_UP, "").toString());
+    viewLayerDown.set(conf.value(KEY_HOTKEY_VIEW_LAYER_DOWN, "").toString());
+    viewLayerReset.set(conf.value(KEY_HOTKEY_VIEW_LAYER_RESET, "").toString());
+
+    // View toggles
+    viewRadialTransparency.set(conf.value(KEY_HOTKEY_VIEW_RADIAL_TRANSPARENCY, "").toString());
+    viewStatusBar.set(conf.value(KEY_HOTKEY_VIEW_STATUS_BAR, "").toString());
+    viewScrollBars.set(conf.value(KEY_HOTKEY_VIEW_SCROLL_BARS, "").toString());
+    viewMenuBar.set(conf.value(KEY_HOTKEY_VIEW_MENU_BAR, "").toString());
+    viewAlwaysOnTop.set(conf.value(KEY_HOTKEY_VIEW_ALWAYS_ON_TOP, "").toString());
+
+    // Side panels
+    panelLog.set(conf.value(KEY_HOTKEY_PANEL_LOG, "Ctrl+L").toString());
+    panelClient.set(conf.value(KEY_HOTKEY_PANEL_CLIENT, "").toString());
+    panelGroup.set(conf.value(KEY_HOTKEY_PANEL_GROUP, "").toString());
+    panelRoom.set(conf.value(KEY_HOTKEY_PANEL_ROOM, "").toString());
+    panelAdventure.set(conf.value(KEY_HOTKEY_PANEL_ADVENTURE, "").toString());
+    panelComms.set(conf.value(KEY_HOTKEY_PANEL_COMMS, "").toString());
+    panelDescription.set(conf.value(KEY_HOTKEY_PANEL_DESCRIPTION, "").toString());
+
+    // Mouse modes
+    modeMoveMap.set(conf.value(KEY_HOTKEY_MODE_MOVE_MAP, "").toString());
+    modeRaypick.set(conf.value(KEY_HOTKEY_MODE_RAYPICK, "").toString());
+    modeSelectRooms.set(conf.value(KEY_HOTKEY_MODE_SELECT_ROOMS, "").toString());
+    modeSelectMarkers.set(conf.value(KEY_HOTKEY_MODE_SELECT_MARKERS, "").toString());
+    modeSelectConnection.set(conf.value(KEY_HOTKEY_MODE_SELECT_CONNECTION, "").toString());
+    modeCreateMarker.set(conf.value(KEY_HOTKEY_MODE_CREATE_MARKER, "").toString());
+    modeCreateRoom.set(conf.value(KEY_HOTKEY_MODE_CREATE_ROOM, "").toString());
+    modeCreateConnection.set(conf.value(KEY_HOTKEY_MODE_CREATE_CONNECTION, "").toString());
+    modeCreateOnewayConnection.set(
+        conf.value(KEY_HOTKEY_MODE_CREATE_ONEWAY_CONNECTION, "").toString());
+
+    // Room operations
+    roomCreate.set(conf.value(KEY_HOTKEY_ROOM_CREATE, "").toString());
+    roomMoveUp.set(conf.value(KEY_HOTKEY_ROOM_MOVE_UP, "").toString());
+    roomMoveDown.set(conf.value(KEY_HOTKEY_ROOM_MOVE_DOWN, "").toString());
+    roomMergeUp.set(conf.value(KEY_HOTKEY_ROOM_MERGE_UP, "").toString());
+    roomMergeDown.set(conf.value(KEY_HOTKEY_ROOM_MERGE_DOWN, "").toString());
+    roomDelete.set(conf.value(KEY_HOTKEY_ROOM_DELETE, "Del").toString());
+    roomConnectNeighbors.set(conf.value(KEY_HOTKEY_ROOM_CONNECT_NEIGHBORS, "").toString());
+    roomMoveToSelected.set(conf.value(KEY_HOTKEY_ROOM_MOVE_TO_SELECTED, "").toString());
+    roomUpdateSelected.set(conf.value(KEY_HOTKEY_ROOM_UPDATE_SELECTED, "").toString());
+}
+
+void Configuration::Hotkeys::write(QSettings &conf) const
+{
+    // File operations
+    conf.setValue(KEY_HOTKEY_FILE_OPEN, fileOpen.get());
+    conf.setValue(KEY_HOTKEY_FILE_SAVE, fileSave.get());
+    conf.setValue(KEY_HOTKEY_FILE_RELOAD, fileReload.get());
+    conf.setValue(KEY_HOTKEY_FILE_QUIT, fileQuit.get());
+
+    // Edit operations
+    conf.setValue(KEY_HOTKEY_EDIT_UNDO, editUndo.get());
+    conf.setValue(KEY_HOTKEY_EDIT_REDO, editRedo.get());
+    conf.setValue(KEY_HOTKEY_EDIT_PREFERENCES, editPreferences.get());
+    conf.setValue(KEY_HOTKEY_EDIT_PREFERENCES_ALT, editPreferencesAlt.get());
+    conf.setValue(KEY_HOTKEY_EDIT_FIND_ROOMS, editFindRooms.get());
+    conf.setValue(KEY_HOTKEY_EDIT_ROOM, editRoom.get());
+
+    // View operations
+    conf.setValue(KEY_HOTKEY_VIEW_ZOOM_IN, viewZoomIn.get());
+    conf.setValue(KEY_HOTKEY_VIEW_ZOOM_OUT, viewZoomOut.get());
+    conf.setValue(KEY_HOTKEY_VIEW_ZOOM_RESET, viewZoomReset.get());
+    conf.setValue(KEY_HOTKEY_VIEW_LAYER_UP, viewLayerUp.get());
+    conf.setValue(KEY_HOTKEY_VIEW_LAYER_DOWN, viewLayerDown.get());
+    conf.setValue(KEY_HOTKEY_VIEW_LAYER_RESET, viewLayerReset.get());
+
+    // View toggles
+    conf.setValue(KEY_HOTKEY_VIEW_RADIAL_TRANSPARENCY, viewRadialTransparency.get());
+    conf.setValue(KEY_HOTKEY_VIEW_STATUS_BAR, viewStatusBar.get());
+    conf.setValue(KEY_HOTKEY_VIEW_SCROLL_BARS, viewScrollBars.get());
+    conf.setValue(KEY_HOTKEY_VIEW_MENU_BAR, viewMenuBar.get());
+    conf.setValue(KEY_HOTKEY_VIEW_ALWAYS_ON_TOP, viewAlwaysOnTop.get());
+
+    // Side panels
+    conf.setValue(KEY_HOTKEY_PANEL_LOG, panelLog.get());
+    conf.setValue(KEY_HOTKEY_PANEL_CLIENT, panelClient.get());
+    conf.setValue(KEY_HOTKEY_PANEL_GROUP, panelGroup.get());
+    conf.setValue(KEY_HOTKEY_PANEL_ROOM, panelRoom.get());
+    conf.setValue(KEY_HOTKEY_PANEL_ADVENTURE, panelAdventure.get());
+    conf.setValue(KEY_HOTKEY_PANEL_COMMS, panelComms.get());
+    conf.setValue(KEY_HOTKEY_PANEL_DESCRIPTION, panelDescription.get());
+
+    // Mouse modes
+    conf.setValue(KEY_HOTKEY_MODE_MOVE_MAP, modeMoveMap.get());
+    conf.setValue(KEY_HOTKEY_MODE_RAYPICK, modeRaypick.get());
+    conf.setValue(KEY_HOTKEY_MODE_SELECT_ROOMS, modeSelectRooms.get());
+    conf.setValue(KEY_HOTKEY_MODE_SELECT_MARKERS, modeSelectMarkers.get());
+    conf.setValue(KEY_HOTKEY_MODE_SELECT_CONNECTION, modeSelectConnection.get());
+    conf.setValue(KEY_HOTKEY_MODE_CREATE_MARKER, modeCreateMarker.get());
+    conf.setValue(KEY_HOTKEY_MODE_CREATE_ROOM, modeCreateRoom.get());
+    conf.setValue(KEY_HOTKEY_MODE_CREATE_CONNECTION, modeCreateConnection.get());
+    conf.setValue(KEY_HOTKEY_MODE_CREATE_ONEWAY_CONNECTION, modeCreateOnewayConnection.get());
+
+    // Room operations
+    conf.setValue(KEY_HOTKEY_ROOM_CREATE, roomCreate.get());
+    conf.setValue(KEY_HOTKEY_ROOM_MOVE_UP, roomMoveUp.get());
+    conf.setValue(KEY_HOTKEY_ROOM_MOVE_DOWN, roomMoveDown.get());
+    conf.setValue(KEY_HOTKEY_ROOM_MERGE_UP, roomMergeUp.get());
+    conf.setValue(KEY_HOTKEY_ROOM_MERGE_DOWN, roomMergeDown.get());
+    conf.setValue(KEY_HOTKEY_ROOM_DELETE, roomDelete.get());
+    conf.setValue(KEY_HOTKEY_ROOM_CONNECT_NEIGHBORS, roomConnectNeighbors.get());
+    conf.setValue(KEY_HOTKEY_ROOM_MOVE_TO_SELECTED, roomMoveToSelected.get());
+    conf.setValue(KEY_HOTKEY_ROOM_UPDATE_SELECTED, roomUpdateSelected.get());
+}
+
+void Configuration::CommsSettings::read(const QSettings &conf)
+{
+    // Communication colors
+    tellColor.set(conf.value(tellColor.getName(), QColor(32, 108, 9)).value<QColor>());
+    whisperColor.set(conf.value(whisperColor.getName(), QColor(103, 135, 149)).value<QColor>());
+    groupColor.set(conf.value(groupColor.getName(), QColor(15, 123, 255)).value<QColor>());
+    askColor.set(conf.value(askColor.getName(), QColor(Qt::yellow)).value<QColor>());
+    sayColor.set(conf.value(sayColor.getName(), QColor(80, 173, 199)).value<QColor>());
+    emoteColor.set(conf.value(emoteColor.getName(), QColor(203, 37, 111)).value<QColor>());
+    socialColor.set(conf.value(socialColor.getName(), QColor(217, 140, 151)).value<QColor>());
+    yellColor.set(conf.value(yellColor.getName(), QColor(176, 80, 189)).value<QColor>());
+    narrateColor.set(conf.value(narrateColor.getName(), QColor(119, 197, 203)).value<QColor>());
+    prayColor.set(conf.value(prayColor.getName(), QColor(173, 216, 230)).value<QColor>());
+    shoutColor.set(conf.value(shoutColor.getName(), QColor(160, 9, 198)).value<QColor>());
+    singColor.set(conf.value(singColor.getName(), QColor(144, 238, 144)).value<QColor>());
+    backgroundColor.set(conf.value(backgroundColor.getName(), QColor(22, 31, 33)).value<QColor>());
+
+    // Font styling options
+    yellAllCaps.set(conf.value(yellAllCaps.getName(), true).toBool());
+    whisperItalic.set(conf.value(whisperItalic.getName(), true).toBool());
+    emoteItalic.set(conf.value(emoteItalic.getName(), true).toBool());
+
+    // Display options
+    showTimestamps.set(conf.value(showTimestamps.getName(), false).toBool());
+    saveLogOnExit.set(conf.value(saveLogOnExit.getName(), false).toBool());
+    logDirectory.set(conf.value(logDirectory.getName(), QString("")).toString());
+
+    // Talker colors
+    talkerYouColor.set(conf.value(talkerYouColor.getName(), QColor(228, 250, 255)).value<QColor>());
+    talkerPlayerColor.set(
+        conf.value(talkerPlayerColor.getName(), QColor(255, 187, 16)).value<QColor>());
+    talkerNpcColor.set(conf.value(talkerNpcColor.getName(), QColor(25, 138, 23)).value<QColor>());
+    talkerAllyColor.set(conf.value(talkerAllyColor.getName(), QColor(33, 166, 255)).value<QColor>());
+    talkerNeutralColor.set(
+        conf.value(talkerNeutralColor.getName(), QColor(166, 168, 168)).value<QColor>());
+    talkerEnemyColor.set(conf.value(talkerEnemyColor.getName(), QColor(173, 7, 37)).value<QColor>());
+
+    // Tab muting (filters)
+    muteDirectTab.set(conf.value(muteDirectTab.getName(), false).toBool());
+    muteLocalTab.set(conf.value(muteLocalTab.getName(), false).toBool());
+    muteGlobalTab.set(conf.value(muteGlobalTab.getName(), false).toBool());
+}
+
+void Configuration::CommsSettings::write(QSettings &conf) const
+{
+    // Communication colors
+    conf.setValue(tellColor.getName(), tellColor.get());
+    conf.setValue(whisperColor.getName(), whisperColor.get());
+    conf.setValue(groupColor.getName(), groupColor.get());
+    conf.setValue(askColor.getName(), askColor.get());
+    conf.setValue(sayColor.getName(), sayColor.get());
+    conf.setValue(emoteColor.getName(), emoteColor.get());
+    conf.setValue(socialColor.getName(), socialColor.get());
+    conf.setValue(yellColor.getName(), yellColor.get());
+    conf.setValue(narrateColor.getName(), narrateColor.get());
+    conf.setValue(prayColor.getName(), prayColor.get());
+    conf.setValue(shoutColor.getName(), shoutColor.get());
+    conf.setValue(singColor.getName(), singColor.get());
+    conf.setValue(backgroundColor.getName(), backgroundColor.get());
+
+    // Font styling options
+    conf.setValue(yellAllCaps.getName(), yellAllCaps.get());
+    conf.setValue(whisperItalic.getName(), whisperItalic.get());
+    conf.setValue(emoteItalic.getName(), emoteItalic.get());
+
+    // Display options
+    conf.setValue(showTimestamps.getName(), showTimestamps.get());
+    conf.setValue(saveLogOnExit.getName(), saveLogOnExit.get());
+    conf.setValue(logDirectory.getName(), logDirectory.get());
+
+    // Talker colors
+    conf.setValue(talkerYouColor.getName(), talkerYouColor.get());
+    conf.setValue(talkerPlayerColor.getName(), talkerPlayerColor.get());
+    conf.setValue(talkerNpcColor.getName(), talkerNpcColor.get());
+    conf.setValue(talkerAllyColor.getName(), talkerAllyColor.get());
+    conf.setValue(talkerNeutralColor.getName(), talkerNeutralColor.get());
+    conf.setValue(talkerEnemyColor.getName(), talkerEnemyColor.get());
+
+    // Tab muting (filters)
+    conf.setValue(muteDirectTab.getName(), muteDirectTab.get());
+    conf.setValue(muteLocalTab.getName(), muteLocalTab.get());
+    conf.setValue(muteGlobalTab.getName(), muteGlobalTab.get());
 }
 
 void Configuration::AccountSettings::write(QSettings &conf) const
@@ -862,6 +1225,8 @@ void Configuration::MumeClockSettings::write(QSettings &conf) const
     // Note: There's no QVariant(int64_t) constructor.
     conf.setValue(KEY_MUME_START_EPOCH, static_cast<qlonglong>(startEpoch));
     conf.setValue(KEY_DISPLAY_CLOCK, display);
+    conf.setValue(KEY_GMCP_BROADCAST_CLOCK, gmcpBroadcast.get());
+    conf.setValue(KEY_GMCP_BROADCAST_INTERVAL, gmcpBroadcastInterval.get());
 }
 
 void Configuration::AdventurePanelSettings::write(QSettings &conf) const
@@ -992,6 +1357,118 @@ void Configuration::CanvasSettings::Advanced::registerChangeCallback(
     verticalAngle.registerChangeCallback(lifetime, callback);
     horizontalAngle.registerChangeCallback(lifetime, callback);
     layerHeight.registerChangeCallback(lifetime, callback);
+}
+
+Configuration::CanvasSettings::VisibilityFilter::VisibilityFilter() = default;
+
+bool Configuration::CanvasSettings::VisibilityFilter::isVisible(InfomarkClassEnum markerClass) const
+{
+    switch (markerClass) {
+    case InfomarkClassEnum::GENERIC:
+        return generic.get();
+    case InfomarkClassEnum::HERB:
+        return herb.get();
+    case InfomarkClassEnum::RIVER:
+        return river.get();
+    case InfomarkClassEnum::PLACE:
+        return place.get();
+    case InfomarkClassEnum::MOB:
+        return mob.get();
+    case InfomarkClassEnum::COMMENT:
+        return comment.get();
+    case InfomarkClassEnum::ROAD:
+        return road.get();
+    case InfomarkClassEnum::OBJECT:
+        return object.get();
+    case InfomarkClassEnum::ACTION:
+        return action.get();
+    case InfomarkClassEnum::LOCALITY:
+        return locality.get();
+    }
+    return true; // Default to visible for unknown types
+}
+
+void Configuration::CanvasSettings::VisibilityFilter::setVisible(InfomarkClassEnum markerClass,
+                                                                 bool visible)
+{
+    switch (markerClass) {
+    case InfomarkClassEnum::GENERIC:
+        generic.set(visible);
+        break;
+    case InfomarkClassEnum::HERB:
+        herb.set(visible);
+        break;
+    case InfomarkClassEnum::RIVER:
+        river.set(visible);
+        break;
+    case InfomarkClassEnum::PLACE:
+        place.set(visible);
+        break;
+    case InfomarkClassEnum::MOB:
+        mob.set(visible);
+        break;
+    case InfomarkClassEnum::COMMENT:
+        comment.set(visible);
+        break;
+    case InfomarkClassEnum::ROAD:
+        road.set(visible);
+        break;
+    case InfomarkClassEnum::OBJECT:
+        object.set(visible);
+        break;
+    case InfomarkClassEnum::ACTION:
+        action.set(visible);
+        break;
+    case InfomarkClassEnum::LOCALITY:
+        locality.set(visible);
+        break;
+    }
+}
+
+void Configuration::CanvasSettings::VisibilityFilter::showAll()
+{
+    generic.set(true);
+    herb.set(true);
+    river.set(true);
+    place.set(true);
+    mob.set(true);
+    comment.set(true);
+    road.set(true);
+    object.set(true);
+    action.set(true);
+    locality.set(true);
+    connections.set(true);
+}
+
+void Configuration::CanvasSettings::VisibilityFilter::hideAll()
+{
+    generic.set(false);
+    herb.set(false);
+    river.set(false);
+    place.set(false);
+    mob.set(false);
+    comment.set(false);
+    road.set(false);
+    object.set(false);
+    action.set(false);
+    locality.set(false);
+    connections.set(false);
+}
+
+void Configuration::CanvasSettings::VisibilityFilter::registerChangeCallback(
+    const ChangeMonitor::Lifetime &lifetime, const ChangeMonitor::Function &callback)
+{
+    generic.registerChangeCallback(lifetime, callback);
+    herb.registerChangeCallback(lifetime, callback);
+    river.registerChangeCallback(lifetime, callback);
+    place.registerChangeCallback(lifetime, callback);
+    mob.registerChangeCallback(lifetime, callback);
+    comment.registerChangeCallback(lifetime, callback);
+    road.registerChangeCallback(lifetime, callback);
+    object.registerChangeCallback(lifetime, callback);
+    action.registerChangeCallback(lifetime, callback);
+    locality.registerChangeCallback(lifetime, callback);
+    connections.registerChangeCallback(lifetime, callback);
 }
 
 void setEnteredMain()

--- a/src/configuration/configuration.h
+++ b/src/configuration/configuration.h
@@ -29,6 +29,9 @@
 
 #undef TRANSPARENT // Bad dog, Microsoft; bad dog!!!
 
+// Forward declaration for InfomarkClassEnum
+enum class InfomarkClassEnum : uint8_t;
+
 #define SUBGROUP() \
     friend class Configuration; \
     void read(const QSettings &conf); \
@@ -79,6 +82,7 @@ public:
         char prefixChar = char_consts::C_UNDERSCORE;
         bool encodeEmoji = true;
         bool decodeEmoji = true;
+        bool enableYellFallbackParsing = true; // Parse yells from game text when GMCP unavailable
 
     private:
         SUBGROUP();
@@ -143,6 +147,10 @@ public:
         bool trilinearFiltering = false;
         bool softwareOpenGL = false;
         QString resourcesDirectory;
+        TextureSetEnum textureSet = TextureSetEnum::MODERN;
+        bool enableSeasonalTextures = true;
+        float layerTransparency = 1.0f;  // 0.0 = only focused layer, 1.0 = maximum transparency
+        bool enableRadialTransparency = true;  // Enable radial transparency zones on upper layers
 
         // not saved yet:
         bool drawCharBeacons = true;
@@ -159,12 +167,21 @@ public:
             NamedConfig<bool> autoTilt{"MMAPPER_AUTO_TILT", true};
             NamedConfig<bool> printPerfStats{"MMAPPER_GL_PERFSTATS", IS_DEBUG_BUILD};
 
+            // Background image settings
+            bool useBackgroundImage = false;
+            QString backgroundImagePath;
+            int backgroundFitMode = 0;  // BackgroundFitModeEnum::FIT
+            float backgroundOpacity = 1.0f;
+            float backgroundFocusedScale = 1.0f;  // Scale factor for FOCUSED mode (0.1 to 10.0)
+            float backgroundFocusedOffsetX = 0.0f;  // X offset for FOCUSED mode (-1000 to 1000)
+            float backgroundFocusedOffsetY = 0.0f;  // Y offset for FOCUSED mode (-1000 to 1000)
+
             // 5..90 degrees
             FixedPoint<1> fov{50, 900, 765};
             // 0..90 degrees
             FixedPoint<1> verticalAngle{0, 900, 450};
-            // -45..45 degrees
-            FixedPoint<1> horizontalAngle{-450, 450, 0};
+            // -180..180 degrees (full rotation)
+            FixedPoint<1> horizontalAngle{-1800, 1800, 0};
             // 1..10 rooms
             FixedPoint<1> layerHeight{10, 100, 15};
 
@@ -175,9 +192,146 @@ public:
             Advanced();
         } advanced;
 
+        struct NODISCARD VisibilityFilter final
+        {
+            NamedConfig<bool> generic{"VISIBLE_MARKER_GENERIC", true};
+            NamedConfig<bool> herb{"VISIBLE_MARKER_HERB", true};
+            NamedConfig<bool> river{"VISIBLE_MARKER_RIVER", true};
+            NamedConfig<bool> place{"VISIBLE_MARKER_PLACE", true};
+            NamedConfig<bool> mob{"VISIBLE_MARKER_MOB", true};
+            NamedConfig<bool> comment{"VISIBLE_MARKER_COMMENT", true};
+            NamedConfig<bool> road{"VISIBLE_MARKER_ROAD", true};
+            NamedConfig<bool> object{"VISIBLE_MARKER_OBJECT", true};
+            NamedConfig<bool> action{"VISIBLE_MARKER_ACTION", true};
+            NamedConfig<bool> locality{"VISIBLE_MARKER_LOCALITY", true};
+            NamedConfig<bool> connections{"VISIBLE_CONNECTIONS", true};
+
+        public:
+            NODISCARD bool isVisible(InfomarkClassEnum markerClass) const;
+            void setVisible(InfomarkClassEnum markerClass, bool visible);
+            NODISCARD bool isConnectionsVisible() const { return connections.get(); }
+            void setConnectionsVisible(bool visible) { connections.set(visible); }
+            void showAll();
+            void hideAll();
+            void registerChangeCallback(const ChangeMonitor::Lifetime &lifetime,
+                                       const ChangeMonitor::Function &callback);
+
+            VisibilityFilter();
+        } visibilityFilter;
+
     private:
         SUBGROUP();
     } canvas;
+
+    struct NODISCARD Hotkeys final
+    {
+        // File operations
+        NamedConfig<QString> fileOpen{"HOTKEY_FILE_OPEN", "Ctrl+O"};
+        NamedConfig<QString> fileSave{"HOTKEY_FILE_SAVE", "Ctrl+S"};
+        NamedConfig<QString> fileReload{"HOTKEY_FILE_RELOAD", "Ctrl+R"};
+        NamedConfig<QString> fileQuit{"HOTKEY_FILE_QUIT", "Ctrl+Q"};
+
+        // Edit operations
+        NamedConfig<QString> editUndo{"HOTKEY_EDIT_UNDO", "Ctrl+Z"};
+        NamedConfig<QString> editRedo{"HOTKEY_EDIT_REDO", "Ctrl+Y"};
+        NamedConfig<QString> editPreferences{"HOTKEY_EDIT_PREFERENCES", "Ctrl+P"};
+        NamedConfig<QString> editPreferencesAlt{"HOTKEY_EDIT_PREFERENCES_ALT", "Esc"};
+        NamedConfig<QString> editFindRooms{"HOTKEY_EDIT_FIND_ROOMS", "Ctrl+F"};
+        NamedConfig<QString> editRoom{"HOTKEY_EDIT_ROOM", "Ctrl+E"};
+
+        // View operations
+        NamedConfig<QString> viewZoomIn{"HOTKEY_VIEW_ZOOM_IN", ""};
+        NamedConfig<QString> viewZoomOut{"HOTKEY_VIEW_ZOOM_OUT", ""};
+        NamedConfig<QString> viewZoomReset{"HOTKEY_VIEW_ZOOM_RESET", "Ctrl+0"};
+        NamedConfig<QString> viewLayerUp{"HOTKEY_VIEW_LAYER_UP", ""};
+        NamedConfig<QString> viewLayerDown{"HOTKEY_VIEW_LAYER_DOWN", ""};
+        NamedConfig<QString> viewLayerReset{"HOTKEY_VIEW_LAYER_RESET", ""};
+
+        // View toggles
+        NamedConfig<QString> viewRadialTransparency{"HOTKEY_VIEW_RADIAL_TRANSPARENCY", ""};
+        NamedConfig<QString> viewStatusBar{"HOTKEY_VIEW_STATUS_BAR", ""};
+        NamedConfig<QString> viewScrollBars{"HOTKEY_VIEW_SCROLL_BARS", ""};
+        NamedConfig<QString> viewMenuBar{"HOTKEY_VIEW_MENU_BAR", ""};
+        NamedConfig<QString> viewAlwaysOnTop{"HOTKEY_VIEW_ALWAYS_ON_TOP", ""};
+
+        // Side panels
+        NamedConfig<QString> panelLog{"HOTKEY_PANEL_LOG", "Ctrl+L"};
+        NamedConfig<QString> panelClient{"HOTKEY_PANEL_CLIENT", ""};
+        NamedConfig<QString> panelGroup{"HOTKEY_PANEL_GROUP", ""};
+        NamedConfig<QString> panelRoom{"HOTKEY_PANEL_ROOM", ""};
+        NamedConfig<QString> panelAdventure{"HOTKEY_PANEL_ADVENTURE", ""};
+        NamedConfig<QString> panelDescription{"HOTKEY_PANEL_DESCRIPTION", ""};
+        NamedConfig<QString> panelComms{"HOTKEY_PANEL_COMMS", ""};
+
+        // Mouse modes
+        NamedConfig<QString> modeMoveMap{"HOTKEY_MODE_MOVE_MAP", ""};
+        NamedConfig<QString> modeRaypick{"HOTKEY_MODE_RAYPICK", ""};
+        NamedConfig<QString> modeSelectRooms{"HOTKEY_MODE_SELECT_ROOMS", ""};
+        NamedConfig<QString> modeSelectMarkers{"HOTKEY_MODE_SELECT_MARKERS", ""};
+        NamedConfig<QString> modeSelectConnection{"HOTKEY_MODE_SELECT_CONNECTION", ""};
+        NamedConfig<QString> modeCreateMarker{"HOTKEY_MODE_CREATE_MARKER", ""};
+        NamedConfig<QString> modeCreateRoom{"HOTKEY_MODE_CREATE_ROOM", ""};
+        NamedConfig<QString> modeCreateConnection{"HOTKEY_MODE_CREATE_CONNECTION", ""};
+        NamedConfig<QString> modeCreateOnewayConnection{"HOTKEY_MODE_CREATE_ONEWAY_CONNECTION", ""};
+
+        // Room operations
+        NamedConfig<QString> roomCreate{"HOTKEY_ROOM_CREATE", ""};
+        NamedConfig<QString> roomMoveUp{"HOTKEY_ROOM_MOVE_UP", ""};
+        NamedConfig<QString> roomMoveDown{"HOTKEY_ROOM_MOVE_DOWN", ""};
+        NamedConfig<QString> roomMergeUp{"HOTKEY_ROOM_MERGE_UP", ""};
+        NamedConfig<QString> roomMergeDown{"HOTKEY_ROOM_MERGE_DOWN", ""};
+        NamedConfig<QString> roomDelete{"HOTKEY_ROOM_DELETE", "Del"};
+        NamedConfig<QString> roomConnectNeighbors{"HOTKEY_ROOM_CONNECT_NEIGHBORS", ""};
+        NamedConfig<QString> roomMoveToSelected{"HOTKEY_ROOM_MOVE_TO_SELECTED", ""};
+        NamedConfig<QString> roomUpdateSelected{"HOTKEY_ROOM_UPDATE_SELECTED", ""};
+
+    private:
+        SUBGROUP();
+    } hotkeys;
+
+    struct NODISCARD CommsSettings final
+    {
+        // Colors for each communication type
+        NamedConfig<QColor> tellColor{"COMMS_TELL_COLOR", QColor(Qt::cyan)};
+        NamedConfig<QColor> whisperColor{"COMMS_WHISPER_COLOR", QColor(135, 206, 250)};  // Light sky blue
+        NamedConfig<QColor> groupColor{"COMMS_GROUP_COLOR", QColor(Qt::green)};
+        NamedConfig<QColor> askColor{"COMMS_ASK_COLOR", QColor(Qt::yellow)};
+        NamedConfig<QColor> sayColor{"COMMS_SAY_COLOR", QColor(Qt::white)};
+        NamedConfig<QColor> emoteColor{"COMMS_EMOTE_COLOR", QColor(Qt::magenta)};
+        NamedConfig<QColor> socialColor{"COMMS_SOCIAL_COLOR", QColor(255, 182, 193)};  // Light pink
+        NamedConfig<QColor> yellColor{"COMMS_YELL_COLOR", QColor(Qt::red)};
+        NamedConfig<QColor> narrateColor{"COMMS_NARRATE_COLOR", QColor(255, 165, 0)};  // Orange
+        NamedConfig<QColor> prayColor{"COMMS_PRAY_COLOR", QColor(173, 216, 230)};  // Light blue
+        NamedConfig<QColor> shoutColor{"COMMS_SHOUT_COLOR", QColor(139, 0, 0)};  // Dark red
+        NamedConfig<QColor> singColor{"COMMS_SING_COLOR", QColor(144, 238, 144)};  // Light green
+        NamedConfig<QColor> backgroundColor{"COMMS_BG_COLOR", QColor(Qt::black)};
+
+        // Talker colors (based on GMCP Comm.Channel talker-type)
+        NamedConfig<QColor> talkerYouColor{"COMMS_TALKER_YOU_COLOR", QColor(255, 215, 0)};  // Gold
+        NamedConfig<QColor> talkerPlayerColor{"COMMS_TALKER_PLAYER_COLOR", QColor(Qt::white)};
+        NamedConfig<QColor> talkerNpcColor{"COMMS_TALKER_NPC_COLOR", QColor(192, 192, 192)};  // Silver/Gray
+        NamedConfig<QColor> talkerAllyColor{"COMMS_TALKER_ALLY_COLOR", QColor(0, 255, 0)};  // Bright green
+        NamedConfig<QColor> talkerNeutralColor{"COMMS_TALKER_NEUTRAL_COLOR", QColor(255, 255, 0)};  // Yellow
+        NamedConfig<QColor> talkerEnemyColor{"COMMS_TALKER_ENEMY_COLOR", QColor(255, 0, 0)};  // Red
+
+        // Font styling options
+        NamedConfig<bool> yellAllCaps{"COMMS_YELL_ALL_CAPS", true};
+        NamedConfig<bool> whisperItalic{"COMMS_WHISPER_ITALIC", true};
+        NamedConfig<bool> emoteItalic{"COMMS_EMOTE_ITALIC", true};
+
+        // Display options
+        NamedConfig<bool> showTimestamps{"COMMS_SHOW_TIMESTAMPS", false};
+        NamedConfig<bool> saveLogOnExit{"COMMS_SAVE_LOG_ON_EXIT", false};
+        NamedConfig<QString> logDirectory{"COMMS_LOG_DIR", ""};
+
+        // Tab muting (acts as a filter)
+        NamedConfig<bool> muteDirectTab{"COMMS_MUTE_DIRECT", false};
+        NamedConfig<bool> muteLocalTab{"COMMS_MUTE_LOCAL", false};
+        NamedConfig<bool> muteGlobalTab{"COMMS_MUTE_GLOBAL", false};
+
+    private:
+        SUBGROUP();
+    } comms;
 
 #define XFOREACH_NAMED_COLOR_OPTIONS(X) \
     X(BACKGROUND, BACKGROUND_NAME) \
@@ -300,6 +454,10 @@ public:
     {
         int64_t startEpoch = 0;
         bool display = false;
+        NamedConfig<bool> gmcpBroadcast{"GMCP_BROADCAST_CLOCK", true};  // Enable GMCP clock broadcasting
+        NamedConfig<int> gmcpBroadcastInterval{"GMCP_BROADCAST_INTERVAL", 2500};  // Update interval in milliseconds (default: 2.5 seconds = 1 MUME minute)
+
+        MumeClockSettings();
 
     private:
         SUBGROUP();

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -34,6 +34,8 @@ class AdventureTracker;
 class AdventureWidget;
 class AutoLogger;
 class ClientWidget;
+class CommsManager;
+class CommsWidget;
 class ConfigDialog;
 class ConnectionListener;
 class ConnectionSelection;
@@ -66,6 +68,7 @@ class RoomSelection;
 class RoomWidget;
 class UpdateDialog;
 class DescriptionWidget;
+class VisibilityFilterWidget;
 
 struct MapLoadData;
 
@@ -85,6 +88,8 @@ private:
     QDockWidget *m_dockDialogGroup = nullptr;
     QDockWidget *m_dockDialogAdventure = nullptr;
     QDockWidget *m_dockDialogDescription = nullptr;
+    QDockWidget *m_dockDialogComms = nullptr;
+    QDockWidget *m_dockDialogVisibleMarkers = nullptr;
 
     std::unique_ptr<GameObserver> m_gameObserver;
     AutoLogger *m_logger = nullptr;
@@ -108,7 +113,11 @@ private:
     AdventureTracker *m_adventureTracker = nullptr;
     AdventureWidget *m_adventureWidget = nullptr;
 
+    CommsManager *m_commsManager = nullptr;
+    CommsWidget *m_commsWidget = nullptr;
+
     DescriptionWidget *m_descriptionWidget = nullptr;
+    VisibilityFilterWidget *m_visibilityFilterWidget = nullptr;
 
     SharedRoomSelection m_roomSelection;
     std::shared_ptr<ConnectionSelection> m_connectionSelection;
@@ -166,6 +175,7 @@ private:
     QAction *zoomOutAct = nullptr;
     QAction *zoomResetAct = nullptr;
     QAction *alwaysOnTopAct = nullptr;
+    QAction *radialTransparencyAct = nullptr;
     QAction *showStatusBarAct = nullptr;
     QAction *showScrollBarsAct = nullptr;
     QAction *showMenuBarAct = nullptr;
@@ -222,6 +232,7 @@ private:
 
     QAction *clientAct = nullptr;
     QAction *saveLogAct = nullptr;
+    QAction *saveCommsLogAct = nullptr;
 
     QAction *gotoRoomAct = nullptr;
     QAction *forceRoomAct = nullptr;
@@ -304,6 +315,8 @@ private:
     void setupMenuBar();
     void setupToolBars();
     void setupStatusBar();
+    void applyHotkeys();
+    void registerGlobalShortcuts();
 
     void readSettings();
     void writeSettings();
@@ -432,6 +445,7 @@ public slots:
     void slot_onOfflineMode();
     void slot_setMode(MapModeEnum mode);
     void slot_alwaysOnTop();
+    void slot_setRadialTransparency();
     void slot_setShowStatusBar();
     void slot_setShowScrollBars();
     void slot_setShowMenuBar();

--- a/src/preferences/commspage.cpp
+++ b/src/preferences/commspage.cpp
@@ -1,0 +1,402 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2025 The MMapper Authors
+
+#include "commspage.h"
+
+#include <QColorDialog>
+#include <QFormLayout>
+#include <QGroupBox>
+#include <QVBoxLayout>
+
+#include "../configuration/configuration.h"
+
+CommsPage::CommsPage(QWidget *parent)
+    : QWidget(parent)
+{
+    setupUI();
+    connectSignals();
+    slot_loadConfig();
+}
+
+CommsPage::~CommsPage() = default;
+
+void CommsPage::setupUI()
+{
+    auto *mainLayout = new QVBoxLayout(this);
+
+    // Talker Colors Group
+    auto *talkerColorsGroup = new QGroupBox(tr("Talker Colors"), this);
+    auto *talkerColorsLayout = new QFormLayout(talkerColorsGroup);
+
+    m_talkerYouColorButton = new QPushButton(tr("Choose Color..."), this);
+    m_talkerYouColorButton->setMinimumWidth(120);
+    m_talkerYouColorButton->setProperty("colorType", "talker_you");
+    talkerColorsLayout->addRow(tr("You (sent messages):"), m_talkerYouColorButton);
+
+    m_talkerPlayerColorButton = new QPushButton(tr("Choose Color..."), this);
+    m_talkerPlayerColorButton->setMinimumWidth(120);
+    m_talkerPlayerColorButton->setProperty("colorType", "talker_player");
+    talkerColorsLayout->addRow(tr("Player:"), m_talkerPlayerColorButton);
+
+    m_talkerNpcColorButton = new QPushButton(tr("Choose Color..."), this);
+    m_talkerNpcColorButton->setMinimumWidth(120);
+    m_talkerNpcColorButton->setProperty("colorType", "talker_npc");
+    talkerColorsLayout->addRow(tr("NPC:"), m_talkerNpcColorButton);
+
+    m_talkerAllyColorButton = new QPushButton(tr("Choose Color..."), this);
+    m_talkerAllyColorButton->setMinimumWidth(120);
+    m_talkerAllyColorButton->setProperty("colorType", "talker_ally");
+    talkerColorsLayout->addRow(tr("Ally:"), m_talkerAllyColorButton);
+
+    m_talkerNeutralColorButton = new QPushButton(tr("Choose Color..."), this);
+    m_talkerNeutralColorButton->setMinimumWidth(120);
+    m_talkerNeutralColorButton->setProperty("colorType", "talker_neutral");
+    talkerColorsLayout->addRow(tr("Neutral:"), m_talkerNeutralColorButton);
+
+    m_talkerEnemyColorButton = new QPushButton(tr("Choose Color..."), this);
+    m_talkerEnemyColorButton->setMinimumWidth(120);
+    m_talkerEnemyColorButton->setProperty("colorType", "talker_enemy");
+    talkerColorsLayout->addRow(tr("Enemy:"), m_talkerEnemyColorButton);
+
+    mainLayout->addWidget(talkerColorsGroup);
+
+    // Communication Colors Group
+    auto *colorsGroup = new QGroupBox(tr("Communication Colors"), this);
+    auto *colorsLayout = new QFormLayout(colorsGroup);
+
+    // Direct communications
+    m_tellColorButton = new QPushButton(tr("Choose Color..."), this);
+    m_tellColorButton->setMinimumWidth(120);
+    m_tellColorButton->setProperty("colorType", "tell");
+    colorsLayout->addRow(tr("Tell:"), m_tellColorButton);
+
+    m_whisperColorButton = new QPushButton(tr("Choose Color..."), this);
+    m_whisperColorButton->setMinimumWidth(120);
+    m_whisperColorButton->setProperty("colorType", "whisper");
+    colorsLayout->addRow(tr("Whisper:"), m_whisperColorButton);
+
+    m_groupColorButton = new QPushButton(tr("Choose Color..."), this);
+    m_groupColorButton->setMinimumWidth(120);
+    m_groupColorButton->setProperty("colorType", "group");
+    colorsLayout->addRow(tr("Group:"), m_groupColorButton);
+
+    m_askColorButton = new QPushButton(tr("Choose Color..."), this);
+    m_askColorButton->setMinimumWidth(120);
+    m_askColorButton->setProperty("colorType", "ask");
+    colorsLayout->addRow(tr("Question:"), m_askColorButton);
+
+    // Local communications
+    m_sayColorButton = new QPushButton(tr("Choose Color..."), this);
+    m_sayColorButton->setMinimumWidth(120);
+    m_sayColorButton->setProperty("colorType", "say");
+    colorsLayout->addRow(tr("Say:"), m_sayColorButton);
+
+    m_emoteColorButton = new QPushButton(tr("Choose Color..."), this);
+    m_emoteColorButton->setMinimumWidth(120);
+    m_emoteColorButton->setProperty("colorType", "emote");
+    colorsLayout->addRow(tr("Emote:"), m_emoteColorButton);
+
+    m_socialColorButton = new QPushButton(tr("Choose Color..."), this);
+    m_socialColorButton->setMinimumWidth(120);
+    m_socialColorButton->setProperty("colorType", "social");
+    colorsLayout->addRow(tr("Social:"), m_socialColorButton);
+
+    m_yellColorButton = new QPushButton(tr("Choose Color..."), this);
+    m_yellColorButton->setMinimumWidth(120);
+    m_yellColorButton->setProperty("colorType", "yell");
+    colorsLayout->addRow(tr("Yell:"), m_yellColorButton);
+
+    // Global communications
+    m_narrateColorButton = new QPushButton(tr("Choose Color..."), this);
+    m_narrateColorButton->setMinimumWidth(120);
+    m_narrateColorButton->setProperty("colorType", "narrate");
+    colorsLayout->addRow(tr("Tale:"), m_narrateColorButton);
+
+    m_singColorButton = new QPushButton(tr("Choose Color..."), this);
+    m_singColorButton->setMinimumWidth(120);
+    m_singColorButton->setProperty("colorType", "sing");
+    colorsLayout->addRow(tr("Song:"), m_singColorButton);
+
+    m_prayColorButton = new QPushButton(tr("Choose Color..."), this);
+    m_prayColorButton->setMinimumWidth(120);
+    m_prayColorButton->setProperty("colorType", "pray");
+    colorsLayout->addRow(tr("Prayer:"), m_prayColorButton);
+
+    m_shoutColorButton = new QPushButton(tr("Choose Color..."), this);
+    m_shoutColorButton->setMinimumWidth(120);
+    m_shoutColorButton->setProperty("colorType", "shout");
+    colorsLayout->addRow(tr("Shout:"), m_shoutColorButton);
+
+    // Background color
+    m_bgColorButton = new QPushButton(tr("Choose Color..."), this);
+    m_bgColorButton->setMinimumWidth(120);
+    colorsLayout->addRow(tr("Background:"), m_bgColorButton);
+
+    mainLayout->addWidget(colorsGroup);
+
+    // Font Styling Group
+    auto *fontGroup = new QGroupBox(tr("Font Styling"), this);
+    auto *fontLayout = new QVBoxLayout(fontGroup);
+
+    m_yellAllCapsCheck = new QCheckBox(tr("Display yells in ALL CAPS"), this);
+    fontLayout->addWidget(m_yellAllCapsCheck);
+
+    m_whisperItalicCheck = new QCheckBox(tr("Display whispers in italic"), this);
+    fontLayout->addWidget(m_whisperItalicCheck);
+
+    m_emoteItalicCheck = new QCheckBox(tr("Display emotes in italic"), this);
+    fontLayout->addWidget(m_emoteItalicCheck);
+
+    mainLayout->addWidget(fontGroup);
+
+    // Display Options Group
+    auto *displayGroup = new QGroupBox(tr("Display Options"), this);
+    auto *displayLayout = new QVBoxLayout(displayGroup);
+
+    m_showTimestampsCheck = new QCheckBox(tr("Show timestamps"), this);
+    displayLayout->addWidget(m_showTimestampsCheck);
+
+    mainLayout->addWidget(displayGroup);
+
+    // Add stretch at the bottom to push everything up
+    mainLayout->addStretch();
+
+    setLayout(mainLayout);
+}
+
+void CommsPage::connectSignals()
+{
+    // Color buttons - all connect to the same slot
+    connect(m_tellColorButton, &QPushButton::clicked, this, &CommsPage::slot_onColorClicked);
+    connect(m_whisperColorButton, &QPushButton::clicked, this, &CommsPage::slot_onColorClicked);
+    connect(m_groupColorButton, &QPushButton::clicked, this, &CommsPage::slot_onColorClicked);
+    connect(m_askColorButton, &QPushButton::clicked, this, &CommsPage::slot_onColorClicked);
+    connect(m_sayColorButton, &QPushButton::clicked, this, &CommsPage::slot_onColorClicked);
+    connect(m_emoteColorButton, &QPushButton::clicked, this, &CommsPage::slot_onColorClicked);
+    connect(m_socialColorButton, &QPushButton::clicked, this, &CommsPage::slot_onColorClicked);
+    connect(m_yellColorButton, &QPushButton::clicked, this, &CommsPage::slot_onColorClicked);
+    connect(m_narrateColorButton, &QPushButton::clicked, this, &CommsPage::slot_onColorClicked);
+    connect(m_singColorButton, &QPushButton::clicked, this, &CommsPage::slot_onColorClicked);
+    connect(m_prayColorButton, &QPushButton::clicked, this, &CommsPage::slot_onColorClicked);
+    connect(m_shoutColorButton, &QPushButton::clicked, this, &CommsPage::slot_onColorClicked);
+    connect(m_bgColorButton, &QPushButton::clicked, this, &CommsPage::slot_onBgColorClicked);
+
+    // Talker color buttons
+    connect(m_talkerYouColorButton, &QPushButton::clicked, this, &CommsPage::slot_onColorClicked);
+    connect(m_talkerPlayerColorButton, &QPushButton::clicked, this, &CommsPage::slot_onColorClicked);
+    connect(m_talkerNpcColorButton, &QPushButton::clicked, this, &CommsPage::slot_onColorClicked);
+    connect(m_talkerAllyColorButton, &QPushButton::clicked, this, &CommsPage::slot_onColorClicked);
+    connect(m_talkerNeutralColorButton, &QPushButton::clicked, this, &CommsPage::slot_onColorClicked);
+    connect(m_talkerEnemyColorButton, &QPushButton::clicked, this, &CommsPage::slot_onColorClicked);
+
+    // Font styling
+    connect(m_yellAllCapsCheck, &QCheckBox::checkStateChanged, this, &CommsPage::slot_onYellAllCapsChanged);
+    connect(m_whisperItalicCheck, &QCheckBox::checkStateChanged, this, &CommsPage::slot_onWhisperItalicChanged);
+    connect(m_emoteItalicCheck, &QCheckBox::checkStateChanged, this, &CommsPage::slot_onEmoteItalicChanged);
+
+    // Display options
+    connect(m_showTimestampsCheck, &QCheckBox::checkStateChanged, this, &CommsPage::slot_onShowTimestampsChanged);
+}
+
+void CommsPage::slot_loadConfig()
+{
+    const auto &comms = getConfig().comms;
+
+    // Load per-type colors and update button backgrounds
+    updateColorButton(m_tellColorButton, comms.tellColor.get());
+    updateColorButton(m_whisperColorButton, comms.whisperColor.get());
+    updateColorButton(m_groupColorButton, comms.groupColor.get());
+    updateColorButton(m_askColorButton, comms.askColor.get());
+    updateColorButton(m_sayColorButton, comms.sayColor.get());
+    updateColorButton(m_emoteColorButton, comms.emoteColor.get());
+    updateColorButton(m_socialColorButton, comms.socialColor.get());
+    updateColorButton(m_yellColorButton, comms.yellColor.get());
+    updateColorButton(m_narrateColorButton, comms.narrateColor.get());
+    updateColorButton(m_singColorButton, comms.singColor.get());
+    updateColorButton(m_prayColorButton, comms.prayColor.get());
+    updateColorButton(m_shoutColorButton, comms.shoutColor.get());
+    updateColorButton(m_bgColorButton, comms.backgroundColor.get());
+
+    // Load talker colors
+    updateColorButton(m_talkerYouColorButton, comms.talkerYouColor.get());
+    updateColorButton(m_talkerPlayerColorButton, comms.talkerPlayerColor.get());
+    updateColorButton(m_talkerNpcColorButton, comms.talkerNpcColor.get());
+    updateColorButton(m_talkerAllyColorButton, comms.talkerAllyColor.get());
+    updateColorButton(m_talkerNeutralColorButton, comms.talkerNeutralColor.get());
+    updateColorButton(m_talkerEnemyColorButton, comms.talkerEnemyColor.get());
+
+    // Load font styling options
+    m_yellAllCapsCheck->setChecked(comms.yellAllCaps.get());
+    m_whisperItalicCheck->setChecked(comms.whisperItalic.get());
+    m_emoteItalicCheck->setChecked(comms.emoteItalic.get());
+
+    // Load display options
+    m_showTimestampsCheck->setChecked(comms.showTimestamps.get());
+}
+
+void CommsPage::updateColorButton(QPushButton *button, const QColor &color)
+{
+    if (!button) {
+        return;
+    }
+
+    // Set button background to the color
+    button->setStyleSheet(QString("background-color: %1; color: %2;")
+                              .arg(color.name())
+                              .arg(color.lightnessF() > 0.5 ? "black" : "white"));
+}
+
+void CommsPage::slot_onColorClicked()
+{
+    auto *button = qobject_cast<QPushButton *>(sender());
+    if (!button) {
+        return;
+    }
+
+    const QString colorType = button->property("colorType").toString();
+    auto &comms = setConfig().comms;
+
+    QColor currentColor;
+    QString dialogTitle;
+
+    // Get current color and dialog title based on type
+    if (colorType == "tell") {
+        currentColor = comms.tellColor.get();
+        dialogTitle = tr("Choose Tell Color");
+    } else if (colorType == "whisper") {
+        currentColor = comms.whisperColor.get();
+        dialogTitle = tr("Choose Whisper Color");
+    } else if (colorType == "group") {
+        currentColor = comms.groupColor.get();
+        dialogTitle = tr("Choose Group Color");
+    } else if (colorType == "ask") {
+        currentColor = comms.askColor.get();
+        dialogTitle = tr("Choose Question Color");
+    } else if (colorType == "say") {
+        currentColor = comms.sayColor.get();
+        dialogTitle = tr("Choose Say Color");
+    } else if (colorType == "emote") {
+        currentColor = comms.emoteColor.get();
+        dialogTitle = tr("Choose Emote Color");
+    } else if (colorType == "social") {
+        currentColor = comms.socialColor.get();
+        dialogTitle = tr("Choose Social Color");
+    } else if (colorType == "yell") {
+        currentColor = comms.yellColor.get();
+        dialogTitle = tr("Choose Yell Color");
+    } else if (colorType == "narrate") {
+        currentColor = comms.narrateColor.get();
+        dialogTitle = tr("Choose Tale Color");
+    } else if (colorType == "sing") {
+        currentColor = comms.singColor.get();
+        dialogTitle = tr("Choose Song Color");
+    } else if (colorType == "pray") {
+        currentColor = comms.prayColor.get();
+        dialogTitle = tr("Choose Prayer Color");
+    } else if (colorType == "shout") {
+        currentColor = comms.shoutColor.get();
+        dialogTitle = tr("Choose Shout Color");
+    } else if (colorType == "talker_you") {
+        currentColor = comms.talkerYouColor.get();
+        dialogTitle = tr("Choose You Color");
+    } else if (colorType == "talker_player") {
+        currentColor = comms.talkerPlayerColor.get();
+        dialogTitle = tr("Choose Player Color");
+    } else if (colorType == "talker_npc") {
+        currentColor = comms.talkerNpcColor.get();
+        dialogTitle = tr("Choose NPC Color");
+    } else if (colorType == "talker_ally") {
+        currentColor = comms.talkerAllyColor.get();
+        dialogTitle = tr("Choose Ally Color");
+    } else if (colorType == "talker_neutral") {
+        currentColor = comms.talkerNeutralColor.get();
+        dialogTitle = tr("Choose Neutral Color");
+    } else if (colorType == "talker_enemy") {
+        currentColor = comms.talkerEnemyColor.get();
+        dialogTitle = tr("Choose Enemy Color");
+    } else {
+        return;
+    }
+
+    QColor newColor = QColorDialog::getColor(currentColor, this, dialogTitle);
+
+    if (newColor.isValid() && newColor != currentColor) {
+        // Set the new color based on type
+        if (colorType == "tell") {
+            comms.tellColor.set(newColor);
+        } else if (colorType == "whisper") {
+            comms.whisperColor.set(newColor);
+        } else if (colorType == "group") {
+            comms.groupColor.set(newColor);
+        } else if (colorType == "ask") {
+            comms.askColor.set(newColor);
+        } else if (colorType == "say") {
+            comms.sayColor.set(newColor);
+        } else if (colorType == "emote") {
+            comms.emoteColor.set(newColor);
+        } else if (colorType == "social") {
+            comms.socialColor.set(newColor);
+        } else if (colorType == "yell") {
+            comms.yellColor.set(newColor);
+        } else if (colorType == "narrate") {
+            comms.narrateColor.set(newColor);
+        } else if (colorType == "sing") {
+            comms.singColor.set(newColor);
+        } else if (colorType == "pray") {
+            comms.prayColor.set(newColor);
+        } else if (colorType == "shout") {
+            comms.shoutColor.set(newColor);
+        } else if (colorType == "talker_you") {
+            comms.talkerYouColor.set(newColor);
+        } else if (colorType == "talker_player") {
+            comms.talkerPlayerColor.set(newColor);
+        } else if (colorType == "talker_npc") {
+            comms.talkerNpcColor.set(newColor);
+        } else if (colorType == "talker_ally") {
+            comms.talkerAllyColor.set(newColor);
+        } else if (colorType == "talker_neutral") {
+            comms.talkerNeutralColor.set(newColor);
+        } else if (colorType == "talker_enemy") {
+            comms.talkerEnemyColor.set(newColor);
+        }
+
+        updateColorButton(button, newColor);
+        emit sig_commsSettingsChanged();
+    }
+}
+
+void CommsPage::slot_onBgColorClicked()
+{
+    const QColor currentColor = getConfig().comms.backgroundColor.get();
+    QColor newColor = QColorDialog::getColor(currentColor, this, tr("Choose Background Color"));
+
+    if (newColor.isValid() && newColor != currentColor) {
+        setConfig().comms.backgroundColor.set(newColor);
+        updateColorButton(m_bgColorButton, newColor);
+        emit sig_commsSettingsChanged();
+    }
+}
+
+void CommsPage::slot_onYellAllCapsChanged(Qt::CheckState state)
+{
+    setConfig().comms.yellAllCaps.set(state == Qt::Checked);
+    emit sig_commsSettingsChanged();
+}
+
+void CommsPage::slot_onWhisperItalicChanged(Qt::CheckState state)
+{
+    setConfig().comms.whisperItalic.set(state == Qt::Checked);
+    emit sig_commsSettingsChanged();
+}
+
+void CommsPage::slot_onEmoteItalicChanged(Qt::CheckState state)
+{
+    setConfig().comms.emoteItalic.set(state == Qt::Checked);
+    emit sig_commsSettingsChanged();
+}
+
+void CommsPage::slot_onShowTimestampsChanged(Qt::CheckState state)
+{
+    setConfig().comms.showTimestamps.set(state == Qt::Checked);
+    emit sig_commsSettingsChanged();
+}

--- a/src/preferences/commspage.h
+++ b/src/preferences/commspage.h
@@ -1,0 +1,71 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2025 The MMapper Authors
+
+#include "../global/macros.h"
+
+#include <QCheckBox>
+#include <QLabel>
+#include <QPushButton>
+#include <QWidget>
+
+class NODISCARD_QOBJECT CommsPage final : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit CommsPage(QWidget *parent);
+    ~CommsPage() final;
+
+    DELETE_CTORS_AND_ASSIGN_OPS(CommsPage);
+
+signals:
+    void sig_commsSettingsChanged();
+
+public slots:
+    void slot_loadConfig();
+
+private slots:
+    void slot_onColorClicked();
+    void slot_onBgColorClicked();
+    void slot_onYellAllCapsChanged(Qt::CheckState state);
+    void slot_onWhisperItalicChanged(Qt::CheckState state);
+    void slot_onEmoteItalicChanged(Qt::CheckState state);
+    void slot_onShowTimestampsChanged(Qt::CheckState state);
+
+private:
+    void setupUI();
+    void connectSignals();
+    void updateColorButton(QPushButton *button, const QColor &color);
+
+    // Color buttons (one per communication type)
+    QPushButton *m_tellColorButton = nullptr;
+    QPushButton *m_whisperColorButton = nullptr;
+    QPushButton *m_groupColorButton = nullptr;
+    QPushButton *m_askColorButton = nullptr;
+    QPushButton *m_sayColorButton = nullptr;
+    QPushButton *m_emoteColorButton = nullptr;
+    QPushButton *m_socialColorButton = nullptr;
+    QPushButton *m_yellColorButton = nullptr;
+    QPushButton *m_narrateColorButton = nullptr;
+    QPushButton *m_prayColorButton = nullptr;
+    QPushButton *m_shoutColorButton = nullptr;
+    QPushButton *m_singColorButton = nullptr;
+    QPushButton *m_bgColorButton = nullptr;
+
+    // Talker color buttons (based on GMCP talker-type)
+    QPushButton *m_talkerYouColorButton = nullptr;
+    QPushButton *m_talkerPlayerColorButton = nullptr;
+    QPushButton *m_talkerNpcColorButton = nullptr;
+    QPushButton *m_talkerAllyColorButton = nullptr;
+    QPushButton *m_talkerNeutralColorButton = nullptr;
+    QPushButton *m_talkerEnemyColorButton = nullptr;
+
+    // Font styling checkboxes
+    QCheckBox *m_yellAllCapsCheck = nullptr;
+    QCheckBox *m_whisperItalicCheck = nullptr;
+    QCheckBox *m_emoteItalicCheck = nullptr;
+
+    // Display options
+    QCheckBox *m_showTimestampsCheck = nullptr;
+};

--- a/src/preferences/configdialog.cpp
+++ b/src/preferences/configdialog.cpp
@@ -8,9 +8,11 @@
 
 #include "autologpage.h"
 #include "clientpage.h"
+#include "commspage.h"
 #include "generalpage.h"
 #include "graphicspage.h"
 #include "grouppage.h"
+#include "hotkeyspage.h"
 #include "mumeprotocolpage.h"
 #include "parserpage.h"
 #include "pathmachinepage.h"
@@ -38,12 +40,16 @@ ConfigDialog::ConfigDialog(QWidget *const parent)
     auto autoLogPage = new AutoLogPage(this);
     auto mumeProtocolPage = new MumeProtocolPage(this);
     auto pathmachinePage = new PathmachinePage(this);
+    auto hotkeysPage = new HotkeysPage(this);
+    auto commsPage = new CommsPage(this);
 
     m_pagesWidget = new QStackedWidget(this);
 
     auto *const pagesWidget = m_pagesWidget;
     pagesWidget->addWidget(generalPage);
     pagesWidget->addWidget(graphicsPage);
+    pagesWidget->addWidget(hotkeysPage);
+    pagesWidget->addWidget(commsPage);
     pagesWidget->addWidget(parserPage);
     pagesWidget->addWidget(clientPage);
     pagesWidget->addWidget(groupPage);
@@ -80,10 +86,21 @@ ConfigDialog::ConfigDialog(QWidget *const parent)
             mumeProtocolPage,
             &MumeProtocolPage::slot_loadConfig);
     connect(this, &ConfigDialog::sig_loadConfig, pathmachinePage, &PathmachinePage::slot_loadConfig);
+    connect(this, &ConfigDialog::sig_loadConfig, hotkeysPage, &HotkeysPage::slot_loadConfig);
+    connect(hotkeysPage, &HotkeysPage::sig_hotkeysChanged, this, &ConfigDialog::sig_hotkeysChanged);
+    connect(this, &ConfigDialog::sig_loadConfig, commsPage, &CommsPage::slot_loadConfig);
+    connect(commsPage,
+            &CommsPage::sig_commsSettingsChanged,
+            this,
+            &ConfigDialog::sig_commsSettingsChanged);
     connect(graphicsPage,
             &GraphicsPage::sig_graphicsSettingsChanged,
             this,
             &ConfigDialog::sig_graphicsSettingsChanged);
+    connect(graphicsPage,
+            &GraphicsPage::sig_textureSettingsChanged,
+            this,
+            &ConfigDialog::sig_textureSettingsChanged);
 }
 
 ConfigDialog::~ConfigDialog()
@@ -122,6 +139,8 @@ void ConfigDialog::createIcons()
 
     addItem(":/icons/generalcfg.png", tr("General"));
     addItem(":/icons/graphicscfg.png", tr("Graphics"));
+    addItem(":/icons/hotkeys.png", tr("Hotkeys"));
+    addItem(":/icons/comms.png", tr("Comms"));
     addItem(":/icons/parsercfg.png", tr("Parser"));
     addItem(":/icons/terminal.png", tr("Integrated\nMud Client"));
     addItem(":/icons/group-recolor.png", tr("Group Panel"));


### PR DESCRIPTION
Communications System:
- New CommsManager to handle all in-game communications
- CommsWidget displaying communications in categorized tabs (Direct, Local, Global)
- Real-time parsing from GMCP Comm.Channel messages
- Fallback text-based parsing when GMCP unavailable
- Tab-based organization (Tell/Whisper, Say/Emote, Narrate/Yell/etc)

Features:
- Color-coded communication types (customizable)
- Talker identification (You, Player, NPC, Ally, Neutral, Enemy)
- Font styling options (CAPS for yells, italic for whispers/emotes)
- Optional timestamps
- Communication log saving
- Tab muting/filtering
- Dockable communications panel

Configuration:
- Comprehensive color settings for each comm type
- Talker-based coloring system
- Font styling preferences
- Log directory configuration
- Per-tab muting controls

GMCP Integration:
- Requires PR-B (GMCP Broadcast) for sig_rawGameText signal
- Parses Comm.Channel GMCP messages
- Falls back to text parsing for compatibility

UI:
- Added Comms preferences page
- Integrated with main window dock system
- Tabbed interface for easy navigation

This provides a centralized, organized view of all game communications with extensive customization options.

## Summary by Sourcery

Introduce a configurable communications panel backed by a GMCP‑aware manager, extend graphics and canvas controls, and centralize hotkey handling with configurable shortcuts and visibility filters.

New Features:
- Add a CommsManager and dockable CommsWidget to collect, categorize, and display in‑game communications from GMCP Comm.Channel messages and raw text.
- Provide a communications preferences page for per‑channel colors, talker‑based coloring, font styling, timestamps, and log behavior.
- Introduce a visibility filter toolbar/panel to toggle per‑marker and connection visibility on the map canvas.
- Add support for texture set selection, optional seasonal textures, and configurable background imagery on the map canvas.
- Enable global, user‑configurable hotkeys for common actions, views, panels, mouse modes, and room operations, including dual shortcuts for preferences.

Enhancements:
- Extend canvas configuration with layer transparency, radial transparency toggle, and richer camera angle ranges, and wire these into the main window and menus.
- Integrate a GMCP‑driven MUME clock broadcast with configurable interval and season‑based texture updates.
- Persist per‑marker visibility settings and expose them via a dedicated visibility filter widget.
- Adjust default UI colors (e.g., background) and connect new preferences signals for texture, comms, and hotkey updates at runtime.

Build:
- Register new communications, visibility filter, and preferences page sources in the CMake build configuration.