### PR TITLE
add configurable hotkey support and _hotkey command

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,10 @@ set(mmapper_SRCS
     client/inputwidget.h
     client/stackedinputwidget.cpp
     client/stackedinputwidget.h
+    client/Hotkey.cpp
+    client/Hotkey.h
+    client/HotkeyManager.cpp
+    client/HotkeyManager.h
     client/PasswordDialog.cpp
     client/PasswordDialog.h
     client/PreviewWidget.cpp
@@ -32,6 +36,8 @@ set(mmapper_SRCS
     clock/mumeclockwidget.h
     clock/mumemoment.cpp
     clock/mumemoment.h
+    configuration/GroupConfig.cpp
+    configuration/GroupConfig.h
     configuration/NamedConfig.h
     configuration/PasswordConfig.cpp
     configuration/PasswordConfig.h
@@ -432,6 +438,7 @@ set(mmapper_SRCS
     parser/AbstractParser-Commands.h
     parser/AbstractParser-Config.cpp
     parser/AbstractParser-Group.cpp
+    parser/AbstractParser-Hotkey.cpp
     parser/AbstractParser-Mark.cpp
     parser/AbstractParser-Room.cpp
     parser/AbstractParser-Timer.cpp

--- a/src/client/ClientWidget.h
+++ b/src/client/ClientWidget.h
@@ -20,6 +20,7 @@ class QObject;
 class StackedInputWidget;
 class PreviewWidget;
 class ConnectionListener;
+class HotkeyManager;
 
 struct ClientTelnetOutputs;
 struct DisplayWidgetOutputs;
@@ -56,9 +57,12 @@ private:
 
     Pipeline m_pipeline;
     ConnectionListener &m_listener;
+    HotkeyManager &m_hotkeyManager;
 
 public:
-    explicit ClientWidget(ConnectionListener &listener, QWidget *parent);
+    explicit ClientWidget(ConnectionListener &listener,
+                          HotkeyManager &hotkeyManager,
+                          QWidget *parent);
     ~ClientWidget() final;
 
 private:
@@ -79,6 +83,7 @@ private:
     NODISCARD PreviewWidget &getPreview();
 
 public:
+    NODISCARD HotkeyManager &getHotkeys();
     NODISCARD bool isUsingClient() const;
     void displayReconnectHint();
 

--- a/src/client/Hotkey.cpp
+++ b/src/client/Hotkey.cpp
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+#include "Hotkey.h"
+
+#include "../global/CaseUtils.h"
+#include "../global/CharUtils.h"
+#include "../global/ConfigConsts-Computed.h"
+#include "../global/TextUtils.h"
+
+#include <sstream>
+
+bool Hotkey::isPolicySatisfied() const
+{
+    const auto mods = modifiers();
+    if (isModifierRequired() && mods.isEmpty()) {
+        return false;
+    }
+    if (isModifierNotShift()) {
+        const bool isNoMod = mods.isEmpty();
+        const bool isOnlyShift = (mods.isShift() && mods.size() == 1);
+        if (isNoMod || isOnlyShift) {
+            return false;
+        }
+    }
+    return true;
+}
+
+Hotkey::Hotkey(std::string_view s)
+{
+    if (s.empty()) {
+        return;
+    }
+
+    size_t start = 0;
+    size_t end = s.find('+');
+    while (true) {
+        std::string part = std::invoke([&s, &start, &end]() {
+            std::string_view sv = (end == std::string::npos) ? s.substr(start)
+                                                             : s.substr(start, end - start);
+            // Trim whitespace
+            while (!sv.empty() && ascii::isSpace(sv.front())) {
+                sv.remove_prefix(1);
+            }
+            while (!sv.empty() && ascii::isSpace(sv.back())) {
+                sv.remove_suffix(1);
+            }
+
+            return ::toUpperUtf8(sv);
+        });
+
+        if (!part.empty()) {
+#define X_PARSE(id, camel, qtenum) \
+    if (part == #id) { \
+        m_modifiers.insert(HotkeyModifierEnum::id); \
+    } else
+            XFOREACH_HOTKEY_MODIFIER(X_PARSE)
+#undef X_PARSE
+            {
+                // Not a modifier, check if its a valid base key
+#define X_NAME_TO_ENUM(id, str, qkey, pol) \
+    if (part == str) { \
+        m_base = HotkeyEnum::id; \
+        m_policy = pol; \
+    } else
+                XFOREACH_HOTKEY_BASE_KEYS(X_NAME_TO_ENUM)
+#undef X_NAME_TO_ENUM
+                {
+                    // Not a valid token
+                    m_base = HotkeyEnum::INVALID;
+                    m_modifiers.clear();
+                    return;
+                }
+            }
+        }
+
+        if (end == std::string::npos) {
+            break;
+        }
+        start = end + 1;
+        end = s.find('+', start);
+    }
+}
+
+Hotkey::Hotkey(Qt::Key key, Qt::KeyboardModifiers modifiers)
+{
+    bool isNumpad = (modifiers & Qt::KeypadModifier);
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wswitch-enum"
+    if (isNumpad) {
+        // Map keypad navigation keys to their numeric counterparts when isNumpad is true,
+        // except on Mac where num lock does not exist.
+        switch (key) {
+#define X_KEYPAD(from, to) \
+    case from: \
+        if constexpr (CURRENT_PLATFORM == PlatformEnum::Mac) { \
+            isNumpad = false; \
+        } else { \
+            key = to; \
+        } \
+        break;
+            XFOREACH_HOTKEY_KEYPAD_MAP(X_KEYPAD)
+#undef X_KEYPAD
+        default:
+            break;
+        }
+    }
+#pragma clang diagnostic pop
+
+    assert(m_base == HotkeyEnum::INVALID);
+#define X_BASE(id, name, qk, pol) \
+    if (key == qk && ((pol == HotkeyPolicyEnum::Keypad) == isNumpad)) { \
+        m_base = HotkeyEnum::id; \
+        m_policy = pol; \
+    }
+    XFOREACH_HOTKEY_BASE_KEYS(X_BASE)
+#undef X_BASE
+    if (m_base == HotkeyEnum::INVALID) {
+        return;
+    }
+
+#define X_MODIFIER(id, camel, qtenum) \
+    if (modifiers & qtenum) { \
+        m_modifiers.insert(HotkeyModifierEnum::id); \
+    }
+    XFOREACH_HOTKEY_MODIFIER(X_MODIFIER)
+#undef X_MODIFIER
+}
+
+std::string Hotkey::to_string() const
+{
+    std::stringstream oss;
+#define X_STR(id, camel, qtenum) \
+    if (modifiers().is##camel()) { \
+        oss << #id << "+"; \
+    }
+    XFOREACH_HOTKEY_MODIFIER(X_STR)
+#undef X_STR
+
+    switch (base()) {
+#define X_SERIALIZE(id, name, qkey, policy) \
+    case HotkeyEnum::id: \
+        oss << name; \
+        break;
+        XFOREACH_HOTKEY_BASE_KEYS(X_SERIALIZE)
+#undef X_SERIALIZE
+    case HotkeyEnum::INVALID:
+        return {};
+    }
+    return oss.str();
+}

--- a/src/client/Hotkey.h
+++ b/src/client/Hotkey.h
@@ -1,0 +1,227 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+#include "../global/Flags.h"
+#include "../global/hash.h"
+#include "../global/macros.h"
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+#include <QString>
+#include <Qt>
+
+#if defined(_MSC_VER) || defined(__MINGW32__)
+#undef DELETE  // Bad dog, Microsoft; bad dog!!!
+#undef INVALID // Bad dog, Microsoft; bad dog!!!
+#endif
+
+// Macro to define all supporting hotkey policies.
+// X(EnumName, Marker, Help)
+#define XFOREACH_HOTKEY_POLICY(X) \
+    X(Any, "", "Can be bound with or without modifiers (e.g. F-keys)") \
+    X(Keypad, "", "Can be bound with or without modifiers (e.g. Numpad)") \
+    X(ModifierRequired, "*", "Requires a modifier (CTRL, ALT, SHIFT, or META)") \
+    X(ModifierNotShift, "**", "Requires a non-SHIFT modifier (CTRL, ALT, or META)")
+
+enum class HotkeyPolicyEnum : uint8_t {
+#define X_ENUM(name, marker, help) name,
+    XFOREACH_HOTKEY_POLICY(X_ENUM)
+#undef X_ENUM
+};
+
+#define X_COUNT(name, marker, help) +1
+static constexpr const size_t NUM_HOTKEY_POLICIES = 0 XFOREACH_HOTKEY_POLICY(X_COUNT);
+#undef X_COUNT
+static_assert(NUM_HOTKEY_POLICIES == 4);
+
+// Macro to define all supported base keys and their Qt mappings.
+// X(EnumName, StringName, QtKey, Policy) -> Defines a unique identity
+#define XFOREACH_HOTKEY_BASE_KEYS(X) \
+    X(F1, "F1", Qt::Key_F1, HotkeyPolicyEnum::Any) \
+    X(F2, "F2", Qt::Key_F2, HotkeyPolicyEnum::Any) \
+    X(F3, "F3", Qt::Key_F3, HotkeyPolicyEnum::Any) \
+    X(F4, "F4", Qt::Key_F4, HotkeyPolicyEnum::Any) \
+    X(F5, "F5", Qt::Key_F5, HotkeyPolicyEnum::Any) \
+    X(F6, "F6", Qt::Key_F6, HotkeyPolicyEnum::Any) \
+    X(F7, "F7", Qt::Key_F7, HotkeyPolicyEnum::Any) \
+    X(F8, "F8", Qt::Key_F8, HotkeyPolicyEnum::Any) \
+    X(F9, "F9", Qt::Key_F9, HotkeyPolicyEnum::Any) \
+    X(F10, "F10", Qt::Key_F10, HotkeyPolicyEnum::Any) \
+    X(F11, "F11", Qt::Key_F11, HotkeyPolicyEnum::Any) \
+    X(F12, "F12", Qt::Key_F12, HotkeyPolicyEnum::Any) \
+    X(NUMPAD0, "NUMPAD0", Qt::Key_0, HotkeyPolicyEnum::Keypad) \
+    X(NUMPAD1, "NUMPAD1", Qt::Key_1, HotkeyPolicyEnum::Keypad) \
+    X(NUMPAD2, "NUMPAD2", Qt::Key_2, HotkeyPolicyEnum::Keypad) \
+    X(NUMPAD3, "NUMPAD3", Qt::Key_3, HotkeyPolicyEnum::Keypad) \
+    X(NUMPAD4, "NUMPAD4", Qt::Key_4, HotkeyPolicyEnum::Keypad) \
+    X(NUMPAD5, "NUMPAD5", Qt::Key_5, HotkeyPolicyEnum::Keypad) \
+    X(NUMPAD6, "NUMPAD6", Qt::Key_6, HotkeyPolicyEnum::Keypad) \
+    X(NUMPAD7, "NUMPAD7", Qt::Key_7, HotkeyPolicyEnum::Keypad) \
+    X(NUMPAD8, "NUMPAD8", Qt::Key_8, HotkeyPolicyEnum::Keypad) \
+    X(NUMPAD9, "NUMPAD9", Qt::Key_9, HotkeyPolicyEnum::Keypad) \
+    X(NUMPAD_SLASH, "NUMPAD_SLASH", Qt::Key_Slash, HotkeyPolicyEnum::Keypad) \
+    X(NUMPAD_ASTERISK, "NUMPAD_ASTERISK", Qt::Key_Asterisk, HotkeyPolicyEnum::Keypad) \
+    X(NUMPAD_MINUS, "NUMPAD_MINUS", Qt::Key_Minus, HotkeyPolicyEnum::Keypad) \
+    X(NUMPAD_PLUS, "NUMPAD_PLUS", Qt::Key_Plus, HotkeyPolicyEnum::Keypad) \
+    X(NUMPAD_PERIOD, "NUMPAD_PERIOD", Qt::Key_Period, HotkeyPolicyEnum::Keypad) \
+    X(HOME, "HOME", Qt::Key_Home, HotkeyPolicyEnum::ModifierRequired) \
+    X(END, "END", Qt::Key_End, HotkeyPolicyEnum::ModifierRequired) \
+    X(INSERT, "INSERT", Qt::Key_Insert, HotkeyPolicyEnum::ModifierRequired) \
+    X(PAGEUP, "PAGEUP", Qt::Key_PageUp, HotkeyPolicyEnum::ModifierRequired) \
+    X(PAGEDOWN, "PAGEDOWN", Qt::Key_PageDown, HotkeyPolicyEnum::ModifierRequired) \
+    X(UP, "UP", Qt::Key_Up, HotkeyPolicyEnum::ModifierRequired) \
+    X(DOWN, "DOWN", Qt::Key_Down, HotkeyPolicyEnum::ModifierRequired) \
+    X(LEFT, "LEFT", Qt::Key_Left, HotkeyPolicyEnum::ModifierRequired) \
+    X(RIGHT, "RIGHT", Qt::Key_Right, HotkeyPolicyEnum::ModifierRequired) \
+    X(DELETE, "DELETE", Qt::Key_Delete, HotkeyPolicyEnum::ModifierRequired) \
+    X(ACCENT, "ACCENT", Qt::Key_QuoteLeft, HotkeyPolicyEnum::ModifierNotShift) \
+    X(K_0, "0", Qt::Key_0, HotkeyPolicyEnum::ModifierNotShift) \
+    X(K_1, "1", Qt::Key_1, HotkeyPolicyEnum::ModifierNotShift) \
+    X(K_2, "2", Qt::Key_2, HotkeyPolicyEnum::ModifierNotShift) \
+    X(K_3, "3", Qt::Key_3, HotkeyPolicyEnum::ModifierNotShift) \
+    X(K_4, "4", Qt::Key_4, HotkeyPolicyEnum::ModifierNotShift) \
+    X(K_5, "5", Qt::Key_5, HotkeyPolicyEnum::ModifierNotShift) \
+    X(K_6, "6", Qt::Key_6, HotkeyPolicyEnum::ModifierNotShift) \
+    X(K_7, "7", Qt::Key_7, HotkeyPolicyEnum::ModifierNotShift) \
+    X(K_8, "8", Qt::Key_8, HotkeyPolicyEnum::ModifierNotShift) \
+    X(K_9, "9", Qt::Key_9, HotkeyPolicyEnum::ModifierNotShift) \
+    X(HYPHEN, "HYPHEN", Qt::Key_Minus, HotkeyPolicyEnum::ModifierNotShift) \
+    X(EQUAL, "EQUAL", Qt::Key_Equal, HotkeyPolicyEnum::ModifierNotShift)
+
+// Macro to define the mapping between keypad navigation keys and their numeric counterparts.
+// X(From, To)
+#define XFOREACH_HOTKEY_KEYPAD_MAP(X) \
+    X(Qt::Key_Home, Qt::Key_7) \
+    X(Qt::Key_Up, Qt::Key_8) \
+    X(Qt::Key_PageUp, Qt::Key_9) \
+    X(Qt::Key_Left, Qt::Key_4) \
+    X(Qt::Key_Clear, Qt::Key_5) \
+    X(Qt::Key_Right, Qt::Key_6) \
+    X(Qt::Key_End, Qt::Key_1) \
+    X(Qt::Key_Down, Qt::Key_2) \
+    X(Qt::Key_PageDown, Qt::Key_3) \
+    X(Qt::Key_Insert, Qt::Key_0) \
+    X(Qt::Key_Delete, Qt::Key_Period)
+
+#define X_COUNT(from, to) +1
+static constexpr const size_t NUM_HOTKEY_KEYPAD_KEYS = 0 XFOREACH_HOTKEY_KEYPAD_MAP(X_COUNT);
+#undef X_COUNT
+static_assert(NUM_HOTKEY_KEYPAD_KEYS == 11);
+
+enum class HotkeyEnum : uint8_t {
+#define X_ENUM(id, name, key, pol) id,
+    XFOREACH_HOTKEY_BASE_KEYS(X_ENUM)
+#undef X_ENUM
+        INVALID
+};
+#define X_COUNT(id, name, key, pol) +1
+static constexpr const size_t NUM_HOTKEY_KEYS = 0 XFOREACH_HOTKEY_BASE_KEYS(X_COUNT);
+#undef X_COUNT
+static_assert(NUM_HOTKEY_KEYS == 50);
+
+// Macro to define hotkeys modifiers
+// X(UPPER, CamelCase, QtEnum)
+#define XFOREACH_HOTKEY_MODIFIER(X) \
+    X(SHIFT, Shift, Qt::ShiftModifier) \
+    X(CTRL, Ctrl, Qt::ControlModifier) \
+    X(ALT, Alt, Qt::AltModifier) \
+    X(META, Meta, Qt::MetaModifier)
+
+enum class HotkeyModifierEnum : uint8_t {
+#define X_ENUM(id, camel, qtenum) id,
+    XFOREACH_HOTKEY_MODIFIER(X_ENUM)
+#undef X_ENUM
+};
+
+#define X_COUNT(id, camel, qtenum) +1
+static constexpr const size_t NUM_HOTKEY_MODIFIERS = 0 XFOREACH_HOTKEY_MODIFIER(X_COUNT);
+#undef X_COUNT
+static_assert(NUM_HOTKEY_MODIFIERS == 4);
+DEFINE_ENUM_COUNT(HotkeyModifierEnum, NUM_HOTKEY_MODIFIERS)
+
+class NODISCARD HotkeyModifiers final
+    : public enums::Flags<HotkeyModifiers, HotkeyModifierEnum, uint8_t>
+{
+public:
+    using Flags::Flags;
+
+public:
+#define X_IS_POLICY(name, camel, qtenum) \
+    NODISCARD bool is##camel() const { return contains(HotkeyModifierEnum::name); }
+    XFOREACH_HOTKEY_MODIFIER(X_IS_POLICY)
+#undef X_IS_POLICY
+};
+
+namespace {
+constexpr bool isUppercase(const char *s)
+{
+    while (*s) {
+        if (*s >= 'a' && *s <= 'z')
+            return false;
+        s++;
+    }
+    return true;
+}
+#define X_CHECK_UPPER(id, name, qkey, policy) \
+    static_assert(isUppercase(name), "Hotkey name must be uppercase: " name);
+XFOREACH_HOTKEY_BASE_KEYS(X_CHECK_UPPER)
+#undef X_CHECK_UPPER
+#define X_CHECK_UPPER(name, camel, qtenum) \
+    static_assert(isUppercase(#name), "Hotkey modifier must be uppercase: " #name);
+XFOREACH_HOTKEY_MODIFIER(X_CHECK_UPPER)
+#undef X_CHECK_UPPER
+} // namespace
+
+class NODISCARD Hotkey final
+{
+private:
+    HotkeyEnum m_base = HotkeyEnum::INVALID;
+    HotkeyModifiers m_modifiers = {};
+    HotkeyPolicyEnum m_policy = HotkeyPolicyEnum::Any;
+
+public:
+    Hotkey() = delete;
+    explicit Hotkey(std::string_view s);
+    explicit Hotkey(Qt::Key key, Qt::KeyboardModifiers modifiers);
+
+public:
+    NODISCARD bool isRecognized() const { return m_base != HotkeyEnum::INVALID; }
+    NODISCARD bool isPolicySatisfied() const;
+    NODISCARD bool isValid() const { return isRecognized() && isPolicySatisfied(); }
+
+public:
+    NODISCARD std::string to_string() const;
+
+public:
+    NODISCARD bool operator==(const Hotkey &other) const
+    {
+        return m_base == other.m_base && m_modifiers == other.m_modifiers;
+    }
+    NODISCARD bool operator!=(const Hotkey &other) const { return !(*this == other); }
+
+public:
+    NODISCARD HotkeyEnum base() const { return m_base; }
+    NODISCARD HotkeyModifiers modifiers() const { return m_modifiers; }
+    NODISCARD HotkeyPolicyEnum policy() const { return m_policy; }
+
+public:
+#define X_IS_POLICY(name, marker, help) \
+    NODISCARD bool is##name() const { return m_policy == HotkeyPolicyEnum::name; }
+    XFOREACH_HOTKEY_POLICY(X_IS_POLICY)
+#undef X_IS_POLICY
+};
+
+template<>
+struct std::hash<Hotkey>
+{
+    std::size_t operator()(const Hotkey &hk) const noexcept
+    {
+        size_t seed = 0;
+        hash_combine(seed, static_cast<uint8_t>(hk.base()));
+        hash_combine(seed, hk.modifiers().asUint32());
+        return seed;
+    }
+};

--- a/src/client/HotkeyManager.cpp
+++ b/src/client/HotkeyManager.cpp
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+#include "HotkeyManager.h"
+
+#include "../configuration/configuration.h"
+#include "../global/TextUtils.h"
+#include "../global/logging.h"
+
+#include <QDebug>
+#include <QSettings>
+
+HotkeyManager::HotkeyManager()
+{
+    setConfig().hotkeys.registerChangeCallback(m_configLifetime,
+                                               [this]() { this->syncFromConfig(); });
+    setConfig().hotkeys.registerResetCallback(m_configLifetime,
+                                              [this]() { this->resetToDefaults(); });
+    syncFromConfig();
+    if (m_hotkeys.empty()) {
+        resetToDefaults();
+    }
+}
+
+void HotkeyManager::syncFromConfig()
+{
+    m_hotkeys.clear();
+    const QVariantMap &data = getConfig().hotkeys.data();
+    for (auto it = data.begin(); it != data.end(); ++it) {
+        auto key = mmqt::toStdStringUtf8(it.key());
+        auto value = mmqt::toStdStringUtf8(it.value().toString());
+        Hotkey hk(key);
+        if (hk.isValid()) {
+            m_hotkeys[hk] = value;
+        } else {
+            MMLOG_WARNING() << "invalid hotkey" << key << value;
+        }
+    }
+}
+
+bool HotkeyManager::setHotkey(const Hotkey &hk, std::string command)
+{
+    if (!hk.isValid()) {
+        return false;
+    }
+
+    QVariantMap data = getConfig().hotkeys.data();
+    data[mmqt::toQStringUtf8(hk.to_string())] = mmqt::toQStringUtf8(command);
+    setConfig().hotkeys.setData(std::move(data));
+    return true;
+}
+
+bool HotkeyManager::removeHotkey(const Hotkey &hk)
+{
+    if (!hk.isRecognized()) {
+        return false;
+    }
+    QVariantMap data = getConfig().hotkeys.data();
+    const auto key = mmqt::toQStringUtf8(hk.to_string());
+    if (!data.contains(key)) {
+        return false;
+    }
+    data.remove(key);
+    setConfig().hotkeys.setData(std::move(data));
+    return true;
+}
+
+std::optional<std::string> HotkeyManager::getCommand(const Hotkey &hk) const
+{
+    if (!hk.isValid()) {
+        return std::nullopt;
+    }
+
+    auto it = m_hotkeys.find(hk);
+    if (it == m_hotkeys.end()) {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
+std::vector<std::pair<Hotkey, std::string>> HotkeyManager::getAllHotkeys() const
+{
+    std::vector<std::pair<Hotkey, std::string>> result;
+    for (const auto &[hk, cmd] : m_hotkeys) {
+        result.emplace_back(hk, cmd);
+    }
+    return result;
+}
+
+void HotkeyManager::resetToDefaults()
+{
+    QVariantMap data;
+#define X_DEFAULT(key, cmd) data[key] = QString(cmd);
+    XFOREACH_DEFAULT_HOTKEYS(X_DEFAULT)
+#undef X_DEFAULT
+    setConfig().hotkeys.setData(std::move(data));
+}
+
+void HotkeyManager::clear()
+{
+    setConfig().hotkeys.setData(QVariantMap());
+}

--- a/src/client/HotkeyManager.h
+++ b/src/client/HotkeyManager.h
@@ -1,0 +1,138 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+#include "../global/ChangeMonitor.h"
+#include "../global/RuleOf5.h"
+#include "../global/macros.h"
+#include "Hotkey.h"
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <QString>
+#include <Qt>
+
+// Macro to define default hotkeys
+// X(SerializedKey, Command)
+#define XFOREACH_DEFAULT_HOTKEYS(X) \
+    X("F1", "F1") \
+    X("F2", "F2") \
+    X("F3", "F3") \
+    X("F4", "F4") \
+    X("F5", "F5") \
+    X("F6", "F6") \
+    X("F7", "F7") \
+    X("F8", "F8") \
+    X("F9", "F9") \
+    X("F10", "F10") \
+    X("F11", "F11") \
+    X("F12", "F12") \
+    X("NUMPAD8", "north") \
+    X("NUMPAD4", "west") \
+    X("NUMPAD6", "east") \
+    X("NUMPAD5", "south") \
+    X("NUMPAD_MINUS", "up") \
+    X("NUMPAD_PLUS", "down") \
+    X("CTRL+NUMPAD8", "open exit north") \
+    X("CTRL+NUMPAD4", "open exit west") \
+    X("CTRL+NUMPAD6", "open exit east") \
+    X("CTRL+NUMPAD5", "open exit south") \
+    X("CTRL+NUMPAD_MINUS", "open exit up") \
+    X("CTRL+NUMPAD_PLUS", "open exit down") \
+    X("ALT+NUMPAD8", "close exit north") \
+    X("ALT+NUMPAD4", "close exit west") \
+    X("ALT+NUMPAD6", "close exit east") \
+    X("ALT+NUMPAD5", "close exit south") \
+    X("ALT+NUMPAD_MINUS", "close exit up") \
+    X("ALT+NUMPAD_PLUS", "close exit down") \
+    X("SHIFT+NUMPAD8", "pick exit north") \
+    X("SHIFT+NUMPAD4", "pick exit west") \
+    X("SHIFT+NUMPAD6", "pick exit east") \
+    X("SHIFT+NUMPAD5", "pick exit south") \
+    X("SHIFT+NUMPAD_MINUS", "pick exit up") \
+    X("SHIFT+NUMPAD_PLUS", "pick exit down") \
+    X("NUMPAD7", "look") \
+    X("NUMPAD9", "flee") \
+    X("NUMPAD2", "lead") \
+    X("NUMPAD0", "bash") \
+    X("NUMPAD1", "ride") \
+    X("NUMPAD3", "stand")
+
+namespace {
+
+constexpr bool is_valid_hotkey(std::string_view hotkey_str)
+{
+    // Find the base key (the part after the last '+')
+    size_t last_plus = hotkey_str.rfind('+');
+    std::string_view base_part = (last_plus == std::string_view::npos)
+                                     ? hotkey_str
+                                     : hotkey_str.substr(last_plus + 1);
+
+    // Determine which modifiers are present
+    bool has_ctrl = hotkey_str.find("CTRL") != std::string_view::npos;
+    bool has_alt = hotkey_str.find("ALT") != std::string_view::npos;
+    bool has_shift = hotkey_str.find("SHIFT") != std::string_view::npos;
+    bool has_meta = hotkey_str.find("META") != std::string_view::npos;
+    bool has_any_mod = has_ctrl || has_alt || has_shift || has_meta;
+
+    // Match against the base key and check policy
+#define CHECK_POLICY(id, name, key, policy) \
+    if (base_part == name) { \
+        if (policy == HotkeyPolicyEnum::ModifierRequired) \
+            return has_any_mod; \
+        if (policy == HotkeyPolicyEnum::ModifierNotShift) \
+            return (has_ctrl || has_alt || has_meta); \
+        return true; \
+    }
+
+    XFOREACH_HOTKEY_BASE_KEYS(CHECK_POLICY)
+#undef CHECK_POLICY
+
+    // Key name not found
+    return false;
+}
+
+// This template trick ensures the compiler evaluates the expression for every macro entry
+template<bool V>
+struct Validate
+{
+    static_assert(V, "Hotkey policy violation detected!");
+};
+
+#define APPLY_VALIDATION(SerializedKey, Command) \
+    static_assert(is_valid_hotkey(SerializedKey), "Invalid Hotkey Policy for: " SerializedKey);
+XFOREACH_DEFAULT_HOTKEYS(APPLY_VALIDATION)
+#undef APPLY_VALIDATION
+
+} // namespace
+
+class NODISCARD HotkeyManager final
+{
+private:
+    std::unordered_map<Hotkey, std::string> m_hotkeys;
+    ChangeMonitor::Lifetime m_configLifetime;
+
+public:
+    HotkeyManager();
+    ~HotkeyManager() = default;
+
+    DELETE_CTORS_AND_ASSIGN_OPS(HotkeyManager);
+
+private:
+    void syncFromConfig();
+
+public:
+    NODISCARD bool setHotkey(const Hotkey &hk, std::string command);
+    NODISCARD bool removeHotkey(const Hotkey &hk);
+
+public:
+    NODISCARD std::optional<std::string> getCommand(const Hotkey &hk) const;
+    NODISCARD std::vector<std::pair<Hotkey, std::string>> getAllHotkeys() const;
+
+public:
+    void resetToDefaults();
+    void clear();
+};

--- a/src/client/inputwidget.h
+++ b/src/client/inputwidget.h
@@ -5,6 +5,7 @@
 
 #include "../global/RuleOf5.h"
 #include "../global/macros.h"
+#include "Hotkey.h"
 #include "PaletteManager.h"
 
 #include <iterator>
@@ -82,12 +83,16 @@ public:
     void displayMessage(const QString &msg) { virt_displayMessage(msg); }
     void showMessage(const QString &msg, const int timeout) { virt_showMessage(msg, timeout); }
     void gotPasswordInput(const QString &password) { virt_gotPasswordInput(password); }
+    void scrollDisplay(bool pageUp) { virt_scrollDisplay(pageUp); }
+    std::optional<QString> getHotkey(const Hotkey &hk) { return virt_getHotkey(hk); }
 
 private:
     virtual void virt_sendUserInput(const QString &msg) = 0;
     virtual void virt_displayMessage(const QString &msg) = 0;
     virtual void virt_showMessage(const QString &msg, int timeout) = 0;
     virtual void virt_gotPasswordInput(const QString &password) = 0;
+    virtual void virt_scrollDisplay(bool pageUp) = 0;
+    virtual std::optional<QString> virt_getHotkey(const Hotkey &hk) = 0;
 };
 
 class NODISCARD_QOBJECT InputWidget final : public QPlainTextEdit
@@ -104,6 +109,7 @@ private:
     InputHistory m_inputHistory;
     PaletteManager m_paletteManager;
     bool m_tabbing = false;
+    bool m_handledInShortcutOverride = false;
 
 public:
     explicit InputWidget(QWidget *parent, InputWidgetOutputs &);
@@ -118,8 +124,9 @@ protected:
 private:
     void gotInput();
     NODISCARD bool tryHistory(int);
-    void keypadMovement(int);
-    void functionKeyPressed(const QString &keyName);
+    NODISCARD bool handleCommandInput(Qt::Key key, Qt::KeyboardModifiers mods);
+    NODISCARD bool handleTerminalShortcut(int key);
+    NODISCARD bool handleBasicKey(int key);
 
 private:
     void tabComplete();
@@ -130,4 +137,5 @@ private:
 
 private:
     void sendUserInput(const QString &msg) { m_outputs.sendUserInput(msg); }
+    void sendCommandWithSeparator(const QString &command);
 };

--- a/src/client/stackedinputwidget.cpp
+++ b/src/client/stackedinputwidget.cpp
@@ -77,6 +77,13 @@ void StackedInputWidget::initInput()
         {
             getSelf().gotPasswordInput(password);
         }
+
+        void virt_scrollDisplay(bool pageUp) final { getOutput().scrollDisplay(pageUp); }
+
+        std::optional<QString> virt_getHotkey(const Hotkey &hk) final
+        {
+            return getOutput().getHotkey(hk);
+        }
     };
 
     auto &out = m_pipeline.outputs.inputOutputs;

--- a/src/client/stackedinputwidget.h
+++ b/src/client/stackedinputwidget.h
@@ -6,6 +6,7 @@
 #include "../global/RuleOf5.h"
 #include "../global/macros.h"
 #include "../global/utils.h"
+#include "Hotkey.h"
 
 #include <QStackedWidget>
 #include <QString>
@@ -39,6 +40,10 @@ public:
     void showMessage(const QString &msg, const int timeout) { virt_showMessage(msg, timeout); }
     // request password
     void requestPassword() { virt_requestPassword(); }
+    // scroll display (pageUp=true for PageUp, false for PageDown)
+    void scrollDisplay(bool pageUp) { virt_scrollDisplay(pageUp); }
+    // try to get a hotkey command
+    std::optional<QString> getHotkey(const Hotkey &hk) { return virt_getHotkey(hk); }
 
 private:
     // sent to the mud
@@ -49,6 +54,10 @@ private:
     virtual void virt_showMessage(const QString &msg, int timeout) = 0;
     // request password
     virtual void virt_requestPassword() = 0;
+    // scroll display
+    virtual void virt_scrollDisplay(bool pageUp) = 0;
+    // try to get a hotkey command
+    virtual std::optional<QString> virt_getHotkey(const Hotkey &hk) = 0;
 };
 
 class NODISCARD_QOBJECT StackedInputWidget final : public QStackedWidget

--- a/src/configuration/GroupConfig.cpp
+++ b/src/configuration/GroupConfig.cpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2019 The MMapper Authors
+
+#include "GroupConfig.h"
+
+#include <QSettings>
+
+GroupConfig::GroupConfig(QString groupName)
+    : m_groupName(std::move(groupName))
+{}
+
+void GroupConfig::read(const QSettings &settings)
+{
+    QVariantMap newData;
+    for (const QString &key : settings.childKeys()) {
+        newData[key] = settings.value(key);
+    }
+    setData(std::move(newData));
+}
+
+void GroupConfig::write(QSettings &settings) const
+{
+    settings.remove(""); // clear the current group
+    for (auto it = m_data.begin(); it != m_data.end(); ++it) {
+        settings.setValue(it.key(), it.value());
+    }
+}
+
+void GroupConfig::setData(QVariantMap data)
+{
+    if (m_data == data) {
+        return;
+    }
+    m_data = std::move(data);
+    notifyChanged();
+}
+
+void GroupConfig::notifyChanged()
+{
+    m_changeMonitor.notifyAll();
+}
+
+void GroupConfig::registerChangeCallback(const ChangeMonitor::Lifetime &lifetime,
+                                         ChangeMonitor::Function callback)
+{
+    m_changeMonitor.registerChangeCallback(lifetime, std::move(callback));
+}
+
+void GroupConfig::resetToDefault()
+{
+    m_resetMonitor.notifyAll();
+}
+
+void GroupConfig::registerResetCallback(const ChangeMonitor::Lifetime &lifetime,
+                                        ChangeMonitor::Function callback)
+{
+    m_resetMonitor.registerChangeCallback(lifetime, std::move(callback));
+}

--- a/src/configuration/GroupConfig.h
+++ b/src/configuration/GroupConfig.h
@@ -1,0 +1,45 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2019 The MMapper Authors
+
+#include "../global/ChangeMonitor.h"
+#include "../global/RuleOf5.h"
+#include "../global/macros.h"
+
+#include <functional>
+
+#include <QMap>
+#include <QString>
+#include <QVariant>
+
+class QSettings;
+
+class NODISCARD GroupConfig final
+{
+private:
+    QString m_groupName;
+    QVariantMap m_data;
+    ChangeMonitor m_changeMonitor;
+    ChangeMonitor m_resetMonitor;
+
+public:
+    GroupConfig() = delete;
+    DELETE_CTORS_AND_ASSIGN_OPS(GroupConfig);
+
+    explicit GroupConfig(QString groupName);
+
+    void read(const QSettings &settings);
+    void write(QSettings &settings) const;
+
+    NODISCARD const QString &getName() const { return m_groupName; }
+    NODISCARD const QVariantMap &data() const { return m_data; }
+    void setData(QVariantMap data);
+
+    void notifyChanged();
+    void registerChangeCallback(const ChangeMonitor::Lifetime &lifetime,
+                                ChangeMonitor::Function callback);
+
+    void resetToDefault();
+    void registerResetCallback(const ChangeMonitor::Lifetime &lifetime,
+                               ChangeMonitor::Function callback);
+};

--- a/src/configuration/configuration.cpp
+++ b/src/configuration/configuration.cpp
@@ -55,11 +55,6 @@ NODISCARD const char *getPlatformEditor()
 
 } // namespace
 
-Configuration::Configuration()
-{
-    read(); // read the settings or set them to the default values
-}
-
 /*
  * TODO: Make a dialog asking if the user wants to import settings
  * from an older version of MMapper, and then change the organization name
@@ -199,6 +194,7 @@ ConstString GRP_CONNECTION = "Connection";
 ConstString GRP_FINDROOMS_DIALOG = "FindRooms Dialog";
 ConstString GRP_GENERAL = "General";
 ConstString GRP_GROUP_MANAGER = "Group Manager";
+ConstString GRP_HOTKEYS = "Hotkeys";
 ConstString GRP_INFOMARKS_DIALOG = "InfoMarks Dialog";
 ConstString GRP_INTEGRATED_MUD_CLIENT = "Integrated Mud Client";
 ConstString GRP_MUME_CLIENT_PROTOCOL = "Mume client protocol";
@@ -208,6 +204,12 @@ ConstString GRP_PARSER = "Parser";
 ConstString GRP_PATH_MACHINE = "Path Machine";
 ConstString GRP_ROOM_PANEL = "Room Panel";
 ConstString GRP_ROOMEDIT_DIALOG = "RoomEdit Dialog";
+
+Configuration::Configuration()
+    : hotkeys(GRP_HOTKEYS)
+{
+    read(); // read the settings or set them to the default values
+}
 
 ConstString KEY_ABSOLUTE_PATH_ACCEPTANCE = "absolute path acceptance";
 ConstString KEY_ACCOUNT_NAME = "account name";
@@ -484,6 +486,7 @@ NODISCARD static uint16_t sanitizeUint16(const int input, const uint16_t default
         GROUP_CALLBACK(callback, GRP_ROOMEDIT_DIALOG, roomEditDialog); \
         GROUP_CALLBACK(callback, GRP_ROOM_PANEL, roomPanel); \
         GROUP_CALLBACK(callback, GRP_FINDROOMS_DIALOG, findRoomsDialog); \
+        GROUP_CALLBACK(callback, GRP_HOTKEYS, hotkeys); \
     } while (false)
 
 void Configuration::read()
@@ -513,6 +516,8 @@ void Configuration::readFrom(QSettings &conf)
 
         // New users get autologger turned on by default
         autoLog.autoLog = (CURRENT_PLATFORM != PlatformEnum::Wasm);
+
+        hotkeys.resetToDefault();
     }
 
     assert(canvas.backgroundColor == colorSettings.BACKGROUND);

--- a/src/configuration/configuration.h
+++ b/src/configuration/configuration.h
@@ -14,6 +14,7 @@
 #include "../global/NamedColors.h"
 #include "../global/RuleOf5.h"
 #include "../global/Signal2.h"
+#include "GroupConfig.h"
 #include "NamedConfig.h"
 
 #include <memory>
@@ -396,6 +397,8 @@ public:
     private:
         SUBGROUP();
     } findRoomsDialog;
+
+    GroupConfig hotkeys;
 
 public:
     DELETE_CTORS_AND_ASSIGN_OPS(Configuration);

--- a/src/global/hash.h
+++ b/src/global/hash.h
@@ -1,6 +1,6 @@
 #pragma once
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (C) 2019 The MMapper Authors
+// Copyright (C) 2019-2026 The MMapper Authors
 
 #include "macros.h"
 
@@ -16,4 +16,11 @@ MAYBE_UNUSED NODISCARD static auto numeric_hash(const T val) noexcept
     char buf[size];
     std::memcpy(buf, &val, size);
     return std::hash<std::string_view>()({buf, size});
+}
+
+template<typename T>
+void hash_combine(std::size_t &seed, const T &value) noexcept
+{
+    constexpr const size_t GOLDEN_RATIO = 0x9e3779b97f4a7c15;
+    seed ^= std::hash<T>{}(value) + GOLDEN_RATIO + (seed << 6) + (seed >> 2);
 }

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -10,6 +10,7 @@
 #include "../adventure/adventurewidget.h"
 #include "../adventure/xpstatuswidget.h"
 #include "../client/ClientWidget.h"
+#include "../client/HotkeyManager.h"
 #include "../clock/mumeclock.h"
 #include "../clock/mumeclockwidget.h"
 #include "../display/InfomarkSelection.h"
@@ -198,6 +199,8 @@ MainWindow::MainWindow()
     // View -> Side Panels -> Description / Area Panel
     m_descriptionWidget = new DescriptionWidget(this);
     m_dockDialogDescription = new QDockWidget(tr("Description Panel"), this);
+
+    m_hotkeyManager = std::make_unique<HotkeyManager>();
     m_dockDialogDescription->setObjectName("DockWidgetDescription");
     m_dockDialogDescription->setAllowedAreas(Qt::AllDockWidgetAreas);
     m_dockDialogDescription->setFeatures(QDockWidget::DockWidgetMovable
@@ -239,7 +242,7 @@ MainWindow::MainWindow()
                                         this);
 
     // View -> Side Panels -> Client Panel
-    m_clientWidget = new ClientWidget(deref(m_listener), this);
+    m_clientWidget = new ClientWidget(deref(m_listener), deref(m_hotkeyManager), this);
     m_clientWidget->setObjectName("InternalMudClientWidget");
     m_dockDialogClient = new QDockWidget("Client Panel", this);
     m_dockDialogClient->setObjectName("DockWidgetClient");

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -40,6 +40,7 @@ class ConnectionSelection;
 class FindRoomsDlg;
 class GameObserver;
 class GroupWidget;
+class HotkeyManager;
 class InfomarkSelection;
 class MapCanvas;
 class MapData;
@@ -109,6 +110,7 @@ private:
     AdventureWidget *m_adventureWidget = nullptr;
 
     DescriptionWidget *m_descriptionWidget = nullptr;
+    std::unique_ptr<HotkeyManager> m_hotkeyManager;
 
     SharedRoomSelection m_roomSelection;
     std::shared_ptr<ConnectionSelection> m_connectionSelection;
@@ -266,6 +268,8 @@ private:
 public:
     explicit MainWindow();
     ~MainWindow() final;
+
+    NODISCARD HotkeyManager &getHotkeyManager() const { return deref(m_hotkeyManager); }
 
     NODISCARD bool saveFile(const QString &fileName, SaveModeEnum mode, SaveFormatEnum format);
     void loadFile(std::shared_ptr<MapSource> source);

--- a/src/parser/AbstractParser-Commands.cpp
+++ b/src/parser/AbstractParser-Commands.cpp
@@ -48,6 +48,7 @@ const Abbrev cmdDisconnect{"disconnect", 4};
 const Abbrev cmdGenerateBaseMap{"generate-base-map"};
 const Abbrev cmdGroup{"group", 2};
 const Abbrev cmdHelp{"help", 2};
+const Abbrev cmdHotkey{"hotkey", 3};
 const Abbrev cmdMap{"map"};
 const Abbrev cmdMark{"mark", 3};
 const Abbrev cmdRemoveDoorNames{"remove-secret-door-names"};
@@ -1090,6 +1091,15 @@ void AbstractParser::initSpecialCommandMap()
             return true;
         },
         makeSimpleHelp("Perform actions on the group manager."));
+
+    /* hpotkey commands */
+    add(
+        cmdHotkey,
+        [this](const std::vector<StringView> & /*s*/, StringView rest) {
+            parseHotkey(rest);
+            return true;
+        },
+        makeSimpleHelp("View or modify hotkeys for the integrated client."));
 
     /* timers command */
     add(

--- a/src/parser/AbstractParser-Hotkey.cpp
+++ b/src/parser/AbstractParser-Hotkey.cpp
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+#include "../client/Hotkey.h"
+#include "../client/HotkeyManager.h"
+#include "../syntax/SyntaxArgs.h"
+#include "../syntax/TreeParser.h"
+#include "AbstractParser-Utils.h"
+#include "abstractparser.h"
+
+#include <algorithm>
+#include <map>
+#include <ostream>
+#include <vector>
+
+class NODISCARD ArgHotkeyName final : public syntax::IArgument
+{
+private:
+    NODISCARD syntax::MatchResult virt_match(const syntax::ParserInput &input,
+                                             syntax::IMatchErrorLogger *) const final;
+
+    std::ostream &virt_to_stream(std::ostream &os) const final;
+};
+
+syntax::MatchResult ArgHotkeyName::virt_match(const syntax::ParserInput &input,
+                                              syntax::IMatchErrorLogger * /*logger */) const
+{
+    if (input.empty()) {
+        return syntax::MatchResult::failure(input);
+    }
+
+    return syntax::MatchResult::success(1, input, Value{input.front()});
+}
+
+std::ostream &ArgHotkeyName::virt_to_stream(std::ostream &os) const
+{
+    return os << "<key-combination>";
+}
+
+namespace {
+void getInstructionalError(AnsiOstream &os, std::string_view keyName)
+{
+    os << "Invalid key combination: [" << keyName << "]\n";
+
+    {
+        os << "\nValid modifiers:\n  ";
+        const auto mods = {
+#define X_STR(id, camel, qtenum) #id,
+            XFOREACH_HOTKEY_MODIFIER(X_STR)
+#undef X_STR
+        };
+        bool first = true;
+        for (const auto &mod : mods) {
+            if (!first)
+                os << ", ";
+            os << mod;
+            first = false;
+        }
+    }
+
+    {
+        os << "\nValid keys:\n  ";
+        std::map<std::string, HotkeyPolicyEnum> keys;
+#define X_SORT(EnumName, StringName, QtKey, Policy) keys[StringName] = Policy;
+        XFOREACH_HOTKEY_BASE_KEYS(X_SORT)
+#undef X_SORT
+        bool first = true;
+        for (const auto &[name, policy] : keys) {
+            if (!first)
+                os << ", ";
+
+            os << name;
+#define X_MARKER(EnumName, Marker, Help) \
+    if (policy == HotkeyPolicyEnum::EnumName) { \
+        os << Marker; \
+    } else
+            XFOREACH_HOTKEY_POLICY(X_MARKER)
+#undef X_MARKER
+            {}
+            first = false;
+        }
+        os << "\n";
+#define X_FOOTNOTE(EnumName, Marker, Help) \
+    if (std::string_view(Marker).length() > 0) { \
+        os << "\n" << Marker << " = " << Help; \
+    }
+        XFOREACH_HOTKEY_POLICY(X_FOOTNOTE)
+#undef X_FOOTNOTE
+        os << "\n";
+    }
+
+    os << "\nExamples:  NUMPAD4  SHIFT+NUMPAD4  CTRL+META+0\n";
+}
+} // namespace
+
+void AbstractParser::parseHotkey(StringView input)
+{
+    using namespace ::syntax;
+    static const auto abb = syntax::abbrevToken;
+
+    auto bindHotkey = Accept(
+        [this](User &user, const Pair *const args) {
+            auto &os = user.getOstream();
+            const auto v = getAnyVectorReversed(args);
+
+            const std::string keyName = v[1].getString();
+
+            Hotkey hk(keyName);
+            if (!hk.isRecognized()) {
+                getInstructionalError(os, keyName);
+                return;
+            }
+
+            if (!hk.isPolicySatisfied()) {
+#define X_POLICY_ERROR(EnumName, Marker, Help) \
+    if (hk.is##EnumName()) { \
+        os << "Error: [" << keyName << "] " << Help << ".\n"; \
+    } else
+                XFOREACH_HOTKEY_POLICY(X_POLICY_ERROR)
+#undef X_POLICY_ERROR
+                {}
+                return;
+            }
+
+            const std::string cmdStr = v[2].isVector() ? concatenate_unquoted(v[2].getVector())
+                                                       : v[2].getString();
+            if (cmdStr.empty()) {
+                os << "No command provided.\n";
+                return;
+            }
+
+            if (m_hotkeyManager.setHotkey(hk, cmdStr)) {
+                os << "Hotkey bound: [" << hk.to_string() << "] -> " << cmdStr << "\n";
+                send_ok(os);
+            } else {
+                os << "Failed to bind hotkey.\n";
+            }
+        },
+        "bind hotkey");
+
+    auto listHotkeys = Accept(
+        [this](User &user, const Pair *) {
+            auto &os = user.getOstream();
+            auto hotkeys = m_hotkeyManager.getAllHotkeys();
+            std::sort(hotkeys.begin(), hotkeys.end(), [](const auto &a, const auto &b) {
+                return a.first.to_string() < b.first.to_string();
+            });
+
+            if (hotkeys.empty()) {
+                os << "No hotkeys configured.\n";
+            } else {
+                os << "Active Hotkeys:\n";
+                for (const auto &[hk, cmd] : hotkeys) {
+                    os << "  [" << hk.to_string() << "] -> " << cmd << "\n";
+                }
+                os << "Total: " << hotkeys.size() << "\n";
+            }
+            send_ok(os);
+        },
+        "list hotkeys");
+
+    auto unbindHotkey = Accept(
+        [this](User &user, const Pair *const args) {
+            auto &os = user.getOstream();
+            const auto v = getAnyVectorReversed(args);
+            const std::string keyName = v[1].getString();
+
+            Hotkey hk{keyName};
+            if (!hk.isRecognized()) {
+                getInstructionalError(os, keyName);
+                return;
+            }
+
+            if (m_hotkeyManager.removeHotkey(hk)) {
+                os << "Hotkey unbound: [" << hk.to_string() << "]\n";
+                send_ok(os);
+            } else {
+                os << "No hotkey configured for: [" << hk.to_string() << "]\n";
+            }
+        },
+        "unbind hotkey");
+
+    // Build syntax tree
+    auto bindSyntax = buildSyntax(abb("bind"),
+                                  TokenMatcher::alloc<ArgHotkeyName>(),
+                                  TokenMatcher::alloc<ArgRest>(),
+                                  bindHotkey);
+
+    auto listSyntax = buildSyntax(abb("list"), listHotkeys);
+
+    auto unbindSyntax = buildSyntax(abb("unbind"),
+                                    TokenMatcher::alloc<ArgHotkeyName>(),
+                                    unbindHotkey);
+
+    auto hotkeyUserSyntax = buildSyntax(bindSyntax, listSyntax, unbindSyntax);
+
+    eval("hotkey", hotkeyUserSyntax, input);
+}

--- a/src/parser/abstractparser.cpp
+++ b/src/parser/abstractparser.cpp
@@ -160,10 +160,11 @@ AbstractParser::AbstractParser(MapData &md,
                                ProxyMudConnectionApi &proxyMudConnection,
                                ProxyUserGmcpApi &proxyUserGmcp,
                                GroupManagerApi &group,
+                               HotkeyManager &hm,
                                QObject *const parent,
                                AbstractParserOutputs &outputs,
                                ParserCommonData &commonData)
-    : ParserCommon{parent, mc, md, group, proxyUserGmcp, outputs, commonData}
+    : ParserCommon{parent, mc, md, group, hm, proxyUserGmcp, outputs, commonData}
     , m_proxyMudConnection{proxyMudConnection}
 {
     QObject::connect(&m_offlineCommandTimer, &QTimer::timeout, this, [this]() {
@@ -645,6 +646,7 @@ void AbstractParser::showHelp()
                      "\n"
                      "Utility commands:\n"
                      "  %1group       - (see \"%1group ??\" for syntax help)\n"
+                     "  %1hotkey      - (see \"%1hotkey ??\" for syntax help)\n"
                      "  %1timer       - (see \"%1timer ??\" for syntax help)\n"
                      "\n"
                      "Config commands:\n"

--- a/src/parser/abstractparser.h
+++ b/src/parser/abstractparser.h
@@ -45,6 +45,7 @@
 #include <QVariant>
 
 class Coordinate;
+class HotkeyManager;
 class MapData;
 class MumeClock;
 class RoomFieldVariant;
@@ -166,6 +167,7 @@ protected:
 
 protected:
     GroupManagerApi &m_group;
+    HotkeyManager &m_hotkeyManager;
     ProxyUserGmcpApi &m_proxyUserGmcp;
     AbstractParserOutputs &m_outputs;
 
@@ -177,6 +179,7 @@ protected:
                           MumeClock &mumeClock,
                           MapData &mapData,
                           GroupManagerApi &group,
+                          HotkeyManager &hotkeyManager,
                           ProxyUserGmcpApi &proxyUserGmcp,
                           AbstractParserOutputs &outputs,
                           ParserCommonData &commonData)
@@ -184,6 +187,7 @@ protected:
         , m_mumeClock{mumeClock}
         , m_mapData{mapData}
         , m_group{group}
+        , m_hotkeyManager{hotkeyManager}
         , m_proxyUserGmcp{proxyUserGmcp}
         , m_outputs{outputs}
         , m_commonData{commonData}
@@ -270,10 +274,18 @@ protected:
                                MumeClock &mumeClock,
                                MapData &mapData,
                                GroupManagerApi &group,
+                               HotkeyManager &hotkeyManager,
                                ProxyUserGmcpApi &proxyUserGmcp,
                                AbstractParserOutputs &outputs,
                                ParserCommonData &parserCommonData)
-        : ParserCommon{parent, mumeClock, mapData, group, proxyUserGmcp, outputs, parserCommonData}
+        : ParserCommon{parent,
+                       mumeClock,
+                       mapData,
+                       group,
+                       hotkeyManager,
+                       proxyUserGmcp,
+                       outputs,
+                       parserCommonData}
     {
         initActionMap();
     }
@@ -339,6 +351,7 @@ public:
                             ProxyMudConnectionApi &,
                             ProxyUserGmcpApi &,
                             GroupManagerApi &,
+                            HotkeyManager &,
                             QObject *parent,
                             AbstractParserOutputs &outputs,
                             ParserCommonData &commonData);
@@ -405,6 +418,7 @@ private:
     NODISCARD bool evalSpecialCommandMap(StringView args);
 
     void parseHelp(StringView words);
+    void parseHotkey(StringView input);
     void parseMark(StringView input);
     void parseRoom(StringView input);
     void parseGroup(StringView input);

--- a/src/parser/mumexmlparser.cpp
+++ b/src/parser/mumexmlparser.cpp
@@ -66,10 +66,11 @@ MumeXmlParser::MumeXmlParser(MapData &md,
                              ProxyUserGmcpApi &proxyGmcp,
                              GroupManagerApi &group,
                              GameObserver &observer,
+                             HotkeyManager &hm,
                              QObject *parent,
                              AbstractParserOutputs &outputs,
                              ParserCommonData &parserCommonData)
-    : MumeXmlParserBase{parent, mc, md, group, proxyGmcp, outputs, parserCommonData}
+    : MumeXmlParserBase{parent, mc, md, group, hm, proxyGmcp, outputs, parserCommonData}
     , m_observer{observer}
 {}
 

--- a/src/parser/mumexmlparser.h
+++ b/src/parser/mumexmlparser.h
@@ -85,6 +85,7 @@ public:
                            ProxyUserGmcpApi &,
                            GroupManagerApi &,
                            GameObserver &,
+                           HotkeyManager &,
                            QObject *parent,
                            AbstractParserOutputs &outputs,
                            ParserCommonData &parserCommonData);

--- a/src/preferences/clientpage.cpp
+++ b/src/preferences/clientpage.cpp
@@ -5,6 +5,7 @@
 #include "clientpage.h"
 
 #include "../configuration/configuration.h"
+#include "../global/macros.h"
 #include "ui_clientpage.h"
 
 #include <QFont>

--- a/src/proxy/MudTelnet.cpp
+++ b/src/proxy/MudTelnet.cpp
@@ -577,9 +577,9 @@ void MudTelnet::parseMudServerStatus(const TelnetMsspBytes &data)
     const OptStdString dayStr = map.lookup(GAME_DAY);
     const OptStdString hourStr = map.lookup(GAME_HOUR);
 
-    MMLOG() << "MSSP game time received with"
-            << " year:" << yearStr.value_or("unknown") << " month:" << monthStr.value_or("unknown")
-            << " day:" << dayStr.value_or("unknown") << " hour:" << hourStr.value_or("unknown");
+    MMLOG() << "MSSP game time received with" << " year:" << yearStr.value_or("unknown")
+            << " month:" << monthStr.value_or("unknown") << " day:" << dayStr.value_or("unknown")
+            << " hour:" << hourStr.value_or("unknown");
 
     if (!yearStr.has_value() || !monthStr.has_value() || !dayStr.has_value()
         || !hourStr.has_value()) {

--- a/src/proxy/proxy.cpp
+++ b/src/proxy/proxy.cpp
@@ -6,6 +6,7 @@
 
 #include "proxy.h"
 
+#include "../client/HotkeyManager.h"
 #include "../clock/mumeclock.h"
 #include "../configuration/PasswordConfig.h"
 #include "../configuration/configuration.h"
@@ -21,6 +22,7 @@
 #include "../map/parseevent.h"
 #include "../mpi/mpifilter.h"
 #include "../mpi/remoteedit.h"
+#include "../mpi/remoteeditwidget.h"
 #include "../observer/gameobserver.h"
 #include "../parser/abstractparser.h"
 #include "../parser/mumexmlparser.h"
@@ -722,6 +724,7 @@ void Proxy::allocParser()
                                                          deref(gmcp),
                                                          m_groupManager.getGroupManagerApi(),
                                                          m_gameObserver,
+                                                         m_mainWindow.getHotkeyManager(),
                                                          this,
                                                          deref(out),
                                                          deref(parserCommon));
@@ -730,6 +733,7 @@ void Proxy::allocParser()
                                                             deref(conn),
                                                             deref(gmcp),
                                                             m_groupManager.getGroupManagerApi(),
+                                                            m_mainWindow.getHotkeyManager(),
                                                             this,
                                                             deref(out),
                                                             deref(parserCommon));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,23 +23,42 @@ if(MMAPPER_IS_DEBUG)
     endif()
 endif()
 
-# Clock
-set(clock_SRCS
+# Common test library
+add_library(mm_test STATIC
     ../src/configuration/configuration.cpp
     ../src/configuration/configuration.h
-    ../src/clock/mumeclock.cpp
-    ../src/clock/mumeclock.h
-    ../src/clock/mumemoment.cpp
-    ../src/clock/mumemoment.h
+    ../src/configuration/GroupConfig.cpp
+    ../src/configuration/GroupConfig.h
     ../src/observer/gameobserver.cpp
     ../src/observer/gameobserver.h
     ../src/proxy/GmcpMessage.cpp
     ../src/proxy/GmcpMessage.h
+)
+set_target_properties(mm_test PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF
+    COMPILE_FLAGS "${WARNING_FLAGS}"
+)
+target_link_libraries(mm_test
+    mm_global
+    Qt6::Core
+    Qt6::Network
+    coverage_config
+)
+
+# Clock
+set(clock_SRCS
+    ../src/clock/mumeclock.cpp
+    ../src/clock/mumeclock.h
+    ../src/clock/mumemoment.cpp
+    ../src/clock/mumemoment.h
     )
 set(TestClock_SRCS testclock.cpp)
 add_executable(TestClock ${TestClock_SRCS} ${clock_SRCS})
-add_dependencies(TestClock mm_global)
+add_dependencies(TestClock mm_test mm_global)
 target_link_libraries(TestClock
+        mm_test
         mm_global
         Qt6::Network
         Qt6::Gui
@@ -57,15 +76,14 @@ add_test(NAME TestClock COMMAND TestClock)
 
 # Expandora
 set(expandoracommon_SRCS
-    ../src/configuration/configuration.cpp
-    ../src/configuration/configuration.h
     ../src/parser/Abbrev.cpp
     )
 set(TestExpandoraCommon_SRCS testexpandoracommon.cpp)
 add_executable(TestExpandoraCommon ${TestExpandoraCommon_SRCS} ${expandoracommon_SRCS})
-add_dependencies(TestExpandoraCommon mm_global mm_map)
+add_dependencies(TestExpandoraCommon mm_test mm_global mm_map)
 target_link_libraries(TestExpandoraCommon
         mm_map
+        mm_test
         mm_global
         Qt6::Gui
         Qt6::Network
@@ -82,15 +100,12 @@ set_target_properties(
 add_test(NAME TestExpandoraCommon COMMAND TestExpandoraCommon)
 
 # Parser
-set(parser_SRCS
-    ../src/configuration/configuration.cpp
-    ../src/configuration/configuration.h
-)
 set(TestParser_SRCS testparser.cpp)
-add_executable(TestParser ${TestParser_SRCS} ${parser_SRCS})
-add_dependencies(TestParser mm_global mm_map)
+add_executable(TestParser ${TestParser_SRCS})
+add_dependencies(TestParser mm_test mm_global mm_map)
 target_link_libraries(TestParser
         mm_map
+        mm_test
         mm_global
         Qt6::Gui
         Qt6::Network
@@ -108,8 +123,6 @@ add_test(NAME TestParser COMMAND TestParser)
 
 # Proxy
 set(proxy_SRCS
-    ../src/proxy/GmcpMessage.cpp
-    ../src/proxy/GmcpMessage.h
     ../src/proxy/GmcpModule.cpp
     ../src/proxy/GmcpModule.h
     ../src/proxy/GmcpUtils.cpp
@@ -119,8 +132,8 @@ set(proxy_SRCS
      )
 set(TestProxy_SRCS TestProxy.cpp)
 add_executable(TestProxy ${TestProxy_SRCS} ${proxy_SRCS})
-add_dependencies(TestProxy mm_global)
-target_link_libraries(TestProxy mm_global Qt6::Test coverage_config)
+add_dependencies(TestProxy mm_test mm_global)
+target_link_libraries(TestProxy mm_test mm_global Qt6::Test coverage_config)
 set_target_properties(
   TestProxy PROPERTIES
   CXX_STANDARD 17
@@ -138,8 +151,9 @@ set(mainwindow_SRCS
     )
 set(TestMainWindow_SRCS TestMainWindow.cpp)
 add_executable(TestMainWindow ${TestMainWindow_SRCS} ${mainwindow_SRCS})
-add_dependencies(TestMainWindow mm_global)
+add_dependencies(TestMainWindow mm_test mm_global)
 target_link_libraries(TestMainWindow
+        mm_test
         mm_global
         Qt6::Network
         Qt6::Test
@@ -175,14 +189,13 @@ add_test(NAME TestGlobal COMMAND TestGlobal)
 
 # Global
 set(TestMap_SRCS
-        ../src/configuration/configuration.cpp
-        ../src/configuration/configuration.h
         TestMap.cpp
 )
 add_executable(TestMap ${TestMap_SRCS})
-add_dependencies(TestMap mm_global mm_map)
+add_dependencies(TestMap mm_test mm_global mm_map)
 target_link_libraries(TestMap
         mm_map
+        mm_test
         mm_global
         Qt6::Gui
         Qt6::Network
@@ -206,15 +219,11 @@ set(adventure_SRCS
         ../src/adventure/adventuretracker.h
         ../src/adventure/lineparsers.cpp
         ../src/adventure/lineparsers.h
-        ../src/configuration/configuration.cpp
-        ../src/configuration/configuration.h
-        ../src/observer/gameobserver.cpp
-        ../src/observer/gameobserver.h
         )
 set(TestAdventure_SRCS testadventure.cpp testadventure.h)
 add_executable(TestAdventure ${TestAdventure_SRCS} ${adventure_SRCS})
-add_dependencies(TestAdventure mm_global)
-target_link_libraries(TestAdventure mm_global Qt6::Widgets Qt6::Network Qt6::Test coverage_config)
+add_dependencies(TestAdventure mm_test mm_global)
+target_link_libraries(TestAdventure mm_test mm_global Qt6::Widgets Qt6::Network Qt6::Test coverage_config)
 set_target_properties(
         TestAdventure PROPERTIES
         CXX_STANDARD 17
@@ -289,12 +298,11 @@ set(room_manager
         ../src/roompanel/RoomMob.cpp
         ../src/roompanel/RoomManager.cpp
         ../src/roompanel/RoomManager.h
-        ../src/proxy/GmcpMessage.cpp
 )
 set(RoomManager roompanel/TestRoomManager.cpp)
 add_executable(TestRoomManager ${room_manager} ${RoomManager})
-add_dependencies(TestRoomManager mm_global)
-target_link_libraries(TestRoomManager mm_global Qt6::Test Qt6::Gui Qt6::Widgets coverage_config)
+add_dependencies(TestRoomManager mm_test mm_global)
+target_link_libraries(TestRoomManager mm_test mm_global Qt6::Test Qt6::Gui Qt6::Widgets coverage_config)
 set_target_properties(
         TestRoomManager PROPERTIES
         CXX_STANDARD 17
@@ -303,3 +311,23 @@ set_target_properties(
         COMPILE_FLAGS "${WARNING_FLAGS}"
 )
 add_test(NAME TestRoomManager COMMAND TestRoomManager)
+
+# HotkeyManager
+set(hotkey_manager_SRCS
+        ../src/client/Hotkey.cpp
+        ../src/client/Hotkey.h
+        ../src/client/HotkeyManager.cpp
+        ../src/client/HotkeyManager.h
+)
+set(TestHotkeyManager_SRCS TestHotkeyManager.cpp TestHotkeyManager.h)
+add_executable(TestHotkeyManager ${TestHotkeyManager_SRCS} ${hotkey_manager_SRCS})
+add_dependencies(TestHotkeyManager mm_test mm_global mm_map)
+target_link_libraries(TestHotkeyManager mm_map mm_test mm_global Qt6::Test Qt6::Network coverage_config)
+set_target_properties(
+        TestHotkeyManager PROPERTIES
+        CXX_STANDARD 17
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+        COMPILE_FLAGS "${WARNING_FLAGS}"
+)
+add_test(NAME TestHotkeyManager COMMAND TestHotkeyManager)

--- a/tests/TestHotkeyManager.cpp
+++ b/tests/TestHotkeyManager.cpp
@@ -1,0 +1,358 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+#include "TestHotkeyManager.h"
+
+#include "../src/client/Hotkey.h"
+#include "../src/client/HotkeyManager.h"
+#include "../src/configuration/configuration.h"
+
+#include <QCoreApplication>
+#include <QSettings>
+#include <QStringList>
+#include <QtTest/QtTest>
+
+TestHotkeyManager::TestHotkeyManager()
+{
+    setEnteredMain();
+}
+TestHotkeyManager::~TestHotkeyManager() = default;
+
+void TestHotkeyManager::checkHk(const HotkeyManager &manager,
+                                const Hotkey &hk,
+                                std::string_view expected)
+{
+    auto actual = manager.getCommand(hk).value_or("");
+    if (actual != expected) {
+        qDebug() << "Failure for key:" << QString::fromStdString(hk.to_string())
+                 << "Expected:" << QString::fromStdString(std::string(expected))
+                 << "Actual:" << QString::fromStdString(actual);
+    }
+    QCOMPARE(actual, std::string(expected));
+}
+
+void TestHotkeyManager::keyNormalizationTest()
+{
+    HotkeyManager manager;
+    manager.clear();
+
+    // Test all base keys defined in macro
+#define X_TEST_KEY(id, name, qkey, pol) \
+    { \
+        const std::string nameStr(name); \
+        std::string boundName = nameStr; \
+        Qt::KeyboardModifiers qm = (pol == HotkeyPolicyEnum::Keypad) ? Qt::KeypadModifier \
+                                                                     : Qt::NoModifier; \
+        if (pol == HotkeyPolicyEnum::ModifierRequired \
+            || pol == HotkeyPolicyEnum::ModifierNotShift) { \
+            boundName = "CTRL+" + nameStr; \
+            qm |= Qt::ControlModifier; \
+        } \
+        QVERIFY(manager.setHotkey(Hotkey{boundName}, "cmd_" + nameStr)); \
+        checkHk(manager, Hotkey{boundName}, "cmd_" + nameStr); \
+        Hotkey hk(qkey, qm); \
+        checkHk(manager, hk, "cmd_" + nameStr); \
+    }
+
+    XFOREACH_HOTKEY_BASE_KEYS(X_TEST_KEY)
+#undef X_TEST_KEY
+
+    // Test that modifiers are normalized to canonical order: SHIFT+CTRL+ALT+META
+
+    // Set a hotkey with non-canonical modifier order
+    QVERIFY(manager.setHotkey(Hotkey{"ALT+CTRL+F1"}, "test1"));
+
+    // Should be retrievable with canonical order
+    checkHk(manager, Hotkey{"CTRL+ALT+F1"}, "test1");
+
+    // Should also be retrievable with the original order (due to normalization)
+    checkHk(manager, Hotkey{"ALT+CTRL+F1"}, "test1");
+
+    // Test all modifier combinations normalize correctly
+    QVERIFY(manager.setHotkey(Hotkey{"META+ALT+SHIFT+CTRL+F2"}, "test2"));
+    checkHk(manager, Hotkey{"SHIFT+CTRL+ALT+META+F2"}, "test2");
+
+    // Test that case is normalized to uppercase
+    QVERIFY(manager.setHotkey(Hotkey{"ctrl+f3"}, "test3"));
+    checkHk(manager, Hotkey{"CTRL+F3"}, "test3");
+}
+
+void TestHotkeyManager::importExportRoundTripTest()
+{
+    HotkeyManager manager;
+    manager.clear();
+
+    // Verify all hotkeys can be set and retrieved
+    QVERIFY(manager.setHotkey(Hotkey{"F1"}, "look"));
+    QVERIFY(manager.setHotkey(Hotkey{"CTRL+F2"}, "open exit n"));
+    QVERIFY(manager.setHotkey(Hotkey{"SHIFT+ALT+F3"}, "pick exit s"));
+    QVERIFY(manager.setHotkey(Hotkey{"NUMPAD8"}, "n"));
+
+    checkHk(manager, Hotkey{"F1"}, "look");
+    checkHk(manager, Hotkey{"CTRL+F2"}, "open exit n");
+    checkHk(manager, Hotkey{"SHIFT+ALT+F3"}, "pick exit s");
+    checkHk(manager, Hotkey{"NUMPAD8"}, "n");
+
+    // Verify total count
+    QCOMPARE(static_cast<int>(manager.getAllHotkeys().size()), 4);
+
+    // Verify serialization
+    QCOMPARE(QString::fromStdString(Hotkey{"F1"}.to_string()), QString("F1"));
+    QCOMPARE(QString::fromStdString(Hotkey{"CTRL+F2"}.to_string()), QString("CTRL+F2"));
+    QCOMPARE(QString::fromStdString(Hotkey{"SHIFT+ALT+F3"}.to_string()), QString("SHIFT+ALT+F3"));
+    QCOMPARE(QString::fromStdString(Hotkey{"NUMPAD8"}.to_string()), QString("NUMPAD8"));
+}
+
+void TestHotkeyManager::importEdgeCasesTest()
+{
+    HotkeyManager manager;
+    manager.clear();
+
+    // Test command with multiple spaces (should preserve spaces in command)
+    std::ignore = manager.setHotkey(Hotkey{"F1"}, "cast 'cure light'");
+    QCOMPARE(manager.getCommand(Hotkey{"F1"}).value_or(""), std::string("cast 'cure light'"));
+
+    // Test leading/trailing whitespace handling in key name
+    QVERIFY(manager.setHotkey(Hotkey{"  F4  "}, "command with spaces"));
+    QCOMPARE(manager.getCommand(Hotkey{"F4"}).value_or(""), std::string("command with spaces"));
+}
+
+void TestHotkeyManager::resetToDefaultsTest()
+{
+    HotkeyManager manager;
+    manager.clear();
+
+    // Set custom hotkeys
+    std::ignore = manager.setHotkey(Hotkey{"F1"}, "custom");
+    std::ignore = manager.setHotkey(Hotkey{"F2"}, "another");
+    checkHk(manager, Hotkey{"F1"}, "custom");
+    QCOMPARE(static_cast<int>(manager.getAllHotkeys().size()), 2);
+
+    // Reset to defaults
+    manager.resetToDefaults();
+
+    // Verify defaults are restored
+    checkHk(manager, Hotkey{"NUMPAD8"}, "north");
+    checkHk(manager, Hotkey{"NUMPAD4"}, "west");
+    checkHk(manager, Hotkey{"CTRL+NUMPAD8"}, "open exit north");
+    checkHk(manager, Hotkey{"ALT+NUMPAD8"}, "close exit north");
+    checkHk(manager, Hotkey{"SHIFT+NUMPAD8"}, "pick exit north");
+
+    // F1 is in defaults
+    checkHk(manager, Hotkey{"F1"}, "F1");
+
+    // Verify defaults are non-empty (don't assert exact count to avoid brittleness)
+    QVERIFY(!manager.getAllHotkeys().empty());
+}
+
+void TestHotkeyManager::exportCountTest()
+{
+    HotkeyManager manager;
+    manager.clear();
+
+    std::ignore = manager.setHotkey(Hotkey{"F1"}, "cmd1");
+    std::ignore = manager.setHotkey(Hotkey{"F2"}, "cmd2");
+
+    auto hotkeys = manager.getAllHotkeys();
+    QCOMPARE(static_cast<int>(hotkeys.size()), 2);
+}
+
+void TestHotkeyManager::setHotkeyTest()
+{
+    HotkeyManager manager;
+    manager.clear();
+
+    // Test setting a new hotkey directly
+    QVERIFY(manager.setHotkey(Hotkey{"F1"}, "look"));
+    checkHk(manager, Hotkey{"F1"}, "look");
+    QCOMPARE(static_cast<int>(manager.getAllHotkeys().size()), 1);
+
+    // Test setting another hotkey
+    QVERIFY(manager.setHotkey(Hotkey{"F2"}, "flee"));
+    checkHk(manager, Hotkey{"F2"}, "flee");
+    QCOMPARE(static_cast<int>(manager.getAllHotkeys().size()), 2);
+
+    // Test updating an existing hotkey (should replace, not add)
+    QVERIFY(manager.setHotkey(Hotkey{"F1"}, "inventory"));
+    checkHk(manager, Hotkey{"F1"}, "inventory");
+    QCOMPARE(static_cast<int>(manager.getAllHotkeys().size()), 2); // Still 2, not 3
+
+    // Test setting hotkey with modifiers
+    QVERIFY(manager.setHotkey(Hotkey{"CTRL+F3"}, "open exit n"));
+    checkHk(manager, Hotkey{"CTRL+F3"}, "open exit n");
+    QCOMPARE(static_cast<int>(manager.getAllHotkeys().size()), 3);
+}
+
+void TestHotkeyManager::removeHotkeyTest()
+{
+    HotkeyManager manager;
+    manager.clear();
+
+    std::ignore = manager.setHotkey(Hotkey{"F1"}, "look");
+    std::ignore = manager.setHotkey(Hotkey{"F2"}, "flee");
+    std::ignore = manager.setHotkey(Hotkey{"CTRL+F3"}, "open exit n");
+    QCOMPARE(static_cast<int>(manager.getAllHotkeys().size()), 3);
+
+    // Test removing a hotkey
+    std::ignore = manager.removeHotkey(Hotkey{"F1"});
+    checkHk(manager, Hotkey{"F1"}, ""); // Should be empty now
+    QCOMPARE(static_cast<int>(manager.getAllHotkeys().size()), 2);
+
+    // Test removing hotkey with modifiers
+    std::ignore = manager.removeHotkey(Hotkey{"CTRL+F3"});
+    checkHk(manager, Hotkey{"CTRL+F3"}, "");
+    QCOMPARE(static_cast<int>(manager.getAllHotkeys().size()), 1);
+}
+
+void TestHotkeyManager::invalidKeyValidationTest()
+{
+    HotkeyManager manager;
+    manager.clear();
+
+    // Test that invalid base keys are rejected
+    QVERIFY(!manager.setHotkey(Hotkey{"F13"}, "invalid"));
+    QCOMPARE(manager.getCommand(Hotkey{"F13"}).value_or(""), std::string("")); // Should not be set
+    QCOMPARE(static_cast<int>(manager.getAllHotkeys().size()), 0);
+
+    // Test typo in key name
+    QVERIFY(!manager.setHotkey(Hotkey{"NUMPDA8"}, "typo")); // Typo: NUMPDA instead of NUMPAD
+}
+
+void TestHotkeyManager::duplicateKeyBehaviorTest()
+{
+    HotkeyManager manager;
+    manager.clear();
+
+    // Test that setHotkey replaces existing entry
+    std::ignore = manager.setHotkey(Hotkey{"F1"}, "original");
+    QCOMPARE(manager.getCommand(Hotkey{"F1"}).value_or(""), std::string("original"));
+    QCOMPARE(static_cast<int>(manager.getAllHotkeys().size()), 1);
+
+    QVERIFY(manager.setHotkey(Hotkey{"F1"}, "replaced"));
+    QCOMPARE(manager.getCommand(Hotkey{"F1"}).value_or(""), std::string("replaced"));
+    QCOMPARE(static_cast<int>(manager.getAllHotkeys().size()), 1); // Still 1, not 2
+}
+
+void TestHotkeyManager::directLookupTest()
+{
+    HotkeyManager manager;
+    manager.clear();
+
+    // Set hotkeys for testing
+    std::ignore = manager.setHotkey(Hotkey{"F1"}, "look");
+    std::ignore = manager.setHotkey(Hotkey{"CTRL+F2"}, "flee");
+    std::ignore = manager.setHotkey(Hotkey{"NUMPAD8"}, "n");
+    std::ignore = manager.setHotkey(Hotkey{"CTRL+NUMPAD5"}, "s");
+    std::ignore = manager.setHotkey(Hotkey{"SHIFT+ALT+UP"}, "north");
+
+    // Test direct lookup for function keys (isNumpad=false)
+    checkHk(manager, Hotkey{Qt::Key_F1, Qt::NoModifier}, "look");
+    checkHk(manager, Hotkey{Qt::Key_F2, Qt::ControlModifier}, "flee");
+
+    // Test that wrong modifiers don't match
+    checkHk(manager, Hotkey{Qt::Key_F1, Qt::ControlModifier}, "");
+
+    // Test numpad keys (isNumpad=true) - Qt::Key_8 with isNumpad=true
+    checkHk(manager, Hotkey{Qt::Key_8, Qt::KeypadModifier}, "n");
+    checkHk(manager, Hotkey{Qt::Key_5, Qt::ControlModifier | Qt::KeypadModifier}, "s");
+
+    // Test that numpad keys don't match non-numpad lookups
+    checkHk(manager, Hotkey{Qt::Key_8, Qt::NoModifier}, "");
+
+    // Test arrow keys (isNumpad=false)
+    checkHk(manager, Hotkey{Qt::Key_Up, (Qt::ShiftModifier | Qt::AltModifier)}, "north");
+
+    // Test NUMPAD8 (NumLock ON) which comes as Qt::Key_8 + Keypad
+    std::ignore = manager.setHotkey(Hotkey{"NUMPAD8"}, "north");
+    checkHk(manager, Hotkey{Qt::Key_8, Qt::KeypadModifier}, "north");
+
+    // Pure keypad-style numeric key with KeypadModifier should be treated as numpad;
+    // unless its a Mac
+    {
+        Hotkey numpad4Hotkey(Qt::Key_4, Qt::KeypadModifier);
+        std::ignore = manager.setHotkey(numpad4Hotkey, "west");
+        QVERIFY(numpad4Hotkey.isKeypad());
+        QCOMPARE(numpad4Hotkey.base(), HotkeyEnum::NUMPAD4);
+        checkHk(manager, numpad4Hotkey, "west");
+
+        Hotkey leftHotkey(Qt::Key_Left, Qt::KeypadModifier);
+        if constexpr (CURRENT_PLATFORM == PlatformEnum::Mac) {
+            QCOMPARE(leftHotkey.base(), HotkeyEnum::LEFT);
+
+        } else {
+            QVERIFY(leftHotkey.isKeypad());
+            QCOMPARE(leftHotkey.base(), HotkeyEnum::NUMPAD4);
+            checkHk(manager, leftHotkey, "west");
+        }
+    }
+}
+
+void TestHotkeyManager::hotkeyParsingAndToStringTest()
+{
+    struct Case
+    {
+        std::string input;
+        std::string canonical;
+        bool valid;
+    };
+
+    const Case cases[] = {
+        // Simple modifier + key, lower-case input -> canonical form
+        {"ctrl+f1", "CTRL+F1", true},
+
+        // Extra whitespace and mixed case; modifier order should be canonicalized
+        {"  CTRL   +   shift  +  f1  ", "SHIFT+CTRL+F1", true},
+
+        // Different modifier order in input, expect canonical order in output
+        {"alt+ctrl+f1", "CTRL+ALT+F1", true},
+
+        // Single key without modifiers
+        {"f5", "F5", true},
+
+        // Policy violations (Recognized, but invalid)
+        {"1", "1", false},
+        {"UP", "UP", false},
+        {"SHIFT+1", "SHIFT+1", false},
+
+        // Valid with required modifiers
+        {"CTRL+1", "CTRL+1", true},
+        {"SHIFT+UP", "SHIFT+UP", true},
+
+        // Duplicate modifiers should be tolerated and normalized
+        {"Ctrl+ctrl+SHIFT+f1", "SHIFT+CTRL+F1", true},
+
+        // Unknown base key
+        {"CTRL+INVALIDKEY", "", false},
+
+        // Unknown modifier token
+        {"Super+F1", "", false},
+
+        // Empty string is invalid
+        {"", "", false},
+    };
+
+    for (const auto &c : cases) {
+        Hotkey hk(c.input);
+
+        QCOMPARE(hk.isValid(), c.valid);
+
+        if (c.valid) {
+            // Canonical string form
+            QCOMPARE(hk.to_string(), c.canonical);
+
+            // Round-trip: constructing from canonical form must preserve it
+            Hotkey roundTrip(hk.to_string());
+            QVERIFY(roundTrip.isValid());
+            QCOMPARE(roundTrip.to_string(), c.canonical);
+        } else if (!c.canonical.empty()) {
+            // Recognized but invalid
+            QVERIFY(hk.isRecognized());
+            QCOMPARE(hk.to_string(), c.canonical);
+        } else {
+            // Unrecognized cases should return INVALID enum
+            QCOMPARE(hk.base(), HotkeyEnum::INVALID);
+        }
+    }
+}
+
+QTEST_MAIN(TestHotkeyManager)

--- a/tests/TestHotkeyManager.h
+++ b/tests/TestHotkeyManager.h
@@ -1,0 +1,35 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+#include "../src/global/macros.h"
+
+#include <QObject>
+
+class Hotkey;
+class HotkeyManager;
+
+class NODISCARD_QOBJECT TestHotkeyManager final : public QObject
+{
+    Q_OBJECT
+
+public:
+    TestHotkeyManager();
+    ~TestHotkeyManager() final;
+
+private Q_SLOTS:
+    void keyNormalizationTest();
+    void importExportRoundTripTest();
+    void importEdgeCasesTest();
+    void resetToDefaultsTest();
+    void exportCountTest();
+    void setHotkeyTest();
+    void removeHotkeyTest();
+    void invalidKeyValidationTest();
+    void duplicateKeyBehaviorTest();
+    void directLookupTest();
+    void hotkeyParsingAndToStringTest();
+
+private:
+    void checkHk(const HotkeyManager &manager, const Hotkey &hk, std::string_view expected);
+};


### PR DESCRIPTION
## Summary by Sourcery

Add configurable hotkey support to the integrated client and expose a new in‑game `hotkey` command for managing key bindings.

New Features:
- Introduce a Hotkey and HotkeyManager abstraction to map key combinations to client commands with default bindings and configuration-backed storage.
- Wire the integrated client input widget to resolve configured hotkeys (including separator handling) and support a new `_hotkey` command in the parser for listing, binding, and unbinding hotkeys.
- Add terminal-style Ctrl+U/Ctrl+W/Ctrl+H editing shortcuts and support for scrolling the client output via keyboard events.

Enhancements:
- Refactor input handling in InputWidget to separate command handling, history navigation, and basic key processing, and to avoid double-processing by honoring ShortcutOverride events.
- Extend configuration with a generic GroupConfig facility and a dedicated Hotkeys group for persisting hotkey mappings, with default initialization on first run.
- Improve parser and proxy wiring so both text and XML parsers receive a shared HotkeyManager from MainWindow, and surface hotkey help in the general help output.
- Add a reusable numeric hash-combine helper and use it to hash Hotkey instances by base key and modifiers.

Tests:
- Introduce a shared mm_test library for tests and refactor existing test targets to reuse common configuration and proxy sources.
- Add a comprehensive HotkeyManager test suite covering parsing/normalization, configuration round-trip, default reset, and lookup behavior, plus a new TestHotkeyManager target in CTest.