### PR TITLE
add Alt+Click drag to adjust viewport

### DIFF
--- a/src/configuration/configuration.h
+++ b/src/configuration/configuration.h
@@ -188,8 +188,8 @@ public:
             FixedPoint<1> fov{50, 900, 765};
             // 0..90 degrees
             FixedPoint<1> verticalAngle{0, 900, 450};
-            // -45..45 degrees
-            FixedPoint<1> horizontalAngle{-450, 450, 0};
+            // -180..180 degrees
+            FixedPoint<1> horizontalAngle{-1800, 1800, 0};
             // 1..10 rooms
             FixedPoint<1> layerHeight{10, 100, 15};
 

--- a/src/display/mapcanvas.h
+++ b/src/display/mapcanvas.h
@@ -146,6 +146,13 @@ private:
     std::unique_ptr<QOpenGLDebugLogger> m_logger;
     Signal2Lifetime m_lifetime;
 
+    struct AltDragState
+    {
+        QPoint lastPos;
+        QCursor originalCursor;
+    };
+    std::optional<AltDragState> m_altDragState;
+
 public:
     explicit MapCanvas(MapData &mapData,
                        PrespammedPath &prespammedPath,


### PR DESCRIPTION
## Summary by Sourcery

Add Alt+Left-click drag interaction to adjust the 3D viewport orientation and extend horizontal camera rotation range.

New Features:
- Allow Alt+Left-click dragging on the map canvas to rotate the camera by adjusting yaw and pitch based on mouse movement.

Enhancements:
- Persist and restore the original cursor while Alt-dragging to give visual feedback of camera-rotation mode.
- Increase the configurable horizontal camera angle range from ±45° to ±180° for wider viewport rotation.