### PR TITLE
add Discord chat badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 MMapper
 ============================
+[![Discord Chat](https://img.shields.io/discord/1091792379503190086.svg)](https://discord.gg/bztx2wjrR9)
 [![Contributors](https://img.shields.io/github/contributors/MUME/MMapper.svg?style=flat)](https://github.com/MUME/MMapper/graphs/contributors)
 [![Code Coverage](https://codecov.io/gh/MUME/MMapper/branch/master/graph/badge.svg)](https://codecov.io/gh/MUME/MMapper)
 [![GitHub](https://img.shields.io/github/license/MUME/MMapper.svg)](https://github.com/MUME/MMapper/blob/master/COPYING.txt)


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Display a Discord chat badge in the README alongside existing project badges.