### PR TITLE
switch to 2D texture arrays

### DIFF
--- a/src/display/Characters.cpp
+++ b/src/display/Characters.cpp
@@ -282,7 +282,7 @@ void CharacterBatch::CharFakeGL::drawBox(const Coordinate &coord,
         const auto &m = m_stack.top().modelView;
         const auto addTransformed = [this, &color, &m](const glm::vec2 &in_vert) -> void {
             const auto tmp = m * glm::vec4(in_vert, 0.f, 1.f);
-            m_charRoomQuads.emplace_back(color, in_vert, glm::vec3{tmp / tmp.w});
+            m_charRoomQuads.emplace_back(color, glm::vec3{in_vert, 0}, glm::vec3{tmp / tmp.w});
         };
         addTransformed(a);
         addTransformed(b);
@@ -329,7 +329,8 @@ void CharacterBatch::CharFakeGL::reallyDrawCharacters(OpenGL &gl, const MapCanva
 
     if (!m_charRoomQuads.empty()) {
         gl.renderColoredTexturedQuads(m_charRoomQuads,
-                                      blended_noDepth.withTexture0(textures.char_room_sel->getId()));
+                                      blended_noDepth.withTexture0(
+                                          textures.char_room_sel->getArrayPosition().array));
     }
 
     if (!m_charTris.empty()) {

--- a/src/display/MapCanvasRoomDrawer.cpp
+++ b/src/display/MapCanvasRoomDrawer.cpp
@@ -142,8 +142,8 @@ struct LayerBatchData;
 
 struct NODISCARD TerrainAndTrail final
 {
-    MMTextureId terrain = INVALID_MM_TEXTURE_ID;
-    MMTextureId trail = INVALID_MM_TEXTURE_ID;
+    MMTexArrayPosition terrain;
+    MMTexArrayPosition trail;
 };
 
 NODISCARD static TerrainAndTrail getRoomTerrainAndTrail(const mctp::MapCanvasTexturesProxy &textures,
@@ -164,6 +164,7 @@ NODISCARD static TerrainAndTrail getRoomTerrainAndTrail(const mctp::MapCanvasTex
 
 struct NODISCARD IRoomVisitorCallbacks
 {
+public:
     virtual ~IRoomVisitorCallbacks();
 
 private:
@@ -171,9 +172,9 @@ private:
 
 private:
     // Rooms
-    virtual void virt_visitTerrainTexture(const RoomHandle &, MMTextureId) = 0;
-    virtual void virt_visitTrailTexture(const RoomHandle &, MMTextureId) = 0;
-    virtual void virt_visitOverlayTexture(const RoomHandle &, MMTextureId) = 0;
+    virtual void virt_visitTerrainTexture(const RoomHandle &, const MMTexArrayPosition &) = 0;
+    virtual void virt_visitTrailTexture(const RoomHandle &, const MMTexArrayPosition &) = 0;
+    virtual void virt_visitOverlayTexture(const RoomHandle &, const MMTexArrayPosition &) = 0;
     virtual void virt_visitNamedColorTint(const RoomHandle &, RoomTintEnum) = 0;
 
     // Walls
@@ -188,15 +189,15 @@ public:
     NODISCARD bool acceptRoom(const RoomHandle &room) const { return virt_acceptRoom(room); }
 
     // Rooms
-    void visitTerrainTexture(const RoomHandle &room, const MMTextureId tex)
+    void visitTerrainTexture(const RoomHandle &room, const MMTexArrayPosition &tex)
     {
         virt_visitTerrainTexture(room, tex);
     }
-    void visitTrailTexture(const RoomHandle &room, const MMTextureId tex)
+    void visitTrailTexture(const RoomHandle &room, const MMTexArrayPosition &tex)
     {
         virt_visitTrailTexture(room, tex);
     }
-    void visitOverlayTexture(const RoomHandle &room, const MMTextureId tex)
+    void visitOverlayTexture(const RoomHandle &room, const MMTexArrayPosition &tex)
     {
         virt_visitOverlayTexture(room, tex);
     }
@@ -243,8 +244,8 @@ static void visitRoom(const RoomHandle &room,
 
     callbacks.visitTerrainTexture(room, terrainAndTrail.terrain);
 
-    if (auto trail = terrainAndTrail.trail) {
-        callbacks.visitOverlayTexture(room, trail);
+    if (auto trail = terrainAndTrail.trail; trail.array != INVALID_MM_TEXTURE_ID) {
+        callbacks.visitTrailTexture(room, trail);
     }
 
     if (isDark) {
@@ -406,36 +407,31 @@ static void visitRooms(const RoomVector &rooms,
 struct NODISCARD RoomTex
 {
     RoomHandle room;
-    MMTextureId tex = INVALID_MM_TEXTURE_ID;
+    MMTexArrayPosition pos;
 
-    explicit RoomTex(RoomHandle moved_room, const MMTextureId input_texid)
+    explicit RoomTex(RoomHandle moved_room, const MMTexArrayPosition &input_pos)
         : room{std::move(moved_room)}
-        , tex{input_texid}
+        , pos{input_pos}
     {
-        if (input_texid == INVALID_MM_TEXTURE_ID) {
-            throw std::invalid_argument("input_texid");
-        }
+        if (input_pos.array == INVALID_MM_TEXTURE_ID)
+            throw std::invalid_argument("input_pos");
     }
 
-    NODISCARD MMTextureId priority() const { return tex; }
-    NODISCARD MMTextureId textureId() const { return tex; }
-
-    NODISCARD friend bool operator<(const RoomTex &lhs, const RoomTex &rhs)
+    NODISCARD static bool isPartitioned(const RoomTex &a, const RoomTex &b)
     {
-        // true if lhs comes strictly before rhs
-        return lhs.priority() < rhs.priority();
+        return a.pos.array < b.pos.array;
     }
 };
 
 struct NODISCARD ColoredRoomTex : public RoomTex
 {
     Color color;
-    ColoredRoomTex(const RoomHandle &room, const MMTextureId tex) = delete;
+    ColoredRoomTex(const RoomHandle &room, const MMTexArrayPosition &tex) = delete;
 
     explicit ColoredRoomTex(RoomHandle moved_room,
-                            const MMTextureId input_texid,
+                            const MMTexArrayPosition input_pos,
                             const Color &input_color)
-        : RoomTex{std::move(moved_room), input_texid}
+        : RoomTex{std::move(moved_room), input_pos}
         , color{input_color}
     {}
 };
@@ -452,13 +448,30 @@ struct NODISCARD ColoredRoomTex : public RoomTex
 // that sorting is at significant fraction of the total runtime.
 struct NODISCARD RoomTexVector final : public std::vector<RoomTex>
 {
+private:
+    bool m_requiresSorting = false;
+
+public:
+    NODISCARD static RoomTexVector sortedRoomTexVector()
+    {
+        RoomTexVector v;
+        v.m_requiresSorting = true;
+        return v;
+    }
+    RoomTexVector() = default;
+
     // sorting stl iterators is slower than christmas with GLIBCXX_DEBUG,
     // so we'll use pointers instead. std::stable_sort isn't
     // necessary because everything's opaque, so we'll use
     // vanilla std::sort, which is N log N instead of N^2 log N.
     void sortByTexture()
     {
+        assert(m_requiresSorting);
         if (size() < 2) {
+            return;
+        }
+
+        if (isSorted()) {
             return;
         }
 
@@ -466,50 +479,24 @@ struct NODISCARD RoomTexVector final : public std::vector<RoomTex>
         RoomTex *const end = beg + size();
         // NOTE: comparison will be std::less<RoomTex>, which uses
         // operator<() if it exists.
-        std::sort(beg, end);
+        std::sort(beg, end, RoomTex::isPartitioned);
     }
 
     NODISCARD bool isSorted() const
     {
-        if (size() < 2) {
+        if (!m_requiresSorting || size() < 2) {
             return true;
         }
 
         const RoomTex *const beg = data();
         const RoomTex *const end = beg + size();
-        return std::is_sorted(beg, end);
+        return std::is_sorted(beg, end, RoomTex::isPartitioned);
     }
 };
 
 struct NODISCARD ColoredRoomTexVector final : public std::vector<ColoredRoomTex>
 {
-    // sorting stl iterators is slower than christmas with GLIBCXX_DEBUG,
-    // so we'll use pointers instead. std::stable_sort isn't
-    // necessary because everything's opaque, so we'll use
-    // vanilla std::sort, which is N log N instead of N^2 log N.
-    void sortByTexture()
-    {
-        if (size() < 2) {
-            return;
-        }
-
-        ColoredRoomTex *const beg = data();
-        ColoredRoomTex *const end = beg + size();
-        // NOTE: comparison will be std::less<RoomTex>, which uses
-        // operator<() if it exists.
-        std::sort(beg, end);
-    }
-
-    NODISCARD bool isSorted() const
-    {
-        if (size() < 2) {
-            return true;
-        }
-
-        const ColoredRoomTex *const beg = data();
-        const ColoredRoomTex *const end = beg + size();
-        return std::is_sorted(beg, end);
-    }
+    NODISCARD static bool isSorted() { return true; }
 };
 
 template<typename T, typename Callback>
@@ -520,11 +507,11 @@ static void foreach_texture(const T &textures, Callback &&callback)
     const auto size = textures.size();
     for (size_t beg = 0, next = size; beg < size; beg = next) {
         const RoomTex &rtex = textures[beg];
-        const auto textureId = rtex.textureId();
+        const auto textureId = rtex.pos.array;
 
         size_t end = beg + 1;
         for (; end < size; ++end) {
-            if (textureId != textures[end].textureId()) {
+            if (textureId != textures[end].pos.array) {
                 break;
             }
         }
@@ -536,7 +523,7 @@ static void foreach_texture(const T &textures, Callback &&callback)
 }
 
 NODISCARD static LayerMeshesIntermediate::FnVec createSortedTexturedMeshes(
-    const std::string_view /*what*/, const RoomTexVector &textures)
+    const std::string_view what, const RoomTexVector &textures)
 {
     if (textures.empty()) {
         return {};
@@ -548,6 +535,19 @@ NODISCARD static LayerMeshesIntermediate::FnVec createSortedTexturedMeshes(
                           [&texCount](size_t /* beg */, size_t /*end*/) -> void { ++texCount; });
         return texCount;
     });
+
+    if constexpr (IS_DEBUG_BUILD) {
+        if (numUniqueTextures > 1) {
+            MMLOG() << what << " has " << numUniqueTextures << " unique textures\n";
+
+            {
+                auto &&os = MMLOG();
+                for (auto &x : textures) {
+                    os << x.pos.array.value() << " at " << x.pos.position << "\n";
+                }
+            }
+        }
+    }
 
     LayerMeshesIntermediate::FnVec tmp_meshes;
     tmp_meshes.reserve(numUniqueTextures);
@@ -562,9 +562,12 @@ NODISCARD static LayerMeshesIntermediate::FnVec createSortedTexturedMeshes(
         // | |  ccw winding
         // A-B
         for (size_t i = beg; i < end; ++i) {
-            const auto &pos = textures[i].room.getPosition();
+            const RoomTex &thisVert = textures[i];
+            const auto &pos = thisVert.room.getPosition();
             const auto v0 = pos.to_vec3();
-#define EMIT(x, y) verts.emplace_back(glm::vec2((x), (y)), v0 + glm::vec3((x), (y), 0))
+            const auto z = thisVert.pos.position;
+
+#define EMIT(x, y) verts.emplace_back(glm::vec3((x), (y), z), v0 + glm::vec3((x), (y), 0))
             EMIT(0, 0);
             EMIT(1, 0);
             EMIT(1, 1);
@@ -572,7 +575,7 @@ NODISCARD static LayerMeshesIntermediate::FnVec createSortedTexturedMeshes(
 #undef EMIT
         }
 
-        tmp_meshes.emplace_back([v = std::move(verts), t = rtex.tex](OpenGL &g) {
+        tmp_meshes.emplace_back([v = std::move(verts), t = rtex.pos.array](OpenGL &g) {
             return g.createTexturedQuadBatch(v, t);
         });
     };
@@ -583,7 +586,7 @@ NODISCARD static LayerMeshesIntermediate::FnVec createSortedTexturedMeshes(
 }
 
 NODISCARD static LayerMeshesIntermediate::FnVec createSortedColoredTexturedMeshes(
-    const std::string_view /*what*/, const ColoredRoomTexVector &textures)
+    const std::string_view what, const ColoredRoomTexVector &textures)
 {
     if (textures.empty()) {
         return {};
@@ -595,6 +598,19 @@ NODISCARD static LayerMeshesIntermediate::FnVec createSortedColoredTexturedMeshe
                           [&texCount](size_t /* beg */, size_t /*end*/) -> void { ++texCount; });
         return texCount;
     });
+
+    if constexpr (IS_DEBUG_BUILD) {
+        if (numUniqueTextures > 1) {
+            MMLOG() << what << " has " << numUniqueTextures << " unique textures\n";
+
+            {
+                auto &&os = MMLOG();
+                for (auto &x : textures) {
+                    os << x.pos.array.value() << " at " << x.pos.position << "\n";
+                }
+            }
+        }
+    }
 
     LayerMeshesIntermediate::FnVec tmp_meshes;
     tmp_meshes.reserve(numUniqueTextures);
@@ -614,8 +630,9 @@ NODISCARD static LayerMeshesIntermediate::FnVec createSortedColoredTexturedMeshe
             const auto &pos = thisVert.room.getPosition();
             const auto v0 = pos.to_vec3();
             const auto color = thisVert.color;
+            const auto z = thisVert.pos.position;
 
-#define EMIT(x, y) verts.emplace_back(color, glm::vec2((x), (y)), v0 + glm::vec3((x), (y), 0))
+#define EMIT(x, y) verts.emplace_back(color, glm::vec3((x), (y), z), v0 + glm::vec3((x), (y), 0))
             EMIT(0, 0);
             EMIT(1, 0);
             EMIT(1, 1);
@@ -623,7 +640,7 @@ NODISCARD static LayerMeshesIntermediate::FnVec createSortedColoredTexturedMeshe
 #undef EMIT
         }
 
-        tmp_meshes.emplace_back([v = std::move(verts), t = rtex.tex](OpenGL &g) {
+        tmp_meshes.emplace_back([v = std::move(verts), t = rtex.pos.array](OpenGL &g) {
             return g.createColoredTexturedQuadBatch(v, t);
         });
     };
@@ -637,7 +654,7 @@ struct NODISCARD LayerBatchData final
 {
     RoomTexVector roomTerrains;
     RoomTexVector roomTrails;
-    RoomTexVector roomOverlays;
+    RoomTexVector roomOverlays = RoomTexVector::sortedRoomTexVector();
     // REVISIT: Consider storing up/down door lines in a separate batch,
     // so they can be rendered thicker.
     ColoredRoomTexVector doors;
@@ -649,29 +666,17 @@ struct NODISCARD LayerBatchData final
     RoomTintArray<PlainQuadBatch> roomTints;
     PlainQuadBatch roomLayerBoostQuads;
 
+    // So it can be used in std containers
     explicit LayerBatchData() = default;
+
     ~LayerBatchData() = default;
-    DEFAULT_MOVES(LayerBatchData);
-    DELETE_COPIES(LayerBatchData);
+    DEFAULT_MOVES_DELETE_COPIES(LayerBatchData);
 
     void sort()
     {
         DECL_TIMER(t, "sort");
 
-        /* TODO: Only sort on 2.1 path, since 3.0 can use GL_TEXTURE_2D_ARRAY. */
-        roomTerrains.sortByTexture();
-        roomTrails.sortByTexture();
         roomOverlays.sortByTexture();
-
-        // REVISIT: We could just make two separate lists and avoid the sort.
-        // However, it may be convenient to have separate dotted vs solid texture,
-        // so we'd still need to sort in that case.
-        roomUpDownExits.sortByTexture();
-        doors.sortByTexture();
-        solidWallLines.sortByTexture();
-        dottedWallLines.sortByTexture();
-        streamIns.sortByTexture();
-        streamOuts.sortByTexture();
     }
 
     NODISCARD LayerMeshesIntermediate buildIntermediate() const
@@ -726,9 +731,9 @@ private:
         return m_bounds.contains(room.getPosition());
     }
 
-    void virt_visitTerrainTexture(const RoomHandle &room, const MMTextureId terrain) final
+    void virt_visitTerrainTexture(const RoomHandle &room, const MMTexArrayPosition &terrain) final
     {
-        if (terrain == INVALID_MM_TEXTURE_ID) {
+        if (terrain.array == INVALID_MM_TEXTURE_ID) {
             return;
         }
 
@@ -743,16 +748,16 @@ private:
 #undef EMIT
     }
 
-    void virt_visitTrailTexture(const RoomHandle &room, const MMTextureId trail) final
+    void virt_visitTrailTexture(const RoomHandle &room, const MMTexArrayPosition &trail) final
     {
-        if (trail != INVALID_MM_TEXTURE_ID) {
+        if (trail.array != INVALID_MM_TEXTURE_ID) {
             m_data.roomTrails.emplace_back(room, trail);
         }
     }
 
-    void virt_visitOverlayTexture(const RoomHandle &room, const MMTextureId overlay) final
+    void virt_visitOverlayTexture(const RoomHandle &room, const MMTexArrayPosition &overlay) final
     {
-        if (overlay != INVALID_MM_TEXTURE_ID) {
+        if (overlay.array != INVALID_MM_TEXTURE_ID) {
             m_data.roomOverlays.emplace_back(room, overlay);
         }
     }
@@ -789,25 +794,26 @@ private:
         if (wallType == WallTypeEnum::DOOR) {
             // Note: We could use two door textures (NESW and UD), and then just rotate the
             // texture coordinates, but doing that would require a different code path.
-            const MMTextureId tex = m_textures.door[dir];
+            const MMTexArrayPosition &tex = m_textures.door[dir];
             m_data.doors.emplace_back(room, tex, glcolor);
+
         } else {
             if (isNESW(dir)) {
                 if (wallType == WallTypeEnum::SOLID) {
-                    const MMTextureId tex = m_textures.wall[dir];
+                    const MMTexArrayPosition &tex = m_textures.wall[dir];
                     m_data.solidWallLines.emplace_back(room, tex, glcolor);
                 } else {
-                    const MMTextureId tex = m_textures.dotted_wall[dir];
+                    const MMTexArrayPosition &tex = m_textures.dotted_wall[dir];
                     m_data.dottedWallLines.emplace_back(room, tex, glcolor);
                 }
             } else {
                 const bool isUp = dir == ExitDirEnum::UP;
                 assert(isUp || dir == ExitDirEnum::DOWN);
 
-                const MMTextureId tex = isClimb
-                                            ? (isUp ? m_textures.exit_climb_up
-                                                    : m_textures.exit_climb_down)
-                                            : (isUp ? m_textures.exit_up : m_textures.exit_down);
+                const MMTexArrayPosition &tex = isClimb ? (isUp ? m_textures.exit_climb_up
+                                                                : m_textures.exit_climb_down)
+                                                        : (isUp ? m_textures.exit_up
+                                                                : m_textures.exit_down);
 
                 m_data.roomUpDownExits.emplace_back(room, tex, glcolor);
             }

--- a/src/display/RoomSelections.cpp
+++ b/src/display/RoomSelections.cpp
@@ -57,7 +57,7 @@ public:
 #define DECL(name, a, b) \
     const TexVert name \
     { \
-        glm::vec2{(a), (b)}, glm::vec3 \
+        glm::vec3{(a), (b), 0}, glm::vec3 \
         { \
             (a), (b), 0 \
         } \
@@ -109,7 +109,7 @@ public:
                 std::abort();
             });
 
-            gl.renderTexturedQuads(arr, rs.withTexture0(texture->getId()));
+            gl.renderTexturedQuads(arr, rs.withTexture0(texture->getArrayPosition().array));
         }
     }
 };

--- a/src/display/mapcanvas_gl.cpp
+++ b/src/display/mapcanvas_gl.cpp
@@ -789,7 +789,7 @@ void MapCanvas::paintDifferences()
     auto &gl = getOpenGL();
 
     if (auto &highlights = highlight.highlights; !highlights.empty()) {
-        highlights.render(gl, m_textures.room_highlight->getId());
+        highlights.render(gl, m_textures.room_highlight->getArrayPosition().array);
     }
 }
 

--- a/src/opengl/OpenGL.h
+++ b/src/opengl/OpenGL.h
@@ -12,6 +12,8 @@
 
 #include <glm/glm.hpp>
 
+#include <QImage>
+#include <QString>
 #include <QSurfaceFormat>
 #include <qopengl.h>
 
@@ -162,5 +164,7 @@ public:
     void setTextureLookup(MMTextureId, SharedMMTexture);
 
 public:
-    void initArray(const SharedMMTexture &array, const std::vector<SharedMMTexture> &input);
+    void initArrayFromFiles(const SharedMMTexture &array, const std::vector<QString> &input);
+    void initArrayFromImages(const SharedMMTexture &array,
+                             const std::vector<std::vector<QImage>> &input);
 };

--- a/src/opengl/OpenGLTypes.h
+++ b/src/opengl/OpenGLTypes.h
@@ -20,14 +20,15 @@
 #include <glm/glm.hpp>
 
 #include <QDebug>
+#include <QOpenGLTexture>
 #include <qopengl.h>
 
 struct NODISCARD TexVert final
 {
-    glm::vec2 tex{};
+    glm::vec3 tex{};
     glm::vec3 vert{};
 
-    explicit TexVert(const glm::vec2 &tex_, const glm::vec3 &vert_)
+    explicit TexVert(const glm::vec3 &tex_, const glm::vec3 &vert_)
         : tex{tex_}
         , vert{vert_}
     {}
@@ -38,10 +39,10 @@ using TexVertVector = std::vector<TexVert>;
 struct NODISCARD ColoredTexVert final
 {
     Color color;
-    glm::vec2 tex{};
+    glm::vec3 tex{};
     glm::vec3 vert{};
 
-    explicit ColoredTexVert(const Color &color_, const glm::vec2 &tex_, const glm::vec3 &vert_)
+    explicit ColoredTexVert(const Color &color_, const glm::vec3 &tex_, const glm::vec3 &vert_)
         : color{color_}
         , tex{tex_}
         , vert{vert_}

--- a/src/opengl/legacy/FunctionsES30.cpp
+++ b/src/opengl/legacy/FunctionsES30.cpp
@@ -33,7 +33,7 @@ std::optional<GLenum> FunctionsES30::virt_toGLenum(const DrawModeEnum mode)
 
 const char *FunctionsES30::virt_getShaderVersion() const
 {
-    return "#version 300 es\n\nprecision highp float;\n\n";
+    return "#version 300 es\n\nprecision highp float;\nprecision mediump sampler2DArray;\n\n";
 }
 
 void FunctionsES30::virt_enableProgramPointSize(bool /* enable */)

--- a/src/opengl/legacy/Legacy.h
+++ b/src/opengl/legacy/Legacy.h
@@ -137,8 +137,11 @@ public:
     using Base::initializeOpenGLFunctions;
 
 public:
+    using Base::glActiveTexture;
     using Base::glAttachShader;
     using Base::glBindBuffer;
+    using Base::glBindTexture;
+    using Base::glBindVertexArray;
     using Base::glBlendFunc;
     using Base::glBlendFuncSeparate;
     using Base::glBufferData;
@@ -151,6 +154,7 @@ public:
     using Base::glDeleteBuffers;
     using Base::glDeleteProgram;
     using Base::glDeleteShader;
+    using Base::glDeleteVertexArrays;
     using Base::glDepthFunc;
     using Base::glDetachShader;
     using Base::glDisable;
@@ -159,6 +163,8 @@ public:
     using Base::glEnable;
     using Base::glEnableVertexAttribArray;
     using Base::glGenBuffers;
+    using Base::glGenerateMipmap;
+    using Base::glGenVertexArrays;
     using Base::glGetAttribLocation;
     using Base::glGetIntegerv;
     using Base::glGetProgramInfoLog;
@@ -166,6 +172,8 @@ public:
     using Base::glGetShaderInfoLog;
     using Base::glGetShaderiv;
     using Base::glGetString;
+    using Base::glGetTexLevelParameteriv;
+    using Base::glGetTexParameteriv;
     using Base::glGetUniformLocation;
     using Base::glHint;
     using Base::glIsBuffer;
@@ -173,7 +181,9 @@ public:
     using Base::glIsShader;
     using Base::glIsTexture;
     using Base::glLinkProgram;
+    using Base::glPixelStorei;
     using Base::glShaderSource;
+    using Base::glTexSubImage3D;
     using Base::glUniform1fv;
     using Base::glUniform1iv;
     using Base::glUniform4fv;
@@ -181,11 +191,6 @@ public:
     using Base::glUniformMatrix4fv;
     using Base::glUseProgram;
     using Base::glVertexAttribPointer;
-
-    // VAO functions
-    using Base::glBindVertexArray;
-    using Base::glDeleteVertexArrays;
-    using Base::glGenVertexArrays;
 
 public:
     void glLineWidth(const GLfloat lineWidth)

--- a/src/opengl/legacy/Meshes.h
+++ b/src/opengl/legacy/Meshes.h
@@ -147,14 +147,14 @@ private:
     void virt_bind() override
     {
         const auto vertSize = static_cast<GLsizei>(sizeof(VertexType_));
-        static_assert(sizeof(std::declval<VertexType_>().tex) == 2 * sizeof(GLfloat));
+        static_assert(sizeof(std::declval<VertexType_>().tex) == 3 * sizeof(GLfloat));
         static_assert(sizeof(std::declval<VertexType_>().vert) == 3 * sizeof(GLfloat));
 
         Functions &gl = Base::m_functions;
         const auto attribs = Attribs::getLocations(Base::m_program);
         gl.glBindBuffer(GL_ARRAY_BUFFER, Base::m_vbo.get());
         /* NOTE: OpenGL 2.x can't use GL_TEXTURE_2D_ARRAY. */
-        gl.enableAttrib(attribs.texPos, 2, GL_FLOAT, GL_FALSE, vertSize, VPO(tex));
+        gl.enableAttrib(attribs.texPos, 3, GL_FLOAT, GL_FALSE, vertSize, VPO(tex));
         gl.enableAttrib(attribs.vertPos, 3, GL_FLOAT, GL_FALSE, vertSize, VPO(vert));
         m_boundAttribs = attribs;
     }
@@ -206,7 +206,7 @@ private:
     {
         const auto vertSize = static_cast<GLsizei>(sizeof(VertexType_));
         static_assert(sizeof(std::declval<VertexType_>().color) == 4 * sizeof(uint8_t));
-        static_assert(sizeof(std::declval<VertexType_>().tex) == 2 * sizeof(GLfloat));
+        static_assert(sizeof(std::declval<VertexType_>().tex) == 3 * sizeof(GLfloat));
         static_assert(sizeof(std::declval<VertexType_>().vert) == 3 * sizeof(GLfloat));
 
         Functions &gl = Base::m_functions;
@@ -214,7 +214,7 @@ private:
         gl.glBindBuffer(GL_ARRAY_BUFFER, Base::m_vbo.get());
         gl.enableAttrib(attribs.colorPos, 4, GL_UNSIGNED_BYTE, GL_TRUE, vertSize, VPO(color));
         /* NOTE: OpenGL 2.x can't use GL_TEXTURE_2D_ARRAY. */
-        gl.enableAttrib(attribs.texPos, 2, GL_FLOAT, GL_FALSE, vertSize, VPO(tex));
+        gl.enableAttrib(attribs.texPos, 3, GL_FLOAT, GL_FALSE, vertSize, VPO(tex));
         gl.enableAttrib(attribs.vertPos, 3, GL_FLOAT, GL_FALSE, vertSize, VPO(vert));
         m_boundAttribs = attribs;
     }

--- a/src/resources/shaders/legacy/tex/acolor/frag.glsl
+++ b/src/resources/shaders/legacy/tex/acolor/frag.glsl
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (C) 2019 The MMapper Authors
 
-uniform sampler2D uTexture;
+uniform sampler2DArray uTexture;
 uniform vec4 uColor;
 
 in vec4 vColor;
-in vec2 vTexCoord;
+in vec3 vTexCoord;
 
 out vec4 vFragmentColor;
 

--- a/src/resources/shaders/legacy/tex/acolor/vert.glsl
+++ b/src/resources/shaders/legacy/tex/acolor/vert.glsl
@@ -4,11 +4,11 @@
 uniform mat4 uMVP;
 
 layout(location = 0) in vec4 aColor;
-layout(location = 1) in vec2 aTexCoord;
+layout(location = 1) in vec3 aTexCoord;
 layout(location = 2) in vec3 aVert;
 
 out vec4 vColor;
-out vec2 vTexCoord;
+out vec3 vTexCoord;
 
 void main()
 {

--- a/src/resources/shaders/legacy/tex/ucolor/frag.glsl
+++ b/src/resources/shaders/legacy/tex/ucolor/frag.glsl
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (C) 2019 The MMapper Authors
 
-uniform sampler2D uTexture;
+uniform sampler2DArray uTexture;
 uniform vec4 uColor;
 
-in vec2 vTexCoord;
+in vec3 vTexCoord;
 
 out vec4 vFragmentColor;
 

--- a/src/resources/shaders/legacy/tex/ucolor/vert.glsl
+++ b/src/resources/shaders/legacy/tex/ucolor/vert.glsl
@@ -3,10 +3,10 @@
 
 uniform mat4 uMVP;
 
-layout(location = 0) in vec2 aTexCoord;
+layout(location = 0) in vec3 aTexCoord;
 layout(location = 1) in vec3 aVert;
 
-out vec2 vTexCoord;
+out vec3 vTexCoord;
 
 void main()
 {


### PR DESCRIPTION
## Summary by Sourcery

Migrate map rendering to use 2D texture arrays instead of individual 2D textures, including data structures, batching, and shader updates.

New Features:
- Support constructing MMTexture objects from explicit image mip chains and tracking their source data for array initialization.
- Introduce 2D texture array initialization helpers in the OpenGL layer for both file-based and in-memory image sources.
- Add per-texture array position tracking to allow batched rendering from shared texture arrays.

Enhancements:
- Group related map textures into shared 2D texture arrays and wire them through MapCanvasTextures, proxies, and batching logic.
- Extend texture vertex formats and mesh bindings to carry a 3D texture coordinate (including array layer) and update legacy shaders to sample from sampler2DArray.
- Improve texture destruction, logging, and sorting behavior to reflect the new array-based texture usage and reduce unnecessary sorting.