### PR TITLE
Add Visibility Filters for selective map element display

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,10 @@ set(mmapper_SRCS
     clock/mumeclockwidget.h
     clock/mumemoment.cpp
     clock/mumemoment.h
+    comms/CommsManager.cpp
+    comms/CommsManager.h
+    comms/CommsWidget.cpp
+    comms/CommsWidget.h
     configuration/NamedConfig.h
     configuration/PasswordConfig.cpp
     configuration/PasswordConfig.h
@@ -226,6 +230,8 @@ set(mmapper_SRCS
     mainwindow/MapZoomSlider.h
     mainwindow/UpdateDialog.cpp
     mainwindow/UpdateDialog.h
+    mainwindow/VisibilityFilterWidget.cpp
+    mainwindow/VisibilityFilterWidget.h
     mainwindow/WinDarkMode.cpp
     mainwindow/WinDarkMode.h
     mainwindow/aboutdialog.cpp
@@ -466,12 +472,16 @@ set(mmapper_SRCS
     preferences/autologpage.h
     preferences/clientpage.cpp
     preferences/clientpage.h
+    preferences/commspage.cpp
+    preferences/commspage.h
     preferences/configdialog.cpp
     preferences/configdialog.h
     preferences/generalpage.cpp
     preferences/generalpage.h
     preferences/graphicspage.cpp
     preferences/graphicspage.h
+    preferences/hotkeyspage.cpp
+    preferences/hotkeyspage.h
     preferences/grouppage.cpp
     preferences/grouppage.h
     preferences/mumeprotocolpage.cpp

--- a/src/configuration/configuration.cpp
+++ b/src/configuration/configuration.cpp
@@ -7,6 +7,7 @@
 #include "configuration.h"
 
 #include "../global/utils.h"
+#include "../map/infomark.h"
 
 #include <cassert>
 #include <mutex>
@@ -50,6 +51,25 @@ NODISCARD const char *getPlatformEditor()
     default:
         return "";
     }
+}
+
+NODISCARD TextureSetEnum intToTextureSet(int value)
+{
+    switch (value) {
+    case 0:
+        return TextureSetEnum::CLASSIC;
+    case 1:
+        return TextureSetEnum::MODERN;
+    case 2:
+        return TextureSetEnum::CUSTOM;
+    default:
+        return TextureSetEnum::MODERN; // Default to Modern
+    }
+}
+
+NODISCARD int textureSetToInt(TextureSetEnum value)
+{
+    return static_cast<int>(value);
 }
 
 } // namespace
@@ -194,10 +214,12 @@ ConstString GRP_ACCOUNT = "Account";
 ConstString GRP_AUTO_LOAD_WORLD = "Auto load world";
 ConstString GRP_AUTO_LOG = "Auto log";
 ConstString GRP_CANVAS = "Canvas";
+ConstString GRP_COMMS = "Communications";
 ConstString GRP_CONNECTION = "Connection";
 ConstString GRP_FINDROOMS_DIALOG = "FindRooms Dialog";
 ConstString GRP_GENERAL = "General";
 ConstString GRP_GROUP_MANAGER = "Group Manager";
+ConstString GRP_HOTKEYS = "Hotkeys";
 ConstString GRP_INFOMARKS_DIALOG = "InfoMarks Dialog";
 ConstString GRP_INTEGRATED_MUD_CLIENT = "Integrated Mud Client";
 ConstString GRP_MUME_CLIENT_PROTOCOL = "Mume client protocol";
@@ -227,9 +249,12 @@ ConstString KEY_CONNECTION_NORMAL_COLOR = "Connection normal color";
 ConstString KEY_CORRECT_POSITION_BONUS = "correct position bonus";
 ConstString KEY_DISPLAY_XP_STATUS = "Display XP status bar widget";
 ConstString KEY_DISPLAY_CLOCK = "Display clock";
+ConstString KEY_GMCP_BROADCAST_CLOCK = "GMCP broadcast clock";
+ConstString KEY_GMCP_BROADCAST_INTERVAL = "GMCP broadcast interval";
 ConstString KEY_DRAW_DOOR_NAMES = "Draw door names";
 ConstString KEY_DRAW_NOT_MAPPED_EXITS = "Draw not mapped exits";
 ConstString KEY_DRAW_UPPER_LAYERS_TEXTURED = "Draw upper layers textured";
+ConstString KEY_LAYER_TRANSPARENCY = "Layer transparency";
 ConstString KEY_EMOJI_ENCODE = "encode emoji";
 ConstString KEY_EMOJI_DECODE = "decode emoji";
 ConstString KEY_EMULATED_EXITS = "Emulated Exits";
@@ -256,6 +281,73 @@ ConstString KEY_3D_FOV = "canvas.advanced.fov";
 ConstString KEY_3D_VERTICAL_ANGLE = "canvas.advanced.verticalAngle";
 ConstString KEY_3D_HORIZONTAL_ANGLE = "canvas.advanced.horizontalAngle";
 ConstString KEY_3D_LAYER_HEIGHT = "canvas.advanced.layerHeight";
+ConstString KEY_BACKGROUND_IMAGE_ENABLED = "canvas.advanced.backgroundImageEnabled";
+ConstString KEY_BACKGROUND_IMAGE_PATH = "canvas.advanced.backgroundImagePath";
+ConstString KEY_BACKGROUND_IMAGE_FIT_MODE = "canvas.advanced.backgroundFitMode";
+ConstString KEY_BACKGROUND_IMAGE_OPACITY = "canvas.advanced.backgroundOpacity";
+ConstString KEY_BACKGROUND_IMAGE_FOCUSED_SCALE = "canvas.advanced.backgroundFocusedScale";
+ConstString KEY_BACKGROUND_IMAGE_FOCUSED_OFFSET_X = "canvas.advanced.backgroundFocusedOffsetX";
+ConstString KEY_BACKGROUND_IMAGE_FOCUSED_OFFSET_Y = "canvas.advanced.backgroundFocusedOffsetY";
+ConstString KEY_VISIBLE_MARKER_GENERIC = "canvas.visibleMarkers.generic";
+ConstString KEY_VISIBLE_MARKER_HERB = "canvas.visibleMarkers.herb";
+ConstString KEY_VISIBLE_MARKER_RIVER = "canvas.visibleMarkers.river";
+ConstString KEY_VISIBLE_MARKER_PLACE = "canvas.visibleMarkers.place";
+ConstString KEY_VISIBLE_MARKER_MOB = "canvas.visibleMarkers.mob";
+ConstString KEY_VISIBLE_MARKER_COMMENT = "canvas.visibleMarkers.comment";
+ConstString KEY_VISIBLE_MARKER_ROAD = "canvas.visibleMarkers.road";
+ConstString KEY_VISIBLE_MARKER_OBJECT = "canvas.visibleMarkers.object";
+ConstString KEY_VISIBLE_MARKER_ACTION = "canvas.visibleMarkers.action";
+ConstString KEY_VISIBLE_MARKER_LOCALITY = "canvas.visibleMarkers.locality";
+ConstString KEY_VISIBLE_CONNECTIONS = "canvas.visibilityFilter.connections";
+
+// Hotkey configuration keys
+ConstString KEY_HOTKEY_FILE_OPEN = "hotkeys.fileOpen";
+ConstString KEY_HOTKEY_FILE_SAVE = "hotkeys.fileSave";
+ConstString KEY_HOTKEY_FILE_RELOAD = "hotkeys.fileReload";
+ConstString KEY_HOTKEY_FILE_QUIT = "hotkeys.fileQuit";
+ConstString KEY_HOTKEY_EDIT_UNDO = "hotkeys.editUndo";
+ConstString KEY_HOTKEY_EDIT_REDO = "hotkeys.editRedo";
+ConstString KEY_HOTKEY_EDIT_PREFERENCES = "hotkeys.editPreferences";
+ConstString KEY_HOTKEY_EDIT_PREFERENCES_ALT = "hotkeys.editPreferencesAlt";
+ConstString KEY_HOTKEY_EDIT_FIND_ROOMS = "hotkeys.editFindRooms";
+ConstString KEY_HOTKEY_EDIT_ROOM = "hotkeys.editRoom";
+ConstString KEY_HOTKEY_VIEW_ZOOM_IN = "hotkeys.viewZoomIn";
+ConstString KEY_HOTKEY_VIEW_ZOOM_OUT = "hotkeys.viewZoomOut";
+ConstString KEY_HOTKEY_VIEW_ZOOM_RESET = "hotkeys.viewZoomReset";
+ConstString KEY_HOTKEY_VIEW_LAYER_UP = "hotkeys.viewLayerUp";
+ConstString KEY_HOTKEY_VIEW_LAYER_DOWN = "hotkeys.viewLayerDown";
+ConstString KEY_HOTKEY_VIEW_LAYER_RESET = "hotkeys.viewLayerReset";
+ConstString KEY_HOTKEY_VIEW_RADIAL_TRANSPARENCY = "hotkeys.viewRadialTransparency";
+ConstString KEY_HOTKEY_VIEW_STATUS_BAR = "hotkeys.viewStatusBar";
+ConstString KEY_HOTKEY_VIEW_SCROLL_BARS = "hotkeys.viewScrollBars";
+ConstString KEY_HOTKEY_VIEW_MENU_BAR = "hotkeys.viewMenuBar";
+ConstString KEY_HOTKEY_VIEW_ALWAYS_ON_TOP = "hotkeys.viewAlwaysOnTop";
+ConstString KEY_HOTKEY_PANEL_LOG = "hotkeys.panelLog";
+ConstString KEY_HOTKEY_PANEL_CLIENT = "hotkeys.panelClient";
+ConstString KEY_HOTKEY_PANEL_GROUP = "hotkeys.panelGroup";
+ConstString KEY_HOTKEY_PANEL_ROOM = "hotkeys.panelRoom";
+ConstString KEY_HOTKEY_PANEL_ADVENTURE = "hotkeys.panelAdventure";
+ConstString KEY_HOTKEY_PANEL_COMMS = "hotkeys.panelComms";
+ConstString KEY_HOTKEY_PANEL_DESCRIPTION = "hotkeys.panelDescription";
+ConstString KEY_HOTKEY_MODE_MOVE_MAP = "hotkeys.modeMoveMap";
+ConstString KEY_HOTKEY_MODE_RAYPICK = "hotkeys.modeRaypick";
+ConstString KEY_HOTKEY_MODE_SELECT_ROOMS = "hotkeys.modeSelectRooms";
+ConstString KEY_HOTKEY_MODE_SELECT_MARKERS = "hotkeys.modeSelectMarkers";
+ConstString KEY_HOTKEY_MODE_SELECT_CONNECTION = "hotkeys.modeSelectConnection";
+ConstString KEY_HOTKEY_MODE_CREATE_MARKER = "hotkeys.modeCreateMarker";
+ConstString KEY_HOTKEY_MODE_CREATE_ROOM = "hotkeys.modeCreateRoom";
+ConstString KEY_HOTKEY_MODE_CREATE_CONNECTION = "hotkeys.modeCreateConnection";
+ConstString KEY_HOTKEY_MODE_CREATE_ONEWAY_CONNECTION = "hotkeys.modeCreateOnewayConnection";
+ConstString KEY_HOTKEY_ROOM_CREATE = "hotkeys.roomCreate";
+ConstString KEY_HOTKEY_ROOM_MOVE_UP = "hotkeys.roomMoveUp";
+ConstString KEY_HOTKEY_ROOM_MOVE_DOWN = "hotkeys.roomMoveDown";
+ConstString KEY_HOTKEY_ROOM_MERGE_UP = "hotkeys.roomMergeUp";
+ConstString KEY_HOTKEY_ROOM_MERGE_DOWN = "hotkeys.roomMergeDown";
+ConstString KEY_HOTKEY_ROOM_DELETE = "hotkeys.roomDelete";
+ConstString KEY_HOTKEY_ROOM_CONNECT_NEIGHBORS = "hotkeys.roomConnectNeighbors";
+ConstString KEY_HOTKEY_ROOM_MOVE_TO_SELECTED = "hotkeys.roomMoveToSelected";
+ConstString KEY_HOTKEY_ROOM_UPDATE_SELECTED = "hotkeys.roomUpdateSelected";
+
 ConstString KEY_LAST_MAP_LOAD_DIRECTORY = "Last map load directory";
 ConstString KEY_LINES_OF_INPUT_HISTORY = "Lines of input history";
 ConstString KEY_LINES_OF_PEEK_PREVIEW = "Lines of peek preview";
@@ -270,6 +362,8 @@ ConstString KEY_PROXY_CONNECTION_STATUS = "Proxy connection status";
 ConstString KEY_PROXY_LISTENS_ON_ANY_INTERFACE = "Proxy listens on any interface";
 ConstString KEY_RELATIVE_PATH_ACCEPTANCE = "relative path acceptance";
 ConstString KEY_RESOURCES_DIRECTORY = "canvas.resourcesDir";
+ConstString KEY_TEXTURE_SET = "canvas.textureSet";
+ConstString KEY_ENABLE_SEASONAL_TEXTURES = "canvas.enableSeasonalTextures";
 ConstString KEY_MUME_REMOTE_PORT = "Remote port number";
 ConstString KEY_REMEMBER_LOGIN = "remember login";
 ConstString KEY_ROOM_CREATION_PENALTY = "room creation penalty";
@@ -441,6 +535,8 @@ NODISCARD static uint16_t sanitizeUint16(const int input, const uint16_t default
         GROUP_CALLBACK(callback, GRP_GENERAL, general); \
         GROUP_CALLBACK(callback, GRP_CONNECTION, connection); \
         GROUP_CALLBACK(callback, GRP_CANVAS, canvas); \
+        GROUP_CALLBACK(callback, GRP_HOTKEYS, hotkeys); \
+        GROUP_CALLBACK(callback, GRP_COMMS, comms); \
         GROUP_CALLBACK(callback, GRP_ACCOUNT, account); \
         GROUP_CALLBACK(callback, GRP_AUTO_LOAD_WORLD, autoLoad); \
         GROUP_CALLBACK(callback, GRP_AUTO_LOG, autoLog); \
@@ -565,7 +661,7 @@ void Configuration::ConnectionSettings::read(const QSettings &conf)
 }
 
 // closest well-known color is "Outer Space"
-static constexpr const std::string_view DEFAULT_BGCOLOR = "#2E3436";
+static constexpr const std::string_view DEFAULT_BGCOLOR = "#161f21";
 // closest well-known color is "Dusty Gray"
 static constexpr const std::string_view DEFAULT_DARK_COLOR = "#A19494";
 // closest well-known color is "Cold Turkey"
@@ -587,11 +683,14 @@ void Configuration::CanvasSettings::read(const QSettings &conf)
                                         .append(DEFAULT_MMAPPER_SUBDIR)
                                         .append(DEFAULT_RESOURCES_SUBDIR))
                              .toString();
+    textureSet = intToTextureSet(conf.value(KEY_TEXTURE_SET, 1).toInt()); // Default: MODERN
+    enableSeasonalTextures = conf.value(KEY_ENABLE_SEASONAL_TEXTURES, true).toBool();
     showMissingMapId.set(conf.value(KEY_SHOW_MISSING_MAP_ID, true).toBool());
     showUnsavedChanges.set(conf.value(KEY_SHOW_UNSAVED_CHANGES, true).toBool());
     showUnmappedExits.set(conf.value(KEY_DRAW_NOT_MAPPED_EXITS, true).toBool());
     drawUpperLayersTextured = conf.value(KEY_DRAW_UPPER_LAYERS_TEXTURED, false).toBool();
     drawDoorNames = conf.value(KEY_DRAW_DOOR_NAMES, true).toBool();
+    layerTransparency = conf.value(KEY_LAYER_TRANSPARENCY, 1.0).toFloat();
     backgroundColor = lookupColor(KEY_BACKGROUND_COLOR, DEFAULT_BGCOLOR);
     connectionNormalColor = lookupColor(KEY_CONNECTION_NORMAL_COLOR, Colors::white.toHex());
     roomDarkColor = lookupColor(KEY_ROOM_DARK_COLOR, DEFAULT_DARK_COLOR);
@@ -605,6 +704,30 @@ void Configuration::CanvasSettings::read(const QSettings &conf)
     advanced.verticalAngle.set(conf.value(KEY_3D_VERTICAL_ANGLE, 450).toInt());
     advanced.horizontalAngle.set(conf.value(KEY_3D_HORIZONTAL_ANGLE, 0).toInt());
     advanced.layerHeight.set(conf.value(KEY_3D_LAYER_HEIGHT, 15).toInt());
+
+    // Load background image settings
+    advanced.useBackgroundImage = conf.value(KEY_BACKGROUND_IMAGE_ENABLED, false).toBool();
+    advanced.backgroundImagePath = conf.value(KEY_BACKGROUND_IMAGE_PATH, "").toString();
+    advanced.backgroundFitMode = conf.value(KEY_BACKGROUND_IMAGE_FIT_MODE, 0).toInt();
+    advanced.backgroundOpacity = conf.value(KEY_BACKGROUND_IMAGE_OPACITY, 1.0f).toFloat();
+    advanced.backgroundFocusedScale = conf.value(KEY_BACKGROUND_IMAGE_FOCUSED_SCALE, 1.0f).toFloat();
+    advanced.backgroundFocusedOffsetX = conf.value(KEY_BACKGROUND_IMAGE_FOCUSED_OFFSET_X, 0.0f)
+                                            .toFloat();
+    advanced.backgroundFocusedOffsetY = conf.value(KEY_BACKGROUND_IMAGE_FOCUSED_OFFSET_Y, 0.0f)
+                                            .toFloat();
+
+    // Load visible markers settings
+    visibilityFilter.generic.set(conf.value(KEY_VISIBLE_MARKER_GENERIC, true).toBool());
+    visibilityFilter.herb.set(conf.value(KEY_VISIBLE_MARKER_HERB, true).toBool());
+    visibilityFilter.river.set(conf.value(KEY_VISIBLE_MARKER_RIVER, true).toBool());
+    visibilityFilter.place.set(conf.value(KEY_VISIBLE_MARKER_PLACE, true).toBool());
+    visibilityFilter.mob.set(conf.value(KEY_VISIBLE_MARKER_MOB, true).toBool());
+    visibilityFilter.comment.set(conf.value(KEY_VISIBLE_MARKER_COMMENT, true).toBool());
+    visibilityFilter.road.set(conf.value(KEY_VISIBLE_MARKER_ROAD, true).toBool());
+    visibilityFilter.object.set(conf.value(KEY_VISIBLE_MARKER_OBJECT, true).toBool());
+    visibilityFilter.action.set(conf.value(KEY_VISIBLE_MARKER_ACTION, true).toBool());
+    visibilityFilter.locality.set(conf.value(KEY_VISIBLE_MARKER_LOCALITY, true).toBool());
+    visibilityFilter.connections.set(conf.value(KEY_VISIBLE_CONNECTIONS, true).toBool());
 }
 
 void Configuration::AccountSettings::read(const QSettings &conf)
@@ -691,11 +814,15 @@ void Configuration::GroupManagerSettings::read(const QSettings &conf)
     npcSortBottom = conf.value(KEY_GROUP_NPC_SORT_BOTTOM, false).toBool();
 }
 
+Configuration::MumeClockSettings::MumeClockSettings() = default;
+
 void Configuration::MumeClockSettings::read(const QSettings &conf)
 {
     // NOTE: old values might be stored as int32
     startEpoch = conf.value(KEY_MUME_START_EPOCH, 1517443173).toLongLong();
     display = conf.value(KEY_DISPLAY_CLOCK, true).toBool();
+    gmcpBroadcast.set(conf.value(KEY_GMCP_BROADCAST_CLOCK, true).toBool());
+    gmcpBroadcastInterval.set(conf.value(KEY_GMCP_BROADCAST_INTERVAL, 2500).toInt());
 }
 
 void Configuration::AdventurePanelSettings::read(const QSettings &conf)
@@ -770,11 +897,14 @@ NODISCARD static auto getQColorName(const XNamedColor &color)
 void Configuration::CanvasSettings::write(QSettings &conf) const
 {
     conf.setValue(KEY_RESOURCES_DIRECTORY, resourcesDirectory);
+    conf.setValue(KEY_TEXTURE_SET, textureSetToInt(textureSet));
+    conf.setValue(KEY_ENABLE_SEASONAL_TEXTURES, enableSeasonalTextures);
     conf.setValue(KEY_SHOW_MISSING_MAP_ID, showMissingMapId.get());
     conf.setValue(KEY_SHOW_UNSAVED_CHANGES, showUnsavedChanges.get());
     conf.setValue(KEY_DRAW_NOT_MAPPED_EXITS, showUnmappedExits.get());
     conf.setValue(KEY_DRAW_UPPER_LAYERS_TEXTURED, drawUpperLayersTextured);
     conf.setValue(KEY_DRAW_DOOR_NAMES, drawDoorNames);
+    conf.setValue(KEY_LAYER_TRANSPARENCY, layerTransparency);
     conf.setValue(KEY_BACKGROUND_COLOR, getQColorName(backgroundColor));
     conf.setValue(KEY_ROOM_DARK_COLOR, getQColorName(roomDarkColor));
     conf.setValue(KEY_ROOM_DARK_LIT_COLOR, getQColorName(roomDarkLitColor));
@@ -788,6 +918,239 @@ void Configuration::CanvasSettings::write(QSettings &conf) const
     conf.setValue(KEY_3D_VERTICAL_ANGLE, advanced.verticalAngle.get());
     conf.setValue(KEY_3D_HORIZONTAL_ANGLE, advanced.horizontalAngle.get());
     conf.setValue(KEY_3D_LAYER_HEIGHT, advanced.layerHeight.get());
+
+    // Save background image settings
+    conf.setValue(KEY_BACKGROUND_IMAGE_ENABLED, advanced.useBackgroundImage);
+    conf.setValue(KEY_BACKGROUND_IMAGE_PATH, advanced.backgroundImagePath);
+    conf.setValue(KEY_BACKGROUND_IMAGE_FIT_MODE, advanced.backgroundFitMode);
+    conf.setValue(KEY_BACKGROUND_IMAGE_OPACITY, advanced.backgroundOpacity);
+    conf.setValue(KEY_BACKGROUND_IMAGE_FOCUSED_SCALE, advanced.backgroundFocusedScale);
+    conf.setValue(KEY_BACKGROUND_IMAGE_FOCUSED_OFFSET_X, advanced.backgroundFocusedOffsetX);
+    conf.setValue(KEY_BACKGROUND_IMAGE_FOCUSED_OFFSET_Y, advanced.backgroundFocusedOffsetY);
+
+    // Save visible markers settings
+    conf.setValue(KEY_VISIBLE_MARKER_GENERIC, visibilityFilter.generic.get());
+    conf.setValue(KEY_VISIBLE_MARKER_HERB, visibilityFilter.herb.get());
+    conf.setValue(KEY_VISIBLE_MARKER_RIVER, visibilityFilter.river.get());
+    conf.setValue(KEY_VISIBLE_MARKER_PLACE, visibilityFilter.place.get());
+    conf.setValue(KEY_VISIBLE_MARKER_MOB, visibilityFilter.mob.get());
+    conf.setValue(KEY_VISIBLE_MARKER_COMMENT, visibilityFilter.comment.get());
+    conf.setValue(KEY_VISIBLE_MARKER_ROAD, visibilityFilter.road.get());
+    conf.setValue(KEY_VISIBLE_MARKER_OBJECT, visibilityFilter.object.get());
+    conf.setValue(KEY_VISIBLE_MARKER_ACTION, visibilityFilter.action.get());
+    conf.setValue(KEY_VISIBLE_MARKER_LOCALITY, visibilityFilter.locality.get());
+    conf.setValue(KEY_VISIBLE_CONNECTIONS, visibilityFilter.connections.get());
+}
+
+void Configuration::Hotkeys::read(const QSettings &conf)
+{
+    // File operations
+    fileOpen.set(conf.value(KEY_HOTKEY_FILE_OPEN, "Ctrl+O").toString());
+    fileSave.set(conf.value(KEY_HOTKEY_FILE_SAVE, "Ctrl+S").toString());
+    fileReload.set(conf.value(KEY_HOTKEY_FILE_RELOAD, "Ctrl+R").toString());
+    fileQuit.set(conf.value(KEY_HOTKEY_FILE_QUIT, "Ctrl+Q").toString());
+
+    // Edit operations
+    editUndo.set(conf.value(KEY_HOTKEY_EDIT_UNDO, "Ctrl+Z").toString());
+    editRedo.set(conf.value(KEY_HOTKEY_EDIT_REDO, "Ctrl+Y").toString());
+    editPreferences.set(conf.value(KEY_HOTKEY_EDIT_PREFERENCES, "Ctrl+P").toString());
+    editPreferencesAlt.set(conf.value(KEY_HOTKEY_EDIT_PREFERENCES_ALT, "Esc").toString());
+    editFindRooms.set(conf.value(KEY_HOTKEY_EDIT_FIND_ROOMS, "Ctrl+F").toString());
+    editRoom.set(conf.value(KEY_HOTKEY_EDIT_ROOM, "Ctrl+E").toString());
+
+    // View operations
+    viewZoomIn.set(conf.value(KEY_HOTKEY_VIEW_ZOOM_IN, "").toString());
+    viewZoomOut.set(conf.value(KEY_HOTKEY_VIEW_ZOOM_OUT, "").toString());
+    viewZoomReset.set(conf.value(KEY_HOTKEY_VIEW_ZOOM_RESET, "Ctrl+0").toString());
+    viewLayerUp.set(conf.value(KEY_HOTKEY_VIEW_LAYER_UP, "").toString());
+    viewLayerDown.set(conf.value(KEY_HOTKEY_VIEW_LAYER_DOWN, "").toString());
+    viewLayerReset.set(conf.value(KEY_HOTKEY_VIEW_LAYER_RESET, "").toString());
+
+    // View toggles
+    viewRadialTransparency.set(conf.value(KEY_HOTKEY_VIEW_RADIAL_TRANSPARENCY, "").toString());
+    viewStatusBar.set(conf.value(KEY_HOTKEY_VIEW_STATUS_BAR, "").toString());
+    viewScrollBars.set(conf.value(KEY_HOTKEY_VIEW_SCROLL_BARS, "").toString());
+    viewMenuBar.set(conf.value(KEY_HOTKEY_VIEW_MENU_BAR, "").toString());
+    viewAlwaysOnTop.set(conf.value(KEY_HOTKEY_VIEW_ALWAYS_ON_TOP, "").toString());
+
+    // Side panels
+    panelLog.set(conf.value(KEY_HOTKEY_PANEL_LOG, "Ctrl+L").toString());
+    panelClient.set(conf.value(KEY_HOTKEY_PANEL_CLIENT, "").toString());
+    panelGroup.set(conf.value(KEY_HOTKEY_PANEL_GROUP, "").toString());
+    panelRoom.set(conf.value(KEY_HOTKEY_PANEL_ROOM, "").toString());
+    panelAdventure.set(conf.value(KEY_HOTKEY_PANEL_ADVENTURE, "").toString());
+    panelComms.set(conf.value(KEY_HOTKEY_PANEL_COMMS, "").toString());
+    panelDescription.set(conf.value(KEY_HOTKEY_PANEL_DESCRIPTION, "").toString());
+
+    // Mouse modes
+    modeMoveMap.set(conf.value(KEY_HOTKEY_MODE_MOVE_MAP, "").toString());
+    modeRaypick.set(conf.value(KEY_HOTKEY_MODE_RAYPICK, "").toString());
+    modeSelectRooms.set(conf.value(KEY_HOTKEY_MODE_SELECT_ROOMS, "").toString());
+    modeSelectMarkers.set(conf.value(KEY_HOTKEY_MODE_SELECT_MARKERS, "").toString());
+    modeSelectConnection.set(conf.value(KEY_HOTKEY_MODE_SELECT_CONNECTION, "").toString());
+    modeCreateMarker.set(conf.value(KEY_HOTKEY_MODE_CREATE_MARKER, "").toString());
+    modeCreateRoom.set(conf.value(KEY_HOTKEY_MODE_CREATE_ROOM, "").toString());
+    modeCreateConnection.set(conf.value(KEY_HOTKEY_MODE_CREATE_CONNECTION, "").toString());
+    modeCreateOnewayConnection.set(
+        conf.value(KEY_HOTKEY_MODE_CREATE_ONEWAY_CONNECTION, "").toString());
+
+    // Room operations
+    roomCreate.set(conf.value(KEY_HOTKEY_ROOM_CREATE, "").toString());
+    roomMoveUp.set(conf.value(KEY_HOTKEY_ROOM_MOVE_UP, "").toString());
+    roomMoveDown.set(conf.value(KEY_HOTKEY_ROOM_MOVE_DOWN, "").toString());
+    roomMergeUp.set(conf.value(KEY_HOTKEY_ROOM_MERGE_UP, "").toString());
+    roomMergeDown.set(conf.value(KEY_HOTKEY_ROOM_MERGE_DOWN, "").toString());
+    roomDelete.set(conf.value(KEY_HOTKEY_ROOM_DELETE, "Del").toString());
+    roomConnectNeighbors.set(conf.value(KEY_HOTKEY_ROOM_CONNECT_NEIGHBORS, "").toString());
+    roomMoveToSelected.set(conf.value(KEY_HOTKEY_ROOM_MOVE_TO_SELECTED, "").toString());
+    roomUpdateSelected.set(conf.value(KEY_HOTKEY_ROOM_UPDATE_SELECTED, "").toString());
+}
+
+void Configuration::Hotkeys::write(QSettings &conf) const
+{
+    // File operations
+    conf.setValue(KEY_HOTKEY_FILE_OPEN, fileOpen.get());
+    conf.setValue(KEY_HOTKEY_FILE_SAVE, fileSave.get());
+    conf.setValue(KEY_HOTKEY_FILE_RELOAD, fileReload.get());
+    conf.setValue(KEY_HOTKEY_FILE_QUIT, fileQuit.get());
+
+    // Edit operations
+    conf.setValue(KEY_HOTKEY_EDIT_UNDO, editUndo.get());
+    conf.setValue(KEY_HOTKEY_EDIT_REDO, editRedo.get());
+    conf.setValue(KEY_HOTKEY_EDIT_PREFERENCES, editPreferences.get());
+    conf.setValue(KEY_HOTKEY_EDIT_PREFERENCES_ALT, editPreferencesAlt.get());
+    conf.setValue(KEY_HOTKEY_EDIT_FIND_ROOMS, editFindRooms.get());
+    conf.setValue(KEY_HOTKEY_EDIT_ROOM, editRoom.get());
+
+    // View operations
+    conf.setValue(KEY_HOTKEY_VIEW_ZOOM_IN, viewZoomIn.get());
+    conf.setValue(KEY_HOTKEY_VIEW_ZOOM_OUT, viewZoomOut.get());
+    conf.setValue(KEY_HOTKEY_VIEW_ZOOM_RESET, viewZoomReset.get());
+    conf.setValue(KEY_HOTKEY_VIEW_LAYER_UP, viewLayerUp.get());
+    conf.setValue(KEY_HOTKEY_VIEW_LAYER_DOWN, viewLayerDown.get());
+    conf.setValue(KEY_HOTKEY_VIEW_LAYER_RESET, viewLayerReset.get());
+
+    // View toggles
+    conf.setValue(KEY_HOTKEY_VIEW_RADIAL_TRANSPARENCY, viewRadialTransparency.get());
+    conf.setValue(KEY_HOTKEY_VIEW_STATUS_BAR, viewStatusBar.get());
+    conf.setValue(KEY_HOTKEY_VIEW_SCROLL_BARS, viewScrollBars.get());
+    conf.setValue(KEY_HOTKEY_VIEW_MENU_BAR, viewMenuBar.get());
+    conf.setValue(KEY_HOTKEY_VIEW_ALWAYS_ON_TOP, viewAlwaysOnTop.get());
+
+    // Side panels
+    conf.setValue(KEY_HOTKEY_PANEL_LOG, panelLog.get());
+    conf.setValue(KEY_HOTKEY_PANEL_CLIENT, panelClient.get());
+    conf.setValue(KEY_HOTKEY_PANEL_GROUP, panelGroup.get());
+    conf.setValue(KEY_HOTKEY_PANEL_ROOM, panelRoom.get());
+    conf.setValue(KEY_HOTKEY_PANEL_ADVENTURE, panelAdventure.get());
+    conf.setValue(KEY_HOTKEY_PANEL_COMMS, panelComms.get());
+    conf.setValue(KEY_HOTKEY_PANEL_DESCRIPTION, panelDescription.get());
+
+    // Mouse modes
+    conf.setValue(KEY_HOTKEY_MODE_MOVE_MAP, modeMoveMap.get());
+    conf.setValue(KEY_HOTKEY_MODE_RAYPICK, modeRaypick.get());
+    conf.setValue(KEY_HOTKEY_MODE_SELECT_ROOMS, modeSelectRooms.get());
+    conf.setValue(KEY_HOTKEY_MODE_SELECT_MARKERS, modeSelectMarkers.get());
+    conf.setValue(KEY_HOTKEY_MODE_SELECT_CONNECTION, modeSelectConnection.get());
+    conf.setValue(KEY_HOTKEY_MODE_CREATE_MARKER, modeCreateMarker.get());
+    conf.setValue(KEY_HOTKEY_MODE_CREATE_ROOM, modeCreateRoom.get());
+    conf.setValue(KEY_HOTKEY_MODE_CREATE_CONNECTION, modeCreateConnection.get());
+    conf.setValue(KEY_HOTKEY_MODE_CREATE_ONEWAY_CONNECTION, modeCreateOnewayConnection.get());
+
+    // Room operations
+    conf.setValue(KEY_HOTKEY_ROOM_CREATE, roomCreate.get());
+    conf.setValue(KEY_HOTKEY_ROOM_MOVE_UP, roomMoveUp.get());
+    conf.setValue(KEY_HOTKEY_ROOM_MOVE_DOWN, roomMoveDown.get());
+    conf.setValue(KEY_HOTKEY_ROOM_MERGE_UP, roomMergeUp.get());
+    conf.setValue(KEY_HOTKEY_ROOM_MERGE_DOWN, roomMergeDown.get());
+    conf.setValue(KEY_HOTKEY_ROOM_DELETE, roomDelete.get());
+    conf.setValue(KEY_HOTKEY_ROOM_CONNECT_NEIGHBORS, roomConnectNeighbors.get());
+    conf.setValue(KEY_HOTKEY_ROOM_MOVE_TO_SELECTED, roomMoveToSelected.get());
+    conf.setValue(KEY_HOTKEY_ROOM_UPDATE_SELECTED, roomUpdateSelected.get());
+}
+
+void Configuration::CommsSettings::read(const QSettings &conf)
+{
+    // Communication colors
+    tellColor.set(conf.value(tellColor.getName(), QColor(32, 108, 9)).value<QColor>());
+    whisperColor.set(conf.value(whisperColor.getName(), QColor(103, 135, 149)).value<QColor>());
+    groupColor.set(conf.value(groupColor.getName(), QColor(15, 123, 255)).value<QColor>());
+    askColor.set(conf.value(askColor.getName(), QColor(Qt::yellow)).value<QColor>());
+    sayColor.set(conf.value(sayColor.getName(), QColor(80, 173, 199)).value<QColor>());
+    emoteColor.set(conf.value(emoteColor.getName(), QColor(203, 37, 111)).value<QColor>());
+    socialColor.set(conf.value(socialColor.getName(), QColor(217, 140, 151)).value<QColor>());
+    yellColor.set(conf.value(yellColor.getName(), QColor(176, 80, 189)).value<QColor>());
+    narrateColor.set(conf.value(narrateColor.getName(), QColor(119, 197, 203)).value<QColor>());
+    prayColor.set(conf.value(prayColor.getName(), QColor(173, 216, 230)).value<QColor>());
+    shoutColor.set(conf.value(shoutColor.getName(), QColor(160, 9, 198)).value<QColor>());
+    singColor.set(conf.value(singColor.getName(), QColor(144, 238, 144)).value<QColor>());
+    backgroundColor.set(conf.value(backgroundColor.getName(), QColor(22, 31, 33)).value<QColor>());
+
+    // Font styling options
+    yellAllCaps.set(conf.value(yellAllCaps.getName(), true).toBool());
+    whisperItalic.set(conf.value(whisperItalic.getName(), true).toBool());
+    emoteItalic.set(conf.value(emoteItalic.getName(), true).toBool());
+
+    // Display options
+    showTimestamps.set(conf.value(showTimestamps.getName(), false).toBool());
+    saveLogOnExit.set(conf.value(saveLogOnExit.getName(), false).toBool());
+    logDirectory.set(conf.value(logDirectory.getName(), QString("")).toString());
+
+    // Talker colors
+    talkerYouColor.set(conf.value(talkerYouColor.getName(), QColor(228, 250, 255)).value<QColor>());
+    talkerPlayerColor.set(
+        conf.value(talkerPlayerColor.getName(), QColor(255, 187, 16)).value<QColor>());
+    talkerNpcColor.set(conf.value(talkerNpcColor.getName(), QColor(25, 138, 23)).value<QColor>());
+    talkerAllyColor.set(conf.value(talkerAllyColor.getName(), QColor(33, 166, 255)).value<QColor>());
+    talkerNeutralColor.set(
+        conf.value(talkerNeutralColor.getName(), QColor(166, 168, 168)).value<QColor>());
+    talkerEnemyColor.set(conf.value(talkerEnemyColor.getName(), QColor(173, 7, 37)).value<QColor>());
+
+    // Tab muting (filters)
+    muteDirectTab.set(conf.value(muteDirectTab.getName(), false).toBool());
+    muteLocalTab.set(conf.value(muteLocalTab.getName(), false).toBool());
+    muteGlobalTab.set(conf.value(muteGlobalTab.getName(), false).toBool());
+}
+
+void Configuration::CommsSettings::write(QSettings &conf) const
+{
+    // Communication colors
+    conf.setValue(tellColor.getName(), tellColor.get());
+    conf.setValue(whisperColor.getName(), whisperColor.get());
+    conf.setValue(groupColor.getName(), groupColor.get());
+    conf.setValue(askColor.getName(), askColor.get());
+    conf.setValue(sayColor.getName(), sayColor.get());
+    conf.setValue(emoteColor.getName(), emoteColor.get());
+    conf.setValue(socialColor.getName(), socialColor.get());
+    conf.setValue(yellColor.getName(), yellColor.get());
+    conf.setValue(narrateColor.getName(), narrateColor.get());
+    conf.setValue(prayColor.getName(), prayColor.get());
+    conf.setValue(shoutColor.getName(), shoutColor.get());
+    conf.setValue(singColor.getName(), singColor.get());
+    conf.setValue(backgroundColor.getName(), backgroundColor.get());
+
+    // Font styling options
+    conf.setValue(yellAllCaps.getName(), yellAllCaps.get());
+    conf.setValue(whisperItalic.getName(), whisperItalic.get());
+    conf.setValue(emoteItalic.getName(), emoteItalic.get());
+
+    // Display options
+    conf.setValue(showTimestamps.getName(), showTimestamps.get());
+    conf.setValue(saveLogOnExit.getName(), saveLogOnExit.get());
+    conf.setValue(logDirectory.getName(), logDirectory.get());
+
+    // Talker colors
+    conf.setValue(talkerYouColor.getName(), talkerYouColor.get());
+    conf.setValue(talkerPlayerColor.getName(), talkerPlayerColor.get());
+    conf.setValue(talkerNpcColor.getName(), talkerNpcColor.get());
+    conf.setValue(talkerAllyColor.getName(), talkerAllyColor.get());
+    conf.setValue(talkerNeutralColor.getName(), talkerNeutralColor.get());
+    conf.setValue(talkerEnemyColor.getName(), talkerEnemyColor.get());
+
+    // Tab muting (filters)
+    conf.setValue(muteDirectTab.getName(), muteDirectTab.get());
+    conf.setValue(muteLocalTab.getName(), muteLocalTab.get());
+    conf.setValue(muteGlobalTab.getName(), muteGlobalTab.get());
 }
 
 void Configuration::AccountSettings::write(QSettings &conf) const
@@ -862,6 +1225,8 @@ void Configuration::MumeClockSettings::write(QSettings &conf) const
     // Note: There's no QVariant(int64_t) constructor.
     conf.setValue(KEY_MUME_START_EPOCH, static_cast<qlonglong>(startEpoch));
     conf.setValue(KEY_DISPLAY_CLOCK, display);
+    conf.setValue(KEY_GMCP_BROADCAST_CLOCK, gmcpBroadcast.get());
+    conf.setValue(KEY_GMCP_BROADCAST_INTERVAL, gmcpBroadcastInterval.get());
 }
 
 void Configuration::AdventurePanelSettings::write(QSettings &conf) const
@@ -992,6 +1357,118 @@ void Configuration::CanvasSettings::Advanced::registerChangeCallback(
     verticalAngle.registerChangeCallback(lifetime, callback);
     horizontalAngle.registerChangeCallback(lifetime, callback);
     layerHeight.registerChangeCallback(lifetime, callback);
+}
+
+Configuration::CanvasSettings::VisibilityFilter::VisibilityFilter() = default;
+
+bool Configuration::CanvasSettings::VisibilityFilter::isVisible(InfomarkClassEnum markerClass) const
+{
+    switch (markerClass) {
+    case InfomarkClassEnum::GENERIC:
+        return generic.get();
+    case InfomarkClassEnum::HERB:
+        return herb.get();
+    case InfomarkClassEnum::RIVER:
+        return river.get();
+    case InfomarkClassEnum::PLACE:
+        return place.get();
+    case InfomarkClassEnum::MOB:
+        return mob.get();
+    case InfomarkClassEnum::COMMENT:
+        return comment.get();
+    case InfomarkClassEnum::ROAD:
+        return road.get();
+    case InfomarkClassEnum::OBJECT:
+        return object.get();
+    case InfomarkClassEnum::ACTION:
+        return action.get();
+    case InfomarkClassEnum::LOCALITY:
+        return locality.get();
+    }
+    return true; // Default to visible for unknown types
+}
+
+void Configuration::CanvasSettings::VisibilityFilter::setVisible(InfomarkClassEnum markerClass,
+                                                                 bool visible)
+{
+    switch (markerClass) {
+    case InfomarkClassEnum::GENERIC:
+        generic.set(visible);
+        break;
+    case InfomarkClassEnum::HERB:
+        herb.set(visible);
+        break;
+    case InfomarkClassEnum::RIVER:
+        river.set(visible);
+        break;
+    case InfomarkClassEnum::PLACE:
+        place.set(visible);
+        break;
+    case InfomarkClassEnum::MOB:
+        mob.set(visible);
+        break;
+    case InfomarkClassEnum::COMMENT:
+        comment.set(visible);
+        break;
+    case InfomarkClassEnum::ROAD:
+        road.set(visible);
+        break;
+    case InfomarkClassEnum::OBJECT:
+        object.set(visible);
+        break;
+    case InfomarkClassEnum::ACTION:
+        action.set(visible);
+        break;
+    case InfomarkClassEnum::LOCALITY:
+        locality.set(visible);
+        break;
+    }
+}
+
+void Configuration::CanvasSettings::VisibilityFilter::showAll()
+{
+    generic.set(true);
+    herb.set(true);
+    river.set(true);
+    place.set(true);
+    mob.set(true);
+    comment.set(true);
+    road.set(true);
+    object.set(true);
+    action.set(true);
+    locality.set(true);
+    connections.set(true);
+}
+
+void Configuration::CanvasSettings::VisibilityFilter::hideAll()
+{
+    generic.set(false);
+    herb.set(false);
+    river.set(false);
+    place.set(false);
+    mob.set(false);
+    comment.set(false);
+    road.set(false);
+    object.set(false);
+    action.set(false);
+    locality.set(false);
+    connections.set(false);
+}
+
+void Configuration::CanvasSettings::VisibilityFilter::registerChangeCallback(
+    const ChangeMonitor::Lifetime &lifetime, const ChangeMonitor::Function &callback)
+{
+    generic.registerChangeCallback(lifetime, callback);
+    herb.registerChangeCallback(lifetime, callback);
+    river.registerChangeCallback(lifetime, callback);
+    place.registerChangeCallback(lifetime, callback);
+    mob.registerChangeCallback(lifetime, callback);
+    comment.registerChangeCallback(lifetime, callback);
+    road.registerChangeCallback(lifetime, callback);
+    object.registerChangeCallback(lifetime, callback);
+    action.registerChangeCallback(lifetime, callback);
+    locality.registerChangeCallback(lifetime, callback);
+    connections.registerChangeCallback(lifetime, callback);
 }
 
 void setEnteredMain()

--- a/src/configuration/configuration.h
+++ b/src/configuration/configuration.h
@@ -29,6 +29,9 @@
 
 #undef TRANSPARENT // Bad dog, Microsoft; bad dog!!!
 
+// Forward declaration for InfomarkClassEnum
+enum class InfomarkClassEnum : uint8_t;
+
 #define SUBGROUP() \
     friend class Configuration; \
     void read(const QSettings &conf); \
@@ -79,6 +82,7 @@ public:
         char prefixChar = char_consts::C_UNDERSCORE;
         bool encodeEmoji = true;
         bool decodeEmoji = true;
+        bool enableYellFallbackParsing = true; // Parse yells from game text when GMCP unavailable
 
     private:
         SUBGROUP();
@@ -143,6 +147,10 @@ public:
         bool trilinearFiltering = false;
         bool softwareOpenGL = false;
         QString resourcesDirectory;
+        TextureSetEnum textureSet = TextureSetEnum::MODERN;
+        bool enableSeasonalTextures = true;
+        float layerTransparency = 1.0f;  // 0.0 = only focused layer, 1.0 = maximum transparency
+        bool enableRadialTransparency = true;  // Enable radial transparency zones on upper layers
 
         // not saved yet:
         bool drawCharBeacons = true;
@@ -159,12 +167,21 @@ public:
             NamedConfig<bool> autoTilt{"MMAPPER_AUTO_TILT", true};
             NamedConfig<bool> printPerfStats{"MMAPPER_GL_PERFSTATS", IS_DEBUG_BUILD};
 
+            // Background image settings
+            bool useBackgroundImage = false;
+            QString backgroundImagePath;
+            int backgroundFitMode = 0;  // BackgroundFitModeEnum::FIT
+            float backgroundOpacity = 1.0f;
+            float backgroundFocusedScale = 1.0f;  // Scale factor for FOCUSED mode (0.1 to 10.0)
+            float backgroundFocusedOffsetX = 0.0f;  // X offset for FOCUSED mode (-1000 to 1000)
+            float backgroundFocusedOffsetY = 0.0f;  // Y offset for FOCUSED mode (-1000 to 1000)
+
             // 5..90 degrees
             FixedPoint<1> fov{50, 900, 765};
             // 0..90 degrees
             FixedPoint<1> verticalAngle{0, 900, 450};
-            // -45..45 degrees
-            FixedPoint<1> horizontalAngle{-450, 450, 0};
+            // -180..180 degrees (full rotation)
+            FixedPoint<1> horizontalAngle{-1800, 1800, 0};
             // 1..10 rooms
             FixedPoint<1> layerHeight{10, 100, 15};
 
@@ -175,9 +192,146 @@ public:
             Advanced();
         } advanced;
 
+        struct NODISCARD VisibilityFilter final
+        {
+            NamedConfig<bool> generic{"VISIBLE_MARKER_GENERIC", true};
+            NamedConfig<bool> herb{"VISIBLE_MARKER_HERB", true};
+            NamedConfig<bool> river{"VISIBLE_MARKER_RIVER", true};
+            NamedConfig<bool> place{"VISIBLE_MARKER_PLACE", true};
+            NamedConfig<bool> mob{"VISIBLE_MARKER_MOB", true};
+            NamedConfig<bool> comment{"VISIBLE_MARKER_COMMENT", true};
+            NamedConfig<bool> road{"VISIBLE_MARKER_ROAD", true};
+            NamedConfig<bool> object{"VISIBLE_MARKER_OBJECT", true};
+            NamedConfig<bool> action{"VISIBLE_MARKER_ACTION", true};
+            NamedConfig<bool> locality{"VISIBLE_MARKER_LOCALITY", true};
+            NamedConfig<bool> connections{"VISIBLE_CONNECTIONS", true};
+
+        public:
+            NODISCARD bool isVisible(InfomarkClassEnum markerClass) const;
+            void setVisible(InfomarkClassEnum markerClass, bool visible);
+            NODISCARD bool isConnectionsVisible() const { return connections.get(); }
+            void setConnectionsVisible(bool visible) { connections.set(visible); }
+            void showAll();
+            void hideAll();
+            void registerChangeCallback(const ChangeMonitor::Lifetime &lifetime,
+                                       const ChangeMonitor::Function &callback);
+
+            VisibilityFilter();
+        } visibilityFilter;
+
     private:
         SUBGROUP();
     } canvas;
+
+    struct NODISCARD Hotkeys final
+    {
+        // File operations
+        NamedConfig<QString> fileOpen{"HOTKEY_FILE_OPEN", "Ctrl+O"};
+        NamedConfig<QString> fileSave{"HOTKEY_FILE_SAVE", "Ctrl+S"};
+        NamedConfig<QString> fileReload{"HOTKEY_FILE_RELOAD", "Ctrl+R"};
+        NamedConfig<QString> fileQuit{"HOTKEY_FILE_QUIT", "Ctrl+Q"};
+
+        // Edit operations
+        NamedConfig<QString> editUndo{"HOTKEY_EDIT_UNDO", "Ctrl+Z"};
+        NamedConfig<QString> editRedo{"HOTKEY_EDIT_REDO", "Ctrl+Y"};
+        NamedConfig<QString> editPreferences{"HOTKEY_EDIT_PREFERENCES", "Ctrl+P"};
+        NamedConfig<QString> editPreferencesAlt{"HOTKEY_EDIT_PREFERENCES_ALT", "Esc"};
+        NamedConfig<QString> editFindRooms{"HOTKEY_EDIT_FIND_ROOMS", "Ctrl+F"};
+        NamedConfig<QString> editRoom{"HOTKEY_EDIT_ROOM", "Ctrl+E"};
+
+        // View operations
+        NamedConfig<QString> viewZoomIn{"HOTKEY_VIEW_ZOOM_IN", ""};
+        NamedConfig<QString> viewZoomOut{"HOTKEY_VIEW_ZOOM_OUT", ""};
+        NamedConfig<QString> viewZoomReset{"HOTKEY_VIEW_ZOOM_RESET", "Ctrl+0"};
+        NamedConfig<QString> viewLayerUp{"HOTKEY_VIEW_LAYER_UP", ""};
+        NamedConfig<QString> viewLayerDown{"HOTKEY_VIEW_LAYER_DOWN", ""};
+        NamedConfig<QString> viewLayerReset{"HOTKEY_VIEW_LAYER_RESET", ""};
+
+        // View toggles
+        NamedConfig<QString> viewRadialTransparency{"HOTKEY_VIEW_RADIAL_TRANSPARENCY", ""};
+        NamedConfig<QString> viewStatusBar{"HOTKEY_VIEW_STATUS_BAR", ""};
+        NamedConfig<QString> viewScrollBars{"HOTKEY_VIEW_SCROLL_BARS", ""};
+        NamedConfig<QString> viewMenuBar{"HOTKEY_VIEW_MENU_BAR", ""};
+        NamedConfig<QString> viewAlwaysOnTop{"HOTKEY_VIEW_ALWAYS_ON_TOP", ""};
+
+        // Side panels
+        NamedConfig<QString> panelLog{"HOTKEY_PANEL_LOG", "Ctrl+L"};
+        NamedConfig<QString> panelClient{"HOTKEY_PANEL_CLIENT", ""};
+        NamedConfig<QString> panelGroup{"HOTKEY_PANEL_GROUP", ""};
+        NamedConfig<QString> panelRoom{"HOTKEY_PANEL_ROOM", ""};
+        NamedConfig<QString> panelAdventure{"HOTKEY_PANEL_ADVENTURE", ""};
+        NamedConfig<QString> panelDescription{"HOTKEY_PANEL_DESCRIPTION", ""};
+        NamedConfig<QString> panelComms{"HOTKEY_PANEL_COMMS", ""};
+
+        // Mouse modes
+        NamedConfig<QString> modeMoveMap{"HOTKEY_MODE_MOVE_MAP", ""};
+        NamedConfig<QString> modeRaypick{"HOTKEY_MODE_RAYPICK", ""};
+        NamedConfig<QString> modeSelectRooms{"HOTKEY_MODE_SELECT_ROOMS", ""};
+        NamedConfig<QString> modeSelectMarkers{"HOTKEY_MODE_SELECT_MARKERS", ""};
+        NamedConfig<QString> modeSelectConnection{"HOTKEY_MODE_SELECT_CONNECTION", ""};
+        NamedConfig<QString> modeCreateMarker{"HOTKEY_MODE_CREATE_MARKER", ""};
+        NamedConfig<QString> modeCreateRoom{"HOTKEY_MODE_CREATE_ROOM", ""};
+        NamedConfig<QString> modeCreateConnection{"HOTKEY_MODE_CREATE_CONNECTION", ""};
+        NamedConfig<QString> modeCreateOnewayConnection{"HOTKEY_MODE_CREATE_ONEWAY_CONNECTION", ""};
+
+        // Room operations
+        NamedConfig<QString> roomCreate{"HOTKEY_ROOM_CREATE", ""};
+        NamedConfig<QString> roomMoveUp{"HOTKEY_ROOM_MOVE_UP", ""};
+        NamedConfig<QString> roomMoveDown{"HOTKEY_ROOM_MOVE_DOWN", ""};
+        NamedConfig<QString> roomMergeUp{"HOTKEY_ROOM_MERGE_UP", ""};
+        NamedConfig<QString> roomMergeDown{"HOTKEY_ROOM_MERGE_DOWN", ""};
+        NamedConfig<QString> roomDelete{"HOTKEY_ROOM_DELETE", "Del"};
+        NamedConfig<QString> roomConnectNeighbors{"HOTKEY_ROOM_CONNECT_NEIGHBORS", ""};
+        NamedConfig<QString> roomMoveToSelected{"HOTKEY_ROOM_MOVE_TO_SELECTED", ""};
+        NamedConfig<QString> roomUpdateSelected{"HOTKEY_ROOM_UPDATE_SELECTED", ""};
+
+    private:
+        SUBGROUP();
+    } hotkeys;
+
+    struct NODISCARD CommsSettings final
+    {
+        // Colors for each communication type
+        NamedConfig<QColor> tellColor{"COMMS_TELL_COLOR", QColor(Qt::cyan)};
+        NamedConfig<QColor> whisperColor{"COMMS_WHISPER_COLOR", QColor(135, 206, 250)};  // Light sky blue
+        NamedConfig<QColor> groupColor{"COMMS_GROUP_COLOR", QColor(Qt::green)};
+        NamedConfig<QColor> askColor{"COMMS_ASK_COLOR", QColor(Qt::yellow)};
+        NamedConfig<QColor> sayColor{"COMMS_SAY_COLOR", QColor(Qt::white)};
+        NamedConfig<QColor> emoteColor{"COMMS_EMOTE_COLOR", QColor(Qt::magenta)};
+        NamedConfig<QColor> socialColor{"COMMS_SOCIAL_COLOR", QColor(255, 182, 193)};  // Light pink
+        NamedConfig<QColor> yellColor{"COMMS_YELL_COLOR", QColor(Qt::red)};
+        NamedConfig<QColor> narrateColor{"COMMS_NARRATE_COLOR", QColor(255, 165, 0)};  // Orange
+        NamedConfig<QColor> prayColor{"COMMS_PRAY_COLOR", QColor(173, 216, 230)};  // Light blue
+        NamedConfig<QColor> shoutColor{"COMMS_SHOUT_COLOR", QColor(139, 0, 0)};  // Dark red
+        NamedConfig<QColor> singColor{"COMMS_SING_COLOR", QColor(144, 238, 144)};  // Light green
+        NamedConfig<QColor> backgroundColor{"COMMS_BG_COLOR", QColor(Qt::black)};
+
+        // Talker colors (based on GMCP Comm.Channel talker-type)
+        NamedConfig<QColor> talkerYouColor{"COMMS_TALKER_YOU_COLOR", QColor(255, 215, 0)};  // Gold
+        NamedConfig<QColor> talkerPlayerColor{"COMMS_TALKER_PLAYER_COLOR", QColor(Qt::white)};
+        NamedConfig<QColor> talkerNpcColor{"COMMS_TALKER_NPC_COLOR", QColor(192, 192, 192)};  // Silver/Gray
+        NamedConfig<QColor> talkerAllyColor{"COMMS_TALKER_ALLY_COLOR", QColor(0, 255, 0)};  // Bright green
+        NamedConfig<QColor> talkerNeutralColor{"COMMS_TALKER_NEUTRAL_COLOR", QColor(255, 255, 0)};  // Yellow
+        NamedConfig<QColor> talkerEnemyColor{"COMMS_TALKER_ENEMY_COLOR", QColor(255, 0, 0)};  // Red
+
+        // Font styling options
+        NamedConfig<bool> yellAllCaps{"COMMS_YELL_ALL_CAPS", true};
+        NamedConfig<bool> whisperItalic{"COMMS_WHISPER_ITALIC", true};
+        NamedConfig<bool> emoteItalic{"COMMS_EMOTE_ITALIC", true};
+
+        // Display options
+        NamedConfig<bool> showTimestamps{"COMMS_SHOW_TIMESTAMPS", false};
+        NamedConfig<bool> saveLogOnExit{"COMMS_SAVE_LOG_ON_EXIT", false};
+        NamedConfig<QString> logDirectory{"COMMS_LOG_DIR", ""};
+
+        // Tab muting (acts as a filter)
+        NamedConfig<bool> muteDirectTab{"COMMS_MUTE_DIRECT", false};
+        NamedConfig<bool> muteLocalTab{"COMMS_MUTE_LOCAL", false};
+        NamedConfig<bool> muteGlobalTab{"COMMS_MUTE_GLOBAL", false};
+
+    private:
+        SUBGROUP();
+    } comms;
 
 #define XFOREACH_NAMED_COLOR_OPTIONS(X) \
     X(BACKGROUND, BACKGROUND_NAME) \
@@ -300,6 +454,10 @@ public:
     {
         int64_t startEpoch = 0;
         bool display = false;
+        NamedConfig<bool> gmcpBroadcast{"GMCP_BROADCAST_CLOCK", true};  // Enable GMCP clock broadcasting
+        NamedConfig<int> gmcpBroadcastInterval{"GMCP_BROADCAST_INTERVAL", 2500};  // Update interval in milliseconds (default: 2.5 seconds = 1 MUME minute)
+
+        MumeClockSettings();
 
     private:
         SUBGROUP();

--- a/src/display/Connections.cpp
+++ b/src/display/Connections.cpp
@@ -226,6 +226,10 @@ void ConnectionDrawer::drawRoomDoorName(const RoomHandle &sourceRoom,
 
 void ConnectionDrawer::drawRoomConnectionsAndDoors(const RoomHandle &room)
 {
+    // Note: We always build connection meshes regardless of visibility filter.
+    // The visibility is handled during rendering by using alpha transparency,
+    // which avoids expensive texture rebuilds when toggling visibility.
+
     const Map &map = room.getMap();
 
     // Ooops, this is wrong since we may reject a connection that would be visible
@@ -624,6 +628,11 @@ ConnectionMeshes ConnectionDrawerBuffers::getMeshes(OpenGL &gl) const
 
 void ConnectionMeshes::render(const int thisLayer, const int focusedLayer) const
 {
+    // Check visibility filter - use alpha 0 to hide without rebuilding batches
+    if (!getConfig().canvas.visibilityFilter.isConnectionsVisible()) {
+        return;  // Early return when hidden - no rendering needed at all
+    }
+
     const auto color = [&thisLayer, &focusedLayer]() {
         if (thisLayer == focusedLayer) {
             return getCanvasNamedColorOptions().connectionNormalColor.getColor();

--- a/src/display/Infomarks.cpp
+++ b/src/display/Infomarks.cpp
@@ -233,6 +233,12 @@ void MapCanvas::drawInfomark(InfomarksBatch &batch,
         return;
     }
 
+    // Check marker visibility settings
+    const auto infoMarkClass = marker.getClass();
+    if (!getConfig().canvas.visibilityFilter.isVisible(infoMarkClass)) {
+        return;
+    }
+
     const Coordinate &pos2 = marker.getPosition2();
     const float x1 = static_cast<float>(pos1.x) / INFOMARK_SCALE + offset.x;
     const float y1 = static_cast<float>(pos1.y) / INFOMARK_SCALE + offset.y;
@@ -242,7 +248,7 @@ void MapCanvas::drawInfomark(InfomarksBatch &batch,
     const float dy = y2 - y1;
 
     const auto infoMarkType = marker.getType();
-    const auto infoMarkClass = marker.getClass();
+    // infoMarkClass already retrieved above for visibility check
 
     // Color depends of the class of the Infomark
     const Color infoMarkColor = getInfomarkColor(infoMarkType, infoMarkClass).withAlpha(0.55f);

--- a/src/mainwindow/VisibilityFilterWidget.cpp
+++ b/src/mainwindow/VisibilityFilterWidget.cpp
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2025 The MMapper Authors
+
+#include "VisibilityFilterWidget.h"
+
+#include "../configuration/configuration.h"
+#include "../map/infomark.h"
+
+#include <QCheckBox>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+VisibilityFilterWidget::VisibilityFilterWidget(QWidget *parent)
+    : QWidget(parent)
+{
+    setupUI();
+    connectSignals();
+    setupChangeCallbacks();
+    updateCheckboxStates();
+}
+
+void VisibilityFilterWidget::setupUI()
+{
+    auto *mainLayout = new QVBoxLayout(this);
+    mainLayout->setContentsMargins(6, 6, 6, 6);
+
+    // Group box for marker checkboxes
+    auto *groupBox = new QGroupBox(tr("Visibility Filter"), this);
+    auto *gridLayout = new QGridLayout(groupBox);
+    gridLayout->setSpacing(8);
+
+    // Create checkboxes in 2-column layout
+    m_genericCheckBox = new QCheckBox(tr("Generic"), groupBox);
+    m_herbCheckBox = new QCheckBox(tr("Herb"), groupBox);
+    m_riverCheckBox = new QCheckBox(tr("River"), groupBox);
+    m_placeCheckBox = new QCheckBox(tr("Place"), groupBox);
+    m_mobCheckBox = new QCheckBox(tr("Mob"), groupBox);
+    m_commentCheckBox = new QCheckBox(tr("Comment"), groupBox);
+    m_roadCheckBox = new QCheckBox(tr("Road"), groupBox);
+    m_objectCheckBox = new QCheckBox(tr("Object"), groupBox);
+    m_actionCheckBox = new QCheckBox(tr("Action"), groupBox);
+    m_localityCheckBox = new QCheckBox(tr("Locality"), groupBox);
+    m_connectionsCheckBox = new QCheckBox(tr("Connections"), groupBox);
+
+    // Add checkboxes to grid (2 columns)
+    gridLayout->addWidget(m_genericCheckBox, 0, 0);
+    gridLayout->addWidget(m_herbCheckBox, 0, 1);
+    gridLayout->addWidget(m_riverCheckBox, 1, 0);
+    gridLayout->addWidget(m_placeCheckBox, 1, 1);
+    gridLayout->addWidget(m_mobCheckBox, 2, 0);
+    gridLayout->addWidget(m_commentCheckBox, 2, 1);
+    gridLayout->addWidget(m_roadCheckBox, 3, 0);
+    gridLayout->addWidget(m_objectCheckBox, 3, 1);
+    gridLayout->addWidget(m_actionCheckBox, 4, 0);
+    gridLayout->addWidget(m_localityCheckBox, 4, 1);
+    gridLayout->addWidget(m_connectionsCheckBox, 5, 0);
+
+    mainLayout->addWidget(groupBox);
+
+    // Buttons layout
+    auto *buttonLayout = new QHBoxLayout();
+    m_showAllButton = new QPushButton(tr("Show All"), this);
+    m_hideAllButton = new QPushButton(tr("Hide All"), this);
+    buttonLayout->addWidget(m_showAllButton);
+    buttonLayout->addWidget(m_hideAllButton);
+    buttonLayout->addStretch();
+
+    mainLayout->addLayout(buttonLayout);
+    mainLayout->addStretch();
+
+    setLayout(mainLayout);
+}
+
+void VisibilityFilterWidget::connectSignals()
+{
+    auto &visibilityFilter = setConfig().canvas.visibilityFilter;
+
+    connect(m_genericCheckBox, &QCheckBox::toggled, [this, &visibilityFilter](bool checked) {
+        visibilityFilter.setVisible(InfomarkClassEnum::GENERIC, checked);
+        emit sig_visibilityChanged();
+    });
+
+    connect(m_herbCheckBox, &QCheckBox::toggled, [this, &visibilityFilter](bool checked) {
+        visibilityFilter.setVisible(InfomarkClassEnum::HERB, checked);
+        emit sig_visibilityChanged();
+    });
+
+    connect(m_riverCheckBox, &QCheckBox::toggled, [this, &visibilityFilter](bool checked) {
+        visibilityFilter.setVisible(InfomarkClassEnum::RIVER, checked);
+        emit sig_visibilityChanged();
+    });
+
+    connect(m_placeCheckBox, &QCheckBox::toggled, [this, &visibilityFilter](bool checked) {
+        visibilityFilter.setVisible(InfomarkClassEnum::PLACE, checked);
+        emit sig_visibilityChanged();
+    });
+
+    connect(m_mobCheckBox, &QCheckBox::toggled, [this, &visibilityFilter](bool checked) {
+        visibilityFilter.setVisible(InfomarkClassEnum::MOB, checked);
+        emit sig_visibilityChanged();
+    });
+
+    connect(m_commentCheckBox, &QCheckBox::toggled, [this, &visibilityFilter](bool checked) {
+        visibilityFilter.setVisible(InfomarkClassEnum::COMMENT, checked);
+        emit sig_visibilityChanged();
+    });
+
+    connect(m_roadCheckBox, &QCheckBox::toggled, [this, &visibilityFilter](bool checked) {
+        visibilityFilter.setVisible(InfomarkClassEnum::ROAD, checked);
+        emit sig_visibilityChanged();
+    });
+
+    connect(m_objectCheckBox, &QCheckBox::toggled, [this, &visibilityFilter](bool checked) {
+        visibilityFilter.setVisible(InfomarkClassEnum::OBJECT, checked);
+        emit sig_visibilityChanged();
+    });
+
+    connect(m_actionCheckBox, &QCheckBox::toggled, [this, &visibilityFilter](bool checked) {
+        visibilityFilter.setVisible(InfomarkClassEnum::ACTION, checked);
+        emit sig_visibilityChanged();
+    });
+
+    connect(m_localityCheckBox, &QCheckBox::toggled, [this, &visibilityFilter](bool checked) {
+        visibilityFilter.setVisible(InfomarkClassEnum::LOCALITY, checked);
+        emit sig_visibilityChanged();
+    });
+
+    connect(m_connectionsCheckBox, &QCheckBox::toggled, [this, &visibilityFilter](bool checked) {
+        visibilityFilter.setConnectionsVisible(checked);
+        emit sig_connectionsVisibilityChanged();
+    });
+
+    // Show All / Hide All buttons
+    connect(m_showAllButton, &QPushButton::clicked, [this, &visibilityFilter]() {
+        visibilityFilter.showAll();
+        emit sig_visibilityChanged();
+        emit sig_connectionsVisibilityChanged();
+    });
+
+    connect(m_hideAllButton, &QPushButton::clicked, [this, &visibilityFilter]() {
+        visibilityFilter.hideAll();
+        emit sig_visibilityChanged();
+        emit sig_connectionsVisibilityChanged();
+    });
+}
+
+void VisibilityFilterWidget::setupChangeCallbacks()
+{
+    auto &visibilityFilter = setConfig().canvas.visibilityFilter;
+    visibilityFilter.registerChangeCallback(m_changeMonitorLifetime, [this]() {
+        updateCheckboxStates();
+    });
+}
+
+void VisibilityFilterWidget::updateCheckboxStates()
+{
+    const auto &visibilityFilter = getConfig().canvas.visibilityFilter;
+
+    // Block signals to prevent triggering setVisible during updates
+    m_genericCheckBox->blockSignals(true);
+    m_herbCheckBox->blockSignals(true);
+    m_riverCheckBox->blockSignals(true);
+    m_placeCheckBox->blockSignals(true);
+    m_mobCheckBox->blockSignals(true);
+    m_commentCheckBox->blockSignals(true);
+    m_roadCheckBox->blockSignals(true);
+    m_objectCheckBox->blockSignals(true);
+    m_actionCheckBox->blockSignals(true);
+    m_localityCheckBox->blockSignals(true);
+    m_connectionsCheckBox->blockSignals(true);
+
+    // Update checkbox states
+    m_genericCheckBox->setChecked(visibilityFilter.isVisible(InfomarkClassEnum::GENERIC));
+    m_herbCheckBox->setChecked(visibilityFilter.isVisible(InfomarkClassEnum::HERB));
+    m_riverCheckBox->setChecked(visibilityFilter.isVisible(InfomarkClassEnum::RIVER));
+    m_placeCheckBox->setChecked(visibilityFilter.isVisible(InfomarkClassEnum::PLACE));
+    m_mobCheckBox->setChecked(visibilityFilter.isVisible(InfomarkClassEnum::MOB));
+    m_commentCheckBox->setChecked(visibilityFilter.isVisible(InfomarkClassEnum::COMMENT));
+    m_roadCheckBox->setChecked(visibilityFilter.isVisible(InfomarkClassEnum::ROAD));
+    m_objectCheckBox->setChecked(visibilityFilter.isVisible(InfomarkClassEnum::OBJECT));
+    m_actionCheckBox->setChecked(visibilityFilter.isVisible(InfomarkClassEnum::ACTION));
+    m_localityCheckBox->setChecked(visibilityFilter.isVisible(InfomarkClassEnum::LOCALITY));
+    m_connectionsCheckBox->setChecked(visibilityFilter.isConnectionsVisible());
+
+    // Unblock signals
+    m_genericCheckBox->blockSignals(false);
+    m_herbCheckBox->blockSignals(false);
+    m_riverCheckBox->blockSignals(false);
+    m_placeCheckBox->blockSignals(false);
+    m_mobCheckBox->blockSignals(false);
+    m_commentCheckBox->blockSignals(false);
+    m_roadCheckBox->blockSignals(false);
+    m_objectCheckBox->blockSignals(false);
+    m_actionCheckBox->blockSignals(false);
+    m_localityCheckBox->blockSignals(false);
+    m_connectionsCheckBox->blockSignals(false);
+}

--- a/src/mainwindow/VisibilityFilterWidget.h
+++ b/src/mainwindow/VisibilityFilterWidget.h
@@ -1,0 +1,47 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2025 The MMapper Authors
+
+#include "../configuration/NamedConfig.h"
+
+#include <QWidget>
+
+class QCheckBox;
+class QPushButton;
+
+class NODISCARD_QOBJECT VisibilityFilterWidget final : public QWidget
+{
+    Q_OBJECT
+
+signals:
+    void sig_visibilityChanged();
+    void sig_connectionsVisibilityChanged();
+
+private:
+    QCheckBox *m_genericCheckBox = nullptr;
+    QCheckBox *m_herbCheckBox = nullptr;
+    QCheckBox *m_riverCheckBox = nullptr;
+    QCheckBox *m_placeCheckBox = nullptr;
+    QCheckBox *m_mobCheckBox = nullptr;
+    QCheckBox *m_commentCheckBox = nullptr;
+    QCheckBox *m_roadCheckBox = nullptr;
+    QCheckBox *m_objectCheckBox = nullptr;
+    QCheckBox *m_actionCheckBox = nullptr;
+    QCheckBox *m_localityCheckBox = nullptr;
+    QCheckBox *m_connectionsCheckBox = nullptr;
+
+    QPushButton *m_showAllButton = nullptr;
+    QPushButton *m_hideAllButton = nullptr;
+
+    ChangeMonitor::Lifetime m_changeMonitorLifetime;
+
+public:
+    explicit VisibilityFilterWidget(QWidget *parent = nullptr);
+    ~VisibilityFilterWidget() final = default;
+
+private:
+    void setupUI();
+    void connectSignals();
+    void setupChangeCallbacks();
+    void updateCheckboxStates();
+};

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -34,6 +34,8 @@ class AdventureTracker;
 class AdventureWidget;
 class AutoLogger;
 class ClientWidget;
+class CommsManager;
+class CommsWidget;
 class ConfigDialog;
 class ConnectionListener;
 class ConnectionSelection;
@@ -66,6 +68,7 @@ class RoomSelection;
 class RoomWidget;
 class UpdateDialog;
 class DescriptionWidget;
+class VisibilityFilterWidget;
 
 struct MapLoadData;
 
@@ -85,6 +88,8 @@ private:
     QDockWidget *m_dockDialogGroup = nullptr;
     QDockWidget *m_dockDialogAdventure = nullptr;
     QDockWidget *m_dockDialogDescription = nullptr;
+    QDockWidget *m_dockDialogComms = nullptr;
+    QDockWidget *m_dockDialogVisibleMarkers = nullptr;
 
     std::unique_ptr<GameObserver> m_gameObserver;
     AutoLogger *m_logger = nullptr;
@@ -108,7 +113,11 @@ private:
     AdventureTracker *m_adventureTracker = nullptr;
     AdventureWidget *m_adventureWidget = nullptr;
 
+    CommsManager *m_commsManager = nullptr;
+    CommsWidget *m_commsWidget = nullptr;
+
     DescriptionWidget *m_descriptionWidget = nullptr;
+    VisibilityFilterWidget *m_visibilityFilterWidget = nullptr;
 
     SharedRoomSelection m_roomSelection;
     std::shared_ptr<ConnectionSelection> m_connectionSelection;
@@ -166,6 +175,7 @@ private:
     QAction *zoomOutAct = nullptr;
     QAction *zoomResetAct = nullptr;
     QAction *alwaysOnTopAct = nullptr;
+    QAction *radialTransparencyAct = nullptr;
     QAction *showStatusBarAct = nullptr;
     QAction *showScrollBarsAct = nullptr;
     QAction *showMenuBarAct = nullptr;
@@ -222,6 +232,7 @@ private:
 
     QAction *clientAct = nullptr;
     QAction *saveLogAct = nullptr;
+    QAction *saveCommsLogAct = nullptr;
 
     QAction *gotoRoomAct = nullptr;
     QAction *forceRoomAct = nullptr;
@@ -304,6 +315,8 @@ private:
     void setupMenuBar();
     void setupToolBars();
     void setupStatusBar();
+    void applyHotkeys();
+    void registerGlobalShortcuts();
 
     void readSettings();
     void writeSettings();
@@ -432,6 +445,7 @@ public slots:
     void slot_onOfflineMode();
     void slot_setMode(MapModeEnum mode);
     void slot_alwaysOnTop();
+    void slot_setRadialTransparency();
     void slot_setShowStatusBar();
     void slot_setShowScrollBars();
     void slot_setShowMenuBar();


### PR DESCRIPTION
Visibility Filter System:
- New VisibilityFilterWidget for controlling map element visibility
- Selective show/hide for all infomark types (Generic, Herb, River, Place, etc.)
- Connection visibility toggle
- Dockable filter panel in main window

Features:
- Per-marker-class visibility controls (10 types)
- Show All / Hide All quick actions
- Connection display toggle
- Real-time map updates when filters change
- Persistent filter state in configuration

Infomark Types:
- Generic, Herb, River, Place, Mob, Comment, Road, Object, Action, Locality
- Each type individually toggleable
- Color-coded by marker class

Configuration Infrastructure:
- VisibilityFilter configuration struct with NamedConfig
- isVisible() and setVisible() helper methods
- Change callbacks for live map updates
- Stored per-marker-class in config

Integration:
- Infomarks.cpp checks visibility before rendering
- Connections.cpp respects connection visibility setting
- MainWindow dock integration
- No dependencies on other PRs

This allows users to declutter the map by hiding marker types they're not currently interested in, improving map readability.

## Summary by Sourcery

Introduce configurable map visibility controls, enhanced graphics options, and new communications/hotkey infrastructure in the main window and configuration system.

New Features:
- Add a dockable Visibility Filter panel with per-infomark-type and connection visibility toggles that update the map in real time.
- Persist per-marker-class and connection visibility preferences in the canvas configuration and expose helpers for querying and updating them.
- Add a dedicated Communications panel backed by a CommsManager/CommsWidget for parsing, displaying, and logging in-game communication channels.
- Introduce configurable global hotkeys for file, edit, view, panel, mouse mode, and room operations, all applied from user preferences.
- Support multiple texture sets, seasonal textures, background images, and radial layer transparency in map rendering.
- Enable GMCP-based MUME clock broadcasting with configurable interval from settings.

Enhancements:
- Wire visibility checks into infomark and connection rendering to skip drawing hidden elements without rebuilding meshes.
- Register all actions with the main window to ensure shortcuts work globally across the application.
- Extend graphics settings with layer transparency and expanded 3D camera angle ranges.
- Add structured configuration groups for hotkeys and communications, including color schemes, styling, and logging options.
- Update default background color and integrate texture reload and seasonal change handling with the map canvas.

Build:
- Add new comms, visibility filter widget, and preference page sources to the CMake build configuration.

Chores:
- Refactor main window initialization order to construct the game observer and clock before map data and to create the AutoLogger earlier.