### PR TITLE
Refactor color

### DIFF
--- a/src/configuration/configuration.cpp
+++ b/src/configuration/configuration.cpp
@@ -1044,21 +1044,39 @@ void setEnteredMain()
     g_config_enteredMain = true;
 }
 
-const Configuration::NamedColorOptions &getNamedColorOptions()
+void Configuration::ResolvedNamedColorOptions::setFrom(const NamedColorOptions &from)
+{
+#define X_CLONE(_id, _name) (this->_id) = (from._id).getColor();
+    XFOREACH_NAMED_COLOR_OPTIONS(X_CLONE)
+#undef X_CLONE
+}
+
+void Configuration::ResolvedCanvasNamedColorOptions::setFrom(const CanvasNamedColorOptions &from)
+{
+#define X_CLONE(_id, _name) (this->_id) = (from._id).getColor();
+    XFOREACH_CANVAS_NAMED_COLOR_OPTIONS(X_CLONE)
+#undef X_CLONE
+}
+
+const Configuration::ResolvedNamedColorOptions &getNamedColorOptions()
 {
     assert(g_config_enteredMain);
     if (g_thread == std::this_thread::get_id()) {
-        return getConfig().colorSettings;
+        thread_local Configuration::ResolvedNamedColorOptions tl_res;
+        tl_res.setFrom(getConfig().colorSettings);
+        return tl_res;
     }
 
     return deref(tl_named_color_options);
 }
 
-const Configuration::CanvasNamedColorOptions &getCanvasNamedColorOptions()
+const Configuration::ResolvedCanvasNamedColorOptions &getCanvasNamedColorOptions()
 {
     assert(g_config_enteredMain);
     if (g_thread == std::this_thread::get_id()) {
-        return getConfig().canvas;
+        thread_local Configuration::ResolvedCanvasNamedColorOptions tl_res;
+        tl_res.setFrom(getConfig().canvas);
+        return tl_res;
     }
 
     return deref(tl_canvas_named_color_options);

--- a/src/configuration/configuration.h
+++ b/src/configuration/configuration.h
@@ -129,30 +129,32 @@ public:
         SUBGROUP();
     } mumeNative;
 
-    static constexpr const std::string_view BACKGROUND_NAME = "background";
-    static constexpr const std::string_view CONNECTION_NORMAL_NAME = "connection-normal";
-    static constexpr const std::string_view ROOM_DARK_NAME = "room-dark";
-    static constexpr const std::string_view ROOM_NO_SUNDEATH_NAME = "room-no-sundeath";
-
 #define XFOREACH_CANVAS_NAMED_COLOR_OPTIONS(X) \
-    X(backgroundColor, BACKGROUND_NAME) \
-    X(connectionNormalColor, CONNECTION_NORMAL_NAME) \
-    X(roomDarkColor, ROOM_DARK_NAME) \
-    X(roomDarkLitColor, ROOM_NO_SUNDEATH_NAME)
+    X(backgroundColor, BACKGROUND) \
+    X(connectionNormalColor, CONNECTION_NORMAL) \
+    X(roomDarkColor, ROOM_DARK) \
+    X(roomDarkLitColor, ROOM_NO_SUNDEATH)
+
+    struct CanvasNamedColorOptions;
+    struct NODISCARD ResolvedCanvasNamedColorOptions final
+    {
+#define X_DECL(_id, _name) Color _id;
+        XFOREACH_CANVAS_NAMED_COLOR_OPTIONS(X_DECL)
+#undef X_DECL
+        void setFrom(const CanvasNamedColorOptions &);
+    };
 
     struct NODISCARD CanvasNamedColorOptions
     {
-#define X_DECL(_id, _name) XNamedColor _id{_name};
+#define X_DECL(_id, _name) XNamedColor _id{NamedColorEnum::_name};
         XFOREACH_CANVAS_NAMED_COLOR_OPTIONS(X_DECL)
 #undef X_DECL
 
-        NODISCARD std::shared_ptr<const CanvasNamedColorOptions> clone() const
+        NODISCARD std::shared_ptr<const ResolvedCanvasNamedColorOptions> clone() const
         {
-            auto pResult = std::make_shared<CanvasNamedColorOptions>();
+            auto pResult = std::make_shared<ResolvedCanvasNamedColorOptions>();
             auto &result = deref(pResult);
-#define X_CLONE(_id, _name) result._id = this->_id.getColor();
-            XFOREACH_CANVAS_NAMED_COLOR_OPTIONS(X_CLONE)
-#undef X_CLONE
+            result.setFrom(*this);
             return pResult;
         }
     };
@@ -204,50 +206,29 @@ public:
         SUBGROUP();
     } canvas;
 
-#define XFOREACH_NAMED_COLOR_OPTIONS(X) \
-    X(BACKGROUND, BACKGROUND_NAME) \
-    X(CONNECTION_NORMAL, CONNECTION_NORMAL_NAME) \
-    X(HIGHLIGHT_NEEDS_SERVER_ID, "highlight-needs-server-id") \
-    X(HIGHLIGHT_UNSAVED, "highlight-unsaved") \
-    X(HIGHLIGHT_TEMPORARY, "highlight-temporary") \
-    X(INFOMARK_COMMENT, "infomark-comment") \
-    X(INFOMARK_HERB, "infomark-herb") \
-    X(INFOMARK_MOB, "infomark-mob") \
-    X(INFOMARK_OBJECT, "infomark-object") \
-    X(INFOMARK_RIVER, "infomark-river") \
-    X(INFOMARK_ROAD, "infomark-road") \
-    X(ROOM_DARK, ROOM_DARK_NAME) \
-    X(ROOM_NO_SUNDEATH, ROOM_NO_SUNDEATH_NAME) \
-    X(STREAM, "stream") \
-    X(TRANSPARENT, ".transparent") \
-    X(VERTICAL_COLOR_CLIMB, "vertical-climb") \
-    X(VERTICAL_COLOR_REGULAR_EXIT, "vertical-regular") \
-    X(WALL_COLOR_BUG_WALL_DOOR, "wall-bug-wall-door") \
-    X(WALL_COLOR_CLIMB, "wall-climb") \
-    X(WALL_COLOR_FALL_DAMAGE, "wall-fall-damage") \
-    X(WALL_COLOR_GUARDED, "wall-guarded") \
-    X(WALL_COLOR_NO_FLEE, "wall-no-flee") \
-    X(WALL_COLOR_NO_MATCH, "wall-no-match") \
-    X(WALL_COLOR_NOT_MAPPED, "wall-not-mapped") \
-    X(WALL_COLOR_RANDOM, "wall-random") \
-    X(WALL_COLOR_REGULAR_EXIT, "wall-regular-exit") \
-    X(WALL_COLOR_SPECIAL, "wall-special")
+    struct NODISCARD NamedColorOptions;
+    struct NODISCARD ResolvedNamedColorOptions final
+    {
+#define X_DECL(_id, _name) XNamedColor _id{NamedColorEnum::_id};
+        XFOREACH_NAMED_COLOR_OPTIONS(X_DECL)
+#undef X_DECL
+
+        void setFrom(const NamedColorOptions &);
+    };
 
     struct NODISCARD NamedColorOptions
     {
-#define X_DECL(_id, _name) XNamedColor _id{_name};
+#define X_DECL(_id, _name) XNamedColor _id{NamedColorEnum::_id};
         XFOREACH_NAMED_COLOR_OPTIONS(X_DECL)
 #undef X_DECL
         NamedColorOptions() = default;
         void resetToDefaults();
 
-        NODISCARD std::shared_ptr<const NamedColorOptions> clone() const
+        NODISCARD std::shared_ptr<const ResolvedNamedColorOptions> clone() const
         {
-            auto pResult = std::make_shared<NamedColorOptions>();
+            auto pResult = std::make_shared<ResolvedNamedColorOptions>();
             auto &result = deref(pResult);
-#define X_CLONE(_id, _name) result._id = this->_id.getColor();
-            XFOREACH_NAMED_COLOR_OPTIONS(X_CLONE)
-#undef X_CLONE
+            result.setFrom(*this);
             return pResult;
         }
     };
@@ -430,11 +411,12 @@ void setEnteredMain();
 NODISCARD Configuration &setConfig();
 NODISCARD const Configuration &getConfig();
 
-using SharedCanvasNamedColorOptions = std::shared_ptr<const Configuration::CanvasNamedColorOptions>;
-using SharedNamedColorOptions = std::shared_ptr<const Configuration::NamedColorOptions>;
+using SharedCanvasNamedColorOptions
+    = std::shared_ptr<const Configuration::ResolvedCanvasNamedColorOptions>;
+using SharedNamedColorOptions = std::shared_ptr<const Configuration::ResolvedNamedColorOptions>;
 
-const Configuration::CanvasNamedColorOptions &getCanvasNamedColorOptions();
-const Configuration::NamedColorOptions &getNamedColorOptions();
+const Configuration::ResolvedCanvasNamedColorOptions &getCanvasNamedColorOptions();
+const Configuration::ResolvedNamedColorOptions &getNamedColorOptions();
 
 struct NODISCARD ThreadLocalNamedColorRaii final
 {

--- a/src/display/Characters.cpp
+++ b/src/display/Characters.cpp
@@ -49,7 +49,7 @@ bool CharacterBatch::isVisible(const Coordinate &c, float margin) const
     return m_mapScreen.isRoomVisible(c, margin);
 }
 
-void CharacterBatch::drawCharacter(const Coordinate &c, const Color &color, bool fill)
+void CharacterBatch::drawCharacter(const Coordinate &c, const Color color, bool fill)
 {
     const Configuration::CanvasSettings &settings = getConfig().canvas;
 
@@ -105,14 +105,14 @@ void CharacterBatch::drawCharacter(const Coordinate &c, const Color &color, bool
 
 void CharacterBatch::CharFakeGL::drawPathSegment(const glm::vec3 &p1,
                                                  const glm::vec3 &p2,
-                                                 const Color &color)
+                                                 const Color color)
 {
     mmgl::generateLineQuadsSafe(m_pathLineQuads, p1, p2, PATH_LINE_WIDTH, color);
 }
 
 void CharacterBatch::drawPreSpammedPath(const Coordinate &c1,
                                         const std::vector<Coordinate> &path,
-                                        const Color &color)
+                                        const Color color)
 {
     if (path.empty()) {
         return;
@@ -366,7 +366,7 @@ void CharacterBatch::CharFakeGL::reallyDrawPaths(OpenGL &gl)
 
 void CharacterBatch::CharFakeGL::addScreenSpaceArrow(const glm::vec3 &pos,
                                                      const float degrees,
-                                                     const Color &color,
+                                                     const Color color,
                                                      const bool fill)
 {
     std::array<glm::vec2, 4> texCoords{

--- a/src/display/Characters.h
+++ b/src/display/Characters.h
@@ -126,9 +126,9 @@ private:
         void reallyDrawPaths(OpenGL &gl);
 
     public:
-        void setColor(const Color &color) { m_color = color; }
-        void reserve(Coordinate c) { m_coordCounts[c]++; }
-        void clear(Coordinate c) { m_coordCounts[c] = 0; }
+        void setColor(const Color color) { m_color = color; }
+        void reserve(const Coordinate c) { m_coordCounts[c]++; }
+        void clear(const Coordinate c) { m_coordCounts[c] = 0; }
 
     public:
         void glPushMatrix() { m_stack.push(); }
@@ -150,11 +150,11 @@ private:
         }
         void drawArrow(bool fill, bool beacon);
         void drawBox(const Coordinate &coord, bool fill, bool beacon, bool isFar);
-        void addScreenSpaceArrow(const glm::vec3 &pos, float degrees, const Color &color, bool fill);
-        void drawPathSegment(const glm::vec3 &p1, const glm::vec3 &p2, const Color &color);
+        void addScreenSpaceArrow(const glm::vec3 &pos, float degrees, const Color color, bool fill);
+        void drawPathSegment(const glm::vec3 &p1, const glm::vec3 &p2, const Color color);
 
         // with blending, without depth; always size 8
-        void drawPathPoint(const Color &color, const glm::vec3 &pos)
+        void drawPathPoint(const Color color, const glm::vec3 &pos)
         {
             m_pathPoints.emplace_back(color, pos);
         }
@@ -207,11 +207,11 @@ public:
     NODISCARD bool isVisible(const Coordinate &c, float margin) const;
 
 public:
-    void drawCharacter(const Coordinate &coordinate, const Color &color, bool fill = true);
+    void drawCharacter(const Coordinate &coordinate, const Color color, bool fill = true);
 
     void drawPreSpammedPath(const Coordinate &coordinate,
                             const std::vector<Coordinate> &path,
-                            const Color &color);
+                            const Color color);
 
 public:
     void reallyDraw(OpenGL &gl, const MapCanvasTextures &textures)

--- a/src/display/Connections.cpp
+++ b/src/display/Connections.cpp
@@ -631,7 +631,7 @@ void ConnectionMeshes::render(const int thisLayer, const int focusedLayer) const
 {
     const auto color = std::invoke([&thisLayer, &focusedLayer]() -> Color {
         if (thisLayer == focusedLayer) {
-            return getCanvasNamedColorOptions().connectionNormalColor.getColor();
+            return XNamedColor{NamedColorEnum::CONNECTION_NORMAL}.getColor();
         }
         return Colors::gray70.withAlpha(FAINT_CONNECTION_ALPHA);
     });
@@ -785,7 +785,7 @@ void ConnectionDrawer::ConnectionFakeGL::drawTriangle(const glm::vec3 &a,
                                                       const glm::vec3 &b,
                                                       const glm::vec3 &c)
 {
-    const auto &color = isNormal() ? getCanvasNamedColorOptions().connectionNormalColor.getColor()
+    const auto &color = isNormal() ? getCanvasNamedColorOptions().connectionNormalColor
                                    : Colors::red;
     auto &verts = deref(m_currentBuffer).triVerts;
     verts.emplace_back(color, a + m_offset);
@@ -799,7 +799,7 @@ void ConnectionDrawer::ConnectionFakeGL::drawLineStrip(const std::vector<glm::ve
     const float extension = CONNECTION_LINE_WIDTH * 0.5f;
 
     // Helper lambda to generate a quad between two points with a specific color.
-    auto generateQuad = [&](const glm::vec3 &p1, const glm::vec3 &p2, const Color &quad_color) {
+    auto generateQuad = [&](const glm::vec3 &p1, const glm::vec3 &p2, const Color quad_color) {
         auto &verts = deref(m_currentBuffer).quadVerts;
 
         const glm::vec3 segment = p2 - p1;
@@ -822,9 +822,8 @@ void ConnectionDrawer::ConnectionFakeGL::drawLineStrip(const std::vector<glm::ve
     const auto size = points.size();
     assert(size >= 2);
 
-    const Color base_color = isNormal()
-                                 ? getCanvasNamedColorOptions().connectionNormalColor.getColor()
-                                 : Colors::red;
+    const Color base_color = isNormal() ? getCanvasNamedColorOptions().connectionNormalColor
+                                        : Colors::red;
 
     for (size_t i = 1; i < size; ++i) {
         const glm::vec3 start_orig = points[i - 1u];

--- a/src/display/Infomarks.cpp
+++ b/src/display/Infomarks.cpp
@@ -36,7 +36,7 @@ static constexpr const float INFOMARK_ARROW_LINE_WIDTH = 0.045f;
 static constexpr float INFOMARK_GUIDE_LINE_WIDTH = 3.f;
 static constexpr float INFOMARK_POINT_SIZE = 6.f;
 
-#define LOOKUP_COLOR_INFOMARK(X) (getNamedColorOptions().X.getColor())
+#define LOOKUP_COLOR_INFOMARK(_X) (XNamedColor{NamedColorEnum::_X}.getColor())
 
 // NOTE: This currently requires rebuilding the infomark meshes if a color changes.
 NODISCARD static Color getInfomarkColor(const InfomarkTypeEnum infoMarkType,
@@ -155,7 +155,7 @@ void InfomarksBatch::drawTriangle(const glm::vec3 &a, const glm::vec3 &b, const 
 
 void InfomarksBatch::renderText(const glm::vec3 &pos,
                                 const std::string &text,
-                                const Color &color,
+                                const Color color,
                                 const std::optional<Color> bgcolor,
                                 const FontFormatFlags fontFormatFlag,
                                 const int rotationAngle)
@@ -255,7 +255,7 @@ void MapCanvas::drawInfomark(InfomarksBatch &batch,
     const glm::vec3 pos{x1, y1, static_cast<float>(layer)};
     batch.setOffset(pos);
 
-    const Color &bgColor = (overrideColor) ? overrideColor.value() : infoMarkColor;
+    const Color bgColor = (overrideColor) ? overrideColor.value() : infoMarkColor;
     batch.setColor(bgColor);
 
     switch (infoMarkType) {
@@ -335,7 +335,7 @@ void MapCanvas::paintSelectedInfomarks()
 
         // draw selection points
         if (m_canvasMouseMode == CanvasMouseModeEnum::SELECT_INFOMARKS) {
-            const auto drawPoint = [&batch](const Coordinate &c, const Color &color) {
+            const auto drawPoint = [&batch](const Coordinate &c, const Color color) {
                 batch.setColor(color);
                 batch.setOffset(glm::vec3{0});
                 const glm::vec3 point{static_cast<glm::vec2>(c.to_vec3())

--- a/src/display/Infomarks.h
+++ b/src/display/Infomarks.h
@@ -59,7 +59,7 @@ public:
         , m_font{font}
     {}
 
-    void setColor(const Color &color) { m_color = color; }
+    void setColor(const Color color) { m_color = color; }
     void setOffset(const glm::vec3 &offset) { m_offset = offset; }
     void drawPoint(const glm::vec3 &a);
     void drawLine(const glm::vec3 &a, const glm::vec3 &b);
@@ -71,7 +71,7 @@ public:
     void drawTriangle(const glm::vec3 &a, const glm::vec3 &b, const glm::vec3 &c);
     void renderText(const glm::vec3 &pos,
                     const std::string &text,
-                    const Color &color,
+                    const Color color,
                     std::optional<Color> bgcolor,
                     FontFormatFlags fontFormatFlag,
                     int rotationAngle);

--- a/src/global/AnsiTextUtils.cpp
+++ b/src/global/AnsiTextUtils.cpp
@@ -992,7 +992,7 @@ std::string_view to_string_view(const AnsiColor16Enum color)
 #undef X_CASE
 }
 
-AnsiColorRGB toAnsiColorRGB(const Color &color)
+AnsiColorRGB toAnsiColorRGB(const Color color)
 {
     const uint8_t red = clamp255(color.getRed());
     const uint8_t green = clamp255(color.getGreen());

--- a/src/global/AnsiTextUtils.h
+++ b/src/global/AnsiTextUtils.h
@@ -210,7 +210,7 @@ NODISCARD AnsiColor256 toAnsiColor256(AnsiColorRGB rgb);
 
 NODISCARD AnsiColorRGB toAnsiColorRGB(AnsiColor16Enum ansi);
 NODISCARD AnsiColorRGB toAnsiColorRGB(AnsiColor256 ansiColor);
-NODISCARD AnsiColorRGB toAnsiColorRGB(const Color &c);
+NODISCARD AnsiColorRGB toAnsiColorRGB(Color c);
 
 // lossy, except when rgb is one of the table entries
 NODISCARD AnsiColor16Enum toAnsiColor16Enum(AnsiColorRGB rgb);

--- a/src/global/Color.cpp
+++ b/src/global/Color.cpp
@@ -20,7 +20,7 @@ static constexpr const int SHIFT_g = 8;
 static constexpr const int SHIFT_b = 16;
 static constexpr const int SHIFT_a = 24;
 
-Color::Color(const Color &rgb, const float alpha)
+Color::Color(const Color rgb, const float alpha)
     : Color{rgb.withAlpha(alpha)}
 {}
 
@@ -179,7 +179,7 @@ Color Color::fromRGB(const uint32_t rgb)
     return c;
 }
 
-AnsiOstream &operator<<(AnsiOstream &os, const Color &c)
+AnsiOstream &operator<<(AnsiOstream &os, const Color c)
 {
     // These may not display as RGB on the client's terminal, but they'll
     // probably look better than showing them all in the default color.

--- a/src/global/Color.h
+++ b/src/global/Color.h
@@ -44,7 +44,7 @@ public:
 
 public:
     explicit Color(uint32_t, float) = delete;
-    explicit Color(const Color &rgb, float alpha);
+    explicit Color(Color rgb, float alpha);
 
 public:
     explicit Color(int r, int g, int b);
@@ -73,10 +73,10 @@ public:
     NODISCARD uint32_t getBlue() const;  // 0..255
 
 public:
-    bool operator==(const Color &rhs) const { return m_color == rhs.m_color; }
-    bool operator!=(const Color &rhs) const { return !operator==(rhs); }
-    explicit operator glm::vec4() const { return getVec4(); }
-    explicit operator QColor() const;
+    NODISCARD bool operator==(const Color &rhs) const { return m_color == rhs.m_color; }
+    NODISCARD bool operator!=(const Color &rhs) const { return !operator==(rhs); }
+    NODISCARD explicit operator glm::vec4() const { return getVec4(); }
+    NODISCARD explicit operator QColor() const;
 
 public:
     NODISCARD Color withAlpha(float alpha) const;
@@ -86,8 +86,8 @@ public:
     NODISCARD static Color fromHex(std::string_view sv);
     NODISCARD std::string toHex() const;
     std::ostream &toHex(std::ostream &os) const;
-    friend std::ostream &operator<<(std::ostream &os, const Color &c) { return c.toHex(os); }
-    friend AnsiOstream &operator<<(AnsiOstream &os, const Color &c);
+    friend std::ostream &operator<<(std::ostream &os, const Color c) { return c.toHex(os); }
+    friend AnsiOstream &operator<<(AnsiOstream &os, Color c);
 
 public:
     // note: this is not done in linear color space.

--- a/src/global/NamedColors.h
+++ b/src/global/NamedColors.h
@@ -9,23 +9,62 @@
 #include <string_view>
 #include <vector>
 
+#undef TRANSPARENT // Bad dog, Microsoft; bad dog!!!
+
+// X(_id, _name)
+#define XFOREACH_NAMED_COLOR_OPTIONS(X) \
+    X(BACKGROUND, "background") \
+    X(CONNECTION_NORMAL, "connection-normal") \
+    X(HIGHLIGHT_NEEDS_SERVER_ID, "highlight-needs-server-id") \
+    X(HIGHLIGHT_UNSAVED, "highlight-unsaved") \
+    X(HIGHLIGHT_TEMPORARY, "highlight-temporary") \
+    X(INFOMARK_COMMENT, "infomark-comment") \
+    X(INFOMARK_HERB, "infomark-herb") \
+    X(INFOMARK_MOB, "infomark-mob") \
+    X(INFOMARK_OBJECT, "infomark-object") \
+    X(INFOMARK_RIVER, "infomark-river") \
+    X(INFOMARK_ROAD, "infomark-road") \
+    X(ROOM_DARK, "room-dark") \
+    X(ROOM_NO_SUNDEATH, "room-no-sundeath") \
+    X(STREAM, "stream") \
+    X(TRANSPARENT, ".transparent") \
+    X(VERTICAL_COLOR_CLIMB, "vertical-climb") \
+    X(VERTICAL_COLOR_REGULAR_EXIT, "vertical-regular") \
+    X(WALL_COLOR_BUG_WALL_DOOR, "wall-bug-wall-door") \
+    X(WALL_COLOR_CLIMB, "wall-climb") \
+    X(WALL_COLOR_FALL_DAMAGE, "wall-fall-damage") \
+    X(WALL_COLOR_GUARDED, "wall-guarded") \
+    X(WALL_COLOR_NO_FLEE, "wall-no-flee") \
+    X(WALL_COLOR_NO_MATCH, "wall-no-match") \
+    X(WALL_COLOR_NOT_MAPPED, "wall-not-mapped") \
+    X(WALL_COLOR_RANDOM, "wall-random") \
+    X(WALL_COLOR_REGULAR_EXIT, "wall-regular-exit") \
+    X(WALL_COLOR_SPECIAL, "wall-special")
+
+#define X_DECL(_id, _name) _id,
+enum class NODISCARD NamedColorEnum : uint8_t { DEFAULT = 0, XFOREACH_NAMED_COLOR_OPTIONS(X_DECL) };
+#undef X_DECL
+#define X_COUNT(_id, _name) +1
+static inline constexpr size_t NUM_NAMED_COLORS = XFOREACH_NAMED_COLOR_OPTIONS(X_COUNT) + 1;
+#undef X_COUNT
+
 // TODO: rename this, but to what? NamedColorHandle?
 class NODISCARD XNamedColor final
 {
-public:
-    static constexpr size_t UNINITIALIZED = 0;
-
 private:
-    const size_t m_index;
+    NamedColorEnum m_value = NamedColorEnum::DEFAULT;
 
 public:
-    XNamedColor() = delete;
+    NODISCARD static std::optional<XNamedColor> lookup(std::string_view sv);
+
+public:
+    XNamedColor() = default;
     XNamedColor(std::nullptr_t) = delete;
-    explicit XNamedColor(std::string_view name);
-    template<size_t N>
-    explicit XNamedColor(const char name[N])
-        : XNamedColor(std::string_view(name, N))
-    {}
+    explicit XNamedColor(const NamedColorEnum color)
+        : m_value{color}
+    {
+        assert(getIndex() < NUM_NAMED_COLORS);
+    }
 
 public:
     ~XNamedColor();
@@ -35,13 +74,15 @@ public:
     DELETE_ASSIGN_OPS(XNamedColor);
 
 public:
-    NODISCARD bool isInitialized() const noexcept { return getIndex() != UNINITIALIZED; }
-    NODISCARD size_t getIndex() const noexcept { return m_index; }
+    NODISCARD bool isInitialized() const;
+    NODISCARD size_t getIndex() const noexcept { return static_cast<uint8_t>(m_value); }
+    NODISCARD NamedColorEnum getNamedColorEnum() const noexcept { return m_value; }
 
 public:
-    NODISCARD std::string getName() const;
+    NODISCARD const std::string &getName() const;
     NODISCARD Color getColor() const;
-    void setColor(Color c);
+    // note: you can't actually set DEFAULT or TRANSPARENT
+    ALLOW_DISCARD bool setColor(Color c);
 
 public:
     NODISCARD explicit operator Color() const { return getColor(); }
@@ -52,10 +93,10 @@ public:
     }
 
 public:
-    NODISCARD bool operator==(const XNamedColor &rhs) const { return m_index == rhs.m_index; }
+    NODISCARD bool operator==(const XNamedColor &rhs) const { return m_value == rhs.m_value; }
     NODISCARD bool operator!=(const XNamedColor &rhs) const { return !(rhs == *this); }
 
 public:
-    // NOTE: This allocates memory.
-    NODISCARD static std::vector<std::string> getAllNames();
+    NODISCARD static const std::vector<Color> &getAllColors();
+    NODISCARD static const std::vector<std::string> &getAllNames();
 };

--- a/src/opengl/Font.cpp
+++ b/src/opengl/Font.cpp
@@ -644,13 +644,13 @@ public:
 
         // measurement, background color, and underline.
         {
-            const auto add = [this](const Color &c, const glm::ivec2 &ivert, const glm::ivec2 &itc) {
+            const auto add = [this](const Color c, const glm::ivec2 &ivert, const glm::ivec2 &itc) {
                 const glm::vec2 tc = getTexCoord(itc);
                 const glm::vec2 vert = transformVert(ivert);
                 m_verts3d.emplace_back(m_opts.pos, c, tc, vert);
             };
 
-            const auto quad = [&add](const Color &c, const Rect &vert, const Rect &tc) {
+            const auto quad = [&add](const Color c, const Rect &vert, const Rect &tc) {
 #define ADD(a, b) add(c, glm::ivec2{vert.a.x, vert.b.y}, glm::ivec2{tc.a.x, tc.b.y})
                 // note: lo and hi refer to members of vert and tc.
                 ADD(lo, lo);
@@ -886,8 +886,8 @@ UniqueMesh GLFont::getFontMesh(const std::vector<FontVert3d> &rawVerts)
 }
 
 void GLFont::renderTextCentered(const QString &text,
-                                const Color &color,
-                                const std::optional<Color> &bgcolor)
+                                const Color color,
+                                const std::optional<Color> bgcolor)
 {
     // here we're converting to latin1 because we cannot display unicode codepoints above 255
     const auto center = glm::vec2{getScreenCenter()};

--- a/src/opengl/Font.h
+++ b/src/opengl/Font.h
@@ -32,7 +32,7 @@ struct NODISCARD GLText final
 
     explicit GLText(const glm::vec3 &pos_,
                     std::string moved_text,
-                    const Color &color_ = {},
+                    const Color color_ = {},
                     std::optional<Color> bgcolor_ = {},
                     const FontFormatFlags fontFormatFlag_ = {},
                     int rotationAngle_ = 0)
@@ -88,8 +88,8 @@ private:
 
 public:
     void renderTextCentered(const QString &text,
-                            const Color &color = {},
-                            const std::optional<Color> &bgcolor = {});
+                            Color color = {},
+                            std::optional<Color> bgcolor = {});
     void render2dTextImmediate(const std::vector<GLText> &text);
     void render3dTextImmediate(const std::vector<GLText> &text);
     void render3dTextImmediate(const std::vector<FontVert3d> &rawVerts);

--- a/src/opengl/LineRendering.cpp
+++ b/src/opengl/LineRendering.cpp
@@ -13,8 +13,8 @@ namespace mmgl {
 void generateLineQuad(std::vector<ColorVert> &verts,
                       const glm::vec3 &p1,
                       const glm::vec3 &p2,
-                      float width,
-                      const Color &color,
+                      const float width,
+                      const Color color,
                       const glm::vec3 &perpendicular_normal)
 {
     // Assert that perpendicular_normal is unit length
@@ -67,8 +67,8 @@ glm::vec3 getOrthogonalNormal(const glm::vec3 &direction, const glm::vec3 &perp_
 void generateLineQuadsSafe(std::vector<ColorVert> &verts,
                            const glm::vec3 &p1,
                            const glm::vec3 &p2,
-                           float width,
-                           const Color &color)
+                           const float width,
+                           const Color color)
 {
     const glm::vec3 segment = p2 - p1;
     if (isNearZero(segment)) {
@@ -84,7 +84,7 @@ void generateLineQuadsSafe(std::vector<ColorVert> &verts,
 void drawZeroLengthSquare(std::vector<ColorVert> &verts,
                           const glm::vec3 &center,
                           float width,
-                          const Color &color)
+                          const Color color)
 {
     float half_size = width / 2.0f;
     glm::vec3 v1 = center + glm::vec3(-half_size, -half_size, 0.0f);

--- a/src/opengl/LineRendering.h
+++ b/src/opengl/LineRendering.h
@@ -32,13 +32,13 @@ void generateLineQuad(std::vector<ColorVert> &verts,
                       const glm::vec3 &p1,
                       const glm::vec3 &p2,
                       float width,
-                      const Color &color,
+                      Color color,
                       const glm::vec3 &perpendicular_normal);
 
 void drawZeroLengthSquare(std::vector<ColorVert> &verts,
                           const glm::vec3 &center,
                           float width,
-                          const Color &color);
+                          Color color);
 
 // Returns a normalized vector perpendicular to the input direction, primarily in the XY plane.
 // Handles near-zero direction vectors by returning a default perpendicular (1,0,0).
@@ -54,7 +54,7 @@ void generateLineQuadsSafe(std::vector<ColorVert> &verts,
                            const glm::vec3 &p1,
                            const glm::vec3 &p2,
                            float width,
-                           const Color &color);
+                           Color color);
 
 // Checks if the squared length of a vector is below the degeneration threshold.
 NODISCARD bool isDegenerate(const glm::vec3 &vec);

--- a/src/opengl/OpenGL.cpp
+++ b/src/opengl/OpenGL.cpp
@@ -140,7 +140,7 @@ UniqueMesh OpenGL::createFontMesh(const SharedMMTexture &texture,
     return getFunctions().createFontMesh(texture, mode, batch);
 }
 
-void OpenGL::clear(const Color &color)
+void OpenGL::clear(const Color color)
 {
     const auto v = color.getVec4();
     auto &gl = getFunctions();

--- a/src/opengl/OpenGL.h
+++ b/src/opengl/OpenGL.h
@@ -155,7 +155,7 @@ public:
     void renderFont3d(const SharedMMTexture &texture, const std::vector<FontVert3d> &verts);
 
 public:
-    void clear(const Color &color);
+    void clear(const Color color);
     void clearDepth();
     void renderPlainFullScreenQuad(const GLRenderState &state);
 

--- a/src/opengl/OpenGLTypes.h
+++ b/src/opengl/OpenGLTypes.h
@@ -5,10 +5,12 @@
 #include "../global/Array.h"
 #include "../global/Color.h"
 #include "../global/IndexedVector.h"
+#include "../global/NamedColors.h"
 #include "../global/TaggedInt.h"
 #include "../global/hash.h"
 #include "../global/utils.h"
 #include "FontFormatFlags.h"
+#include "global/ConfigConsts.h"
 
 #include <cstdint>
 #include <memory>
@@ -42,7 +44,7 @@ struct NODISCARD ColoredTexVert final
     glm::vec3 tex{};
     glm::vec3 vert{};
 
-    explicit ColoredTexVert(const Color &color_, const glm::vec3 &tex_, const glm::vec3 &vert_)
+    explicit ColoredTexVert(const Color color_, const glm::vec3 &tex_, const glm::vec3 &vert_)
         : color{color_}
         , tex{tex_}
         , vert{vert_}
@@ -56,7 +58,7 @@ struct NODISCARD ColorVert final
     Color color;
     glm::vec3 vert{};
 
-    explicit ColorVert(const Color &color_, const glm::vec3 &vert_)
+    explicit ColorVert(const Color color_, const glm::vec3 &vert_)
         : color{color_}
         , vert{vert_}
     {}
@@ -76,7 +78,7 @@ struct NODISCARD FontVert3d final
     glm::vec2 vert{}; // screen space
 
     explicit FontVert3d(const glm::vec3 &base_,
-                        const Color &color_,
+                        const Color color_,
                         const glm::vec2 &tex_,
                         const glm::vec2 &vert_)
         : base{base_}
@@ -202,7 +204,7 @@ struct NODISCARD GLRenderState final
         return copy;
     }
 
-    NODISCARD GLRenderState withColor(const Color &new_color) const
+    NODISCARD GLRenderState withColor(const Color new_color) const
     {
         GLRenderState copy = *this;
         copy.uniforms.color = new_color;

--- a/src/opengl/legacy/AbstractShaderProgram.cpp
+++ b/src/opengl/legacy/AbstractShaderProgram.cpp
@@ -140,7 +140,7 @@ void AbstractShaderProgram::setPointSize(const float in_pointSize)
     }
 }
 
-void AbstractShaderProgram::setColor(const char *const name, const Color &color)
+void AbstractShaderProgram::setColor(const char *const name, const Color color)
 {
     const auto location = getUniformLocation(name);
     const glm::vec4 v = color.getVec4();

--- a/src/opengl/legacy/AbstractShaderProgram.h
+++ b/src/opengl/legacy/AbstractShaderProgram.h
@@ -85,7 +85,7 @@ private:
 
 public:
     void setPointSize(float in_pointSize);
-    void setColor(const char *name, const Color &color);
+    void setColor(const char *name, Color color);
     void setMatrix(const char *name, const glm::mat4 &m);
     void setTexture(const char *name, int textureUnit);
     void setViewport(const char *name, const Viewport &input_viewport);


### PR DESCRIPTION
## Summary by Sourcery

Refactor named color handling to use a fixed enum-based system and simplify color passing and rendering APIs.

New Features:
- Introduce a NamedColorEnum enumeration and global registry for named colors, including default, transparent, and configuration-defined names.

Bug Fixes:
- Ensure invalid or non-existent named color lookups are handled safely with optionals and user-visible error messages.
- Prevent modification of default and transparent colors through configuration commands.

Enhancements:
- Refactor XNamedColor to wrap a NamedColorEnum instead of dynamic indices and provide lookup, initialization tracking, and bulk accessors for names and colors.
- Split configuration color options into mutable configuration structs and resolved, color-only views for safer sharing across threads.
- Update rendering and map canvas code to pass Color and NamedColorEnum values directly, reducing reliance on mutable global configuration objects.
- Tighten Color and related APIs by using value parameters, adding NODISCARD on key methods, and simplifying stream and OpenGL helper signatures.
- Improve error reporting in map rendering by logging detailed messages before notifying the user.