### PR TITLE
use ccache in GitHub actions

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -18,6 +18,12 @@ jobs:
         fetch-depth: 0
         submodules: true
 
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        create-symlink: true
+        key: ${{ github.job }}
+
     - name: Install Build Dependencies
       run: |
         sudo apt update -qq
@@ -47,7 +53,9 @@ jobs:
           -DWITH_WEBSOCKET=ON \
           -DWITH_QTKEYCHAIN=ON \
           -DWITH_TESTS=OFF \
-          -DPACKAGE_TYPE=AppImage
+          -DPACKAGE_TYPE=AppImage \
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         make -j$(getconf _NPROCESSORS_ONLN)
         make DESTDIR=appdir install
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -22,6 +22,12 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
+    - if: runner.os == 'Linux' || runner.os == 'macOS'
+      name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        create-symlink: true
+        key: ${{ github.job }}-${{ matrix.os }}
     - if: runner.os == 'Windows' || runner.os == 'macOS'
       uses: lukka/get-cmake@latest
     - if: runner.os == 'Windows'
@@ -84,7 +90,7 @@ jobs:
         mkdir -p build ${{ github.workspace }}/artifact
         cd build
         cmake --version
-        cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -G 'Ninja' -DCPACK_PACKAGE_DIRECTORY=${{ github.workspace }}/artifact $MMAPPER_CMAKE_EXTRA -DWITH_WEBSOCKET=ON -DWITH_QTKEYCHAIN=ON -S .. || exit -1
+        cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -G 'Ninja' -DCPACK_PACKAGE_DIRECTORY=${{ github.workspace }}/artifact $MMAPPER_CMAKE_EXTRA -DWITH_WEBSOCKET=ON -DWITH_QTKEYCHAIN=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -S .. || exit -1
         cmake --build . --parallel
 
     # Package

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -30,6 +30,12 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
+    - if: runner.os == 'Linux' || runner.os == 'macOS'
+      name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        create-symlink: true
+        key: ${{ github.job }}-${{ matrix.os }}-${{ matrix.compiler }}
     - if: runner.os == 'Windows' || runner.os == 'macOS'
       uses: lukka/get-cmake@latest
     - if: matrix.compiler == 'msvc'
@@ -130,7 +136,7 @@ jobs:
         mkdir -p build ${{ github.workspace }}/artifact
         cd build
         cmake --version
-        cmake -DCMAKE_BUILD_TYPE=Debug -G 'Ninja' -DWITH_MAP=OFF -DCPACK_PACKAGE_DIRECTORY=${{ github.workspace }}/artifact $MMAPPER_CMAKE_EXTRA -DWITH_WEBSOCKET=ON -DWITH_QTKEYCHAIN=ON -S .. || exit -1
+        cmake -DCMAKE_BUILD_TYPE=Debug -G 'Ninja' -DWITH_MAP=OFF -DCPACK_PACKAGE_DIRECTORY=${{ github.workspace }}/artifact $MMAPPER_CMAKE_EXTRA -DWITH_WEBSOCKET=ON -DWITH_QTKEYCHAIN=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -S .. || exit -1
         cmake --build . --parallel
 
       #

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -18,6 +18,12 @@ jobs:
         fetch-depth: 0
         submodules: true
 
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        create-symlink: true
+        key: ${{ github.job }}
+
     - name: Install Qt for Wasm
       uses: jurplel/install-qt-action@v4
       with:
@@ -42,7 +48,9 @@ jobs:
           -DWITH_WEBSOCKET=ON \
           -DWITH_UPDATER=OFF \
           -DCMAKE_BUILD_TYPE=Release \
-          -DPACKAGE_TYPE=Wasm
+          -DPACKAGE_TYPE=Wasm \
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build
 
     - name: Add coi-serviceworker.js


### PR DESCRIPTION
## Summary by Sourcery

Enable compiler caching in CI builds to speed up repeated compilations across workflows.

Build:
- Add ccache GitHub Action to AppImage and Wasm build workflows.
- Configure release and test workflows on Linux and macOS to use ccache with C and C++ compilers via CMake launcher settings.
- Pass ccache as the C and C++ compiler launcher in CMake invocations for AppImage, Wasm, release, and test builds.