### PR TITLE
use instanced rendering for rooms, drastically reducing VRAM usage

### DIFF
--- a/src/display/MapBatches.h
+++ b/src/display/MapBatches.h
@@ -33,15 +33,13 @@ struct NODISCARD LayerMeshes final
     explicit operator bool() const { return isValid; }
 };
 
-using PlainQuadBatch = std::vector<glm::vec3>;
-
 struct NODISCARD LayerMeshesIntermediate final
 {
     using Fn = std::function<UniqueMesh(OpenGL &)>;
     using FnVec = std::vector<Fn>;
     FnVec terrain;
     FnVec trails;
-    RoomTintArray<PlainQuadBatch> tints;
+    RoomTintArray<Fn> tints;
     FnVec overlays;
     FnVec doors;
     FnVec walls;
@@ -49,7 +47,7 @@ struct NODISCARD LayerMeshesIntermediate final
     FnVec upDownExits;
     FnVec streamIns;
     FnVec streamOuts;
-    PlainQuadBatch layerBoost;
+    Fn layerBoost;
     bool isValid = false;
 
     LayerMeshesIntermediate() = default;

--- a/src/display/Textures.cpp
+++ b/src/display/Textures.cpp
@@ -305,6 +305,12 @@ void MapCanvas::initTextures()
         textures.stream_out[dir] = loadTexture(
             getPixmapFilenameRaw(QString::asprintf("stream-out-%s.png", lowercaseDirection(dir))));
     }
+    {
+        // 1x1
+        QImage whitePixel(1, 1, QImage::Format_RGBA8888);
+        whitePixel.fill(Qt::white);
+        textures.white_pixel = MMTexture::alloc(std::vector<QImage>{whitePixel});
+    }
 
     // char images are 256
     textures.char_arrows = loadTexture(getPixmapFilenameRaw("char-arrows.png"));
@@ -478,6 +484,13 @@ void MapCanvas::initTextures()
             auto thing = combine(textures.terrain, textures.road);
             maybeCreateArray2(thing, pArrayTex);
             textures.terrain_Array = textures.road_Array = pArrayTex;
+        }
+
+        {
+            SharedMMTexture pArrayTex;
+            std::vector<SharedMMTexture> pixels{textures.white_pixel};
+            maybeCreateArray2(pixels, pArrayTex);
+            textures.white_pixel_Array = pArrayTex;
         }
 
         {

--- a/src/display/Textures.h
+++ b/src/display/Textures.h
@@ -179,7 +179,8 @@ using TextureArrayNESWUD = EnumIndexedArray<SharedMMTexture, ExitDirEnum, NUM_EX
     X(SharedMMTexture, room_sel_distant) \
     X(SharedMMTexture, room_sel_move_bad) \
     X(SharedMMTexture, room_sel_move_good) \
-    X(SharedMMTexture, room_highlight)
+    X(SharedMMTexture, room_highlight) \
+    X(SharedMMTexture, white_pixel)
 
 struct NODISCARD MapCanvasTextures final
 {

--- a/src/display/mapcanvas.cpp
+++ b/src/display/mapcanvas.cpp
@@ -1139,6 +1139,7 @@ void MapCanvas::selectionChanged()
 
 void MapCanvas::graphicsSettingsChanged()
 {
+    m_opengl.resetNamedColorsBuffer();
     update();
 }
 

--- a/src/display/mapcanvas.h
+++ b/src/display/mapcanvas.h
@@ -66,25 +66,24 @@ private:
 
     struct NODISCARD Diff final
     {
+        using DiffQuadVector = std::vector<RoomQuadTexVert>;
+
         struct NODISCARD MaybeDataOrMesh final
-            : public std::variant<std::monostate, ColoredTexVertVector, UniqueMesh>
+            : public std::variant<std::monostate, DiffQuadVector, UniqueMesh>
         {
         public:
-            using base = std::variant<std::monostate, ColoredTexVertVector, UniqueMesh>;
+            using base = std::variant<std::monostate, DiffQuadVector, UniqueMesh>;
             using base::base;
 
         public:
             NODISCARD bool empty() const { return std::holds_alternative<std::monostate>(*this); }
-            NODISCARD bool hasData() const
-            {
-                return std::holds_alternative<ColoredTexVertVector>(*this);
-            }
+            NODISCARD bool hasData() const { return std::holds_alternative<DiffQuadVector>(*this); }
             NODISCARD bool hasMesh() const { return std::holds_alternative<UniqueMesh>(*this); }
 
         public:
-            NODISCARD const ColoredTexVertVector &getData() const
+            NODISCARD const DiffQuadVector &getData() const
             {
-                return std::get<ColoredTexVertVector>(*this);
+                return std::get<DiffQuadVector>(*this);
             }
             NODISCARD const UniqueMesh &getMesh() const { return std::get<UniqueMesh>(*this); }
 
@@ -96,7 +95,7 @@ private:
                 }
 
                 if (hasData()) {
-                    *this = gl.createColoredTexturedQuadBatch(getData(), texId);
+                    *this = gl.createRoomQuadTexBatch(getData(), texId);
                     assert(hasMesh());
                     // REVISIT: rendering immediately after uploading the mesh may lag,
                     // so consider delaying until the data is already on the GPU.
@@ -107,7 +106,7 @@ private:
                     return;
                 }
                 auto &mesh = getMesh();
-                mesh.render(GLRenderState().withBlend(BlendModeEnum::TRANSPARENCY));
+                mesh.render(gl.getDefaultRenderState().withBlend(BlendModeEnum::TRANSPARENCY));
             }
         };
 

--- a/src/global/NamedColors.cpp
+++ b/src/global/NamedColors.cpp
@@ -17,11 +17,13 @@ struct NODISCARD GlobalData final
     using InitArray = EnumIndexedArray<bool, NamedColorEnum, NUM_NAMED_COLORS>;
     using Map = std::map<std::string, NamedColorEnum>;
     using NamesVector = std::vector<std::string>;
+    using Vec4Vector = std::vector<glm::vec4>;
 
 private:
     Map m_map;
     NamesVector m_names;
     ColorVector m_colors;
+    Vec4Vector m_vec4s;
     InitArray m_initialized;
 
 private:
@@ -31,6 +33,7 @@ public:
     GlobalData()
     {
         m_colors.resize(NUM_NAMED_COLORS);
+        m_vec4s.assign(MAX_NAMED_COLORS, glm::vec4{0.0f});
         m_names.resize(NUM_NAMED_COLORS);
 
         static const auto white = Colors::white;
@@ -43,6 +46,7 @@ public:
             const auto color = (id == NamedColorEnum::TRANSPARENT) ? transparent_black : white;
 
             m_colors[idx] = color;
+            m_vec4s[idx] = color.getVec4();
             m_names[idx] = name;
             m_map.emplace(name, id);
         };
@@ -69,6 +73,7 @@ public:
 
         const auto idx = getIndex(id);
         m_colors.at(idx) = c;
+        m_vec4s.at(idx) = c.getVec4();
         m_initialized.at(id) = true;
         return true;
     }
@@ -81,6 +86,7 @@ public:
 
     NODISCARD const std::vector<std::string> &getAllNames() const { return m_names; }
     NODISCARD const std::vector<Color> &getAllColors() const { return m_colors; }
+    NODISCARD const std::vector<glm::vec4> &getAllVec4s() const { return m_vec4s; }
 
 public:
     NODISCARD std::optional<NamedColorEnum> lookup(std::string_view name) const
@@ -138,4 +144,9 @@ const std::vector<std::string> &XNamedColor::getAllNames()
 const std::vector<Color> &XNamedColor::getAllColors()
 {
     return getGlobalData().getAllColors();
+}
+
+const std::vector<glm::vec4> &XNamedColor::getAllColorsAsVec4()
+{
+    return getGlobalData().getAllVec4s();
 }

--- a/src/global/NamedColors.h
+++ b/src/global/NamedColors.h
@@ -48,6 +48,9 @@ enum class NODISCARD NamedColorEnum : uint8_t { DEFAULT = 0, XFOREACH_NAMED_COLO
 static inline constexpr size_t NUM_NAMED_COLORS = XFOREACH_NAMED_COLOR_OPTIONS(X_COUNT) + 1;
 #undef X_COUNT
 
+static inline constexpr size_t MAX_NAMED_COLORS = 32;
+static_assert(MAX_NAMED_COLORS >= NUM_NAMED_COLORS);
+
 // TODO: rename this, but to what? NamedColorHandle?
 class NODISCARD XNamedColor final
 {
@@ -98,5 +101,6 @@ public:
 
 public:
     NODISCARD static const std::vector<Color> &getAllColors();
+    NODISCARD static const std::vector<glm::vec4> &getAllColorsAsVec4();
     NODISCARD static const std::vector<std::string> &getAllNames();
 };

--- a/src/opengl/OpenGL.h
+++ b/src/opengl/OpenGL.h
@@ -89,6 +89,11 @@ public:
     NODISCARD UniqueMesh createColoredTexturedQuadBatch(const std::vector<ColoredTexVert> &verts,
                                                         MMTextureId texture);
 
+public:
+    NODISCARD UniqueMesh createRoomQuadTexBatch(const std::vector<RoomQuadTexVert> &verts,
+                                                MMTextureId texture);
+
+public:
     NODISCARD UniqueMesh createFontMesh(const SharedMMTexture &texture,
                                         DrawModeEnum mode,
                                         const std::vector<FontVert3d> &batch);
@@ -161,6 +166,9 @@ public:
 
 public:
     void cleanup();
+    NODISCARD GLRenderState getDefaultRenderState();
+    void bindNamedColorsBuffer();
+    void resetNamedColorsBuffer();
     void setTextureLookup(MMTextureId, SharedMMTexture);
 
 public:

--- a/src/opengl/legacy/AbstractShaderProgram.cpp
+++ b/src/opengl/legacy/AbstractShaderProgram.cpp
@@ -3,6 +3,8 @@
 
 #include "AbstractShaderProgram.h"
 
+#include "../../global/ConfigConsts.h"
+
 namespace Legacy {
 
 AbstractShaderProgram::AbstractShaderProgram(std::string dirName,

--- a/src/opengl/legacy/FunctionsES30.cpp
+++ b/src/opengl/legacy/FunctionsES30.cpp
@@ -25,6 +25,7 @@ std::optional<GLenum> FunctionsES30::virt_toGLenum(const DrawModeEnum mode)
 
     case DrawModeEnum::INVALID:
     case DrawModeEnum::QUADS:
+    case DrawModeEnum::INSTANCED_QUADS:
         break;
     }
 

--- a/src/opengl/legacy/FunctionsGL33.cpp
+++ b/src/opengl/legacy/FunctionsGL33.cpp
@@ -1,5 +1,6 @@
 #include "FunctionsGL33.h"
 
+#include "../../global/ConfigConsts.h"
 #include "../OpenGLConfig.h"
 
 #include <optional>
@@ -27,7 +28,10 @@ std::optional<GLenum> FunctionsGL33::virt_toGLenum(const DrawModeEnum mode)
     case DrawModeEnum::QUADS:
 #ifndef MMAPPER_NO_OPENGL
         return canRenderQuads() ? std::make_optional(GL_QUADS) : std::nullopt;
+#else
+        FALLTHROUGH;
 #endif
+    case DrawModeEnum::INSTANCED_QUADS:
     case DrawModeEnum::INVALID:
         break;
     }

--- a/src/opengl/legacy/ShaderUtils.cpp
+++ b/src/opengl/legacy/ShaderUtils.cpp
@@ -5,6 +5,7 @@
 
 #include "../../global/ConfigConsts.h"
 #include "../../global/Consts.h"
+#include "../../global/NamedColors.h"
 #include "../../global/PrintUtils.h"
 #include "../../global/TextUtils.h"
 
@@ -211,7 +212,12 @@ NODISCARD static GLuint compileShader(Functions &gl, const GLenum type, const So
     // NOTE: GLES 2.0 required `const char**` instead of `const char*const*`,
     // so Qt uses the least common denominator without the middle const;
     // that's the reason the `ptrs` array below is not `const`.
-    std::array<const char *, 3> ptrs = {gl.getShaderVersion(), "#line 1\n", source.source.c_str()};
+    std::string defineNamedColors = "#define MAX_NAMED_COLORS " + std::to_string(MAX_NAMED_COLORS)
+                                    + "\n";
+    std::array<const char *, 4> ptrs = {gl.getShaderVersion(),
+                                        defineNamedColors.c_str(),
+                                        "#line 1\n",
+                                        source.source.c_str()};
     gl.glShaderSource(shaderId, static_cast<GLsizei>(ptrs.size()), ptrs.data(), nullptr);
     gl.glCompileShader(shaderId);
     checkShaderInfo(gl, shaderId);
@@ -248,6 +254,7 @@ Program loadShaders(Functions &gl, const Source &vert, const Source &frag)
 
     gl.glLinkProgram(prog);
     checkProgramInfo(gl, prog);
+    gl.applyDefaultUniformBlockBindings(prog);
 
     for (const GLuint s : shaders) {
         if (is_valid(s)) {

--- a/src/opengl/legacy/Shaders.cpp
+++ b/src/opengl/legacy/Shaders.cpp
@@ -31,8 +31,37 @@ AColorPlainShader::~AColorPlainShader() = default;
 UColorPlainShader::~UColorPlainShader() = default;
 AColorTexturedShader::~AColorTexturedShader() = default;
 UColorTexturedShader::~UColorTexturedShader() = default;
+
+RoomQuadTexShader::~RoomQuadTexShader() = default;
+
 FontShader::~FontShader() = default;
 PointShader::~PointShader() = default;
+
+void ShaderPrograms::early_init()
+{
+    std::ignore = getPlainAColorShader();
+    std::ignore = getPlainUColorShader();
+    std::ignore = getTexturedAColorShader();
+    std::ignore = getTexturedUColorShader();
+
+    std::ignore = getRoomQuadTexShader();
+
+    std::ignore = getFontShader();
+    std::ignore = getPointShader();
+}
+
+void ShaderPrograms::resetAll()
+{
+    m_aColorShader.reset();
+    m_uColorShader.reset();
+    m_aTexturedShader.reset();
+    m_uTexturedShader.reset();
+
+    m_roomQuadTexShader.reset();
+
+    m_font.reset();
+    m_point.reset();
+}
 
 // essentially a private member of ShaderPrograms
 template<typename T>
@@ -76,6 +105,11 @@ const std::shared_ptr<UColorPlainShader> &ShaderPrograms::getPlainUColorShader()
 const std::shared_ptr<AColorTexturedShader> &ShaderPrograms::getTexturedAColorShader()
 {
     return getInitialized<AColorTexturedShader>(m_aTexturedShader, getFunctions(), "tex/acolor");
+}
+
+const std::shared_ptr<RoomQuadTexShader> &ShaderPrograms::getRoomQuadTexShader()
+{
+    return getInitialized<RoomQuadTexShader>(m_roomQuadTexShader, getFunctions(), "room/tex/acolor");
 }
 
 const std::shared_ptr<UColorTexturedShader> &ShaderPrograms::getTexturedUColorShader()

--- a/src/opengl/legacy/Shaders.h
+++ b/src/opengl/legacy/Shaders.h
@@ -56,6 +56,24 @@ private:
     }
 };
 
+struct NODISCARD RoomQuadTexShader final : public AbstractShaderProgram
+{
+public:
+    using AbstractShaderProgram::AbstractShaderProgram;
+
+    ~RoomQuadTexShader() final;
+
+private:
+    void virt_setUniforms(const glm::mat4 &mvp, const GLRenderState::Uniforms &uniforms) final
+    {
+        assert(uniforms.textures[0] != INVALID_MM_TEXTURE_ID);
+
+        setColor("uColor", uniforms.color);
+        setMatrix("uMVP", mvp);
+        setTexture("uTexture", 0);
+    }
+};
+
 struct NODISCARD UColorTexturedShader final : public AbstractShaderProgram
 {
 public:
@@ -116,10 +134,17 @@ struct NODISCARD ShaderPrograms final
 {
 private:
     Functions &m_functions;
+
+private:
     std::shared_ptr<AColorPlainShader> m_aColorShader;
     std::shared_ptr<UColorPlainShader> m_uColorShader;
     std::shared_ptr<AColorTexturedShader> m_aTexturedShader;
     std::shared_ptr<UColorTexturedShader> m_uTexturedShader;
+
+private:
+    std::shared_ptr<RoomQuadTexShader> m_roomQuadTexShader;
+
+private:
     std::shared_ptr<FontShader> m_font;
     std::shared_ptr<PointShader> m_point;
 
@@ -134,15 +159,7 @@ private:
     NODISCARD Functions &getFunctions() { return m_functions; }
 
 public:
-    void resetAll()
-    {
-        m_aColorShader.reset();
-        m_uColorShader.reset();
-        m_aTexturedShader.reset();
-        m_uTexturedShader.reset();
-        m_font.reset();
-        m_point.reset();
-    }
+    void resetAll();
 
 public:
     // attribute color (aka "Colored")
@@ -153,8 +170,16 @@ public:
     NODISCARD const std::shared_ptr<AColorTexturedShader> &getTexturedAColorShader();
     // uniform color + textured (aka "Textured")
     NODISCARD const std::shared_ptr<UColorTexturedShader> &getTexturedUColorShader();
+
+public:
+    NODISCARD const std::shared_ptr<RoomQuadTexShader> &getRoomQuadTexShader();
+
+public:
     NODISCARD const std::shared_ptr<FontShader> &getFontShader();
     NODISCARD const std::shared_ptr<PointShader> &getPointShader();
+
+public:
+    void early_init();
 };
 
 } // namespace Legacy

--- a/src/opengl/legacy/SimpleMesh.cpp
+++ b/src/opengl/legacy/SimpleMesh.cpp
@@ -2,3 +2,58 @@
 // Copyright (C) 2019 The MMapper Authors
 
 #include "SimpleMesh.h"
+
+#include "../../global/ConfigConsts.h"
+
+void Legacy::drawRoomQuad(Functions &gl, const GLsizei numVerts)
+{
+    static constexpr size_t NUM_ELEMENTS = 4;
+    const SharedVbo shared = gl.getSharedVbos().get(SharedVboEnum::InstancedQuadIbo);
+    VBO &vbo = deref(shared);
+
+    if (!vbo) {
+        if (IS_DEBUG_BUILD) {
+            qDebug() << "allocating shared VBO for drawRoomQuad";
+        }
+
+        vbo.emplace(gl.shared_from_this());
+
+        // CCW order
+        const std::vector<uint8_t> indices{0, 1, 2, 3};
+        assert(indices.size() == NUM_ELEMENTS);
+
+        MAYBE_UNUSED const auto numIndices = gl.setIbo(vbo.get(),
+                                                       indices,
+                                                       BufferUsageEnum::STATIC_DRAW);
+        assert(numIndices == NUM_ELEMENTS);
+    }
+
+    struct NODISCARD IBOBinder final
+    {
+    private:
+        Functions &m_gl;
+
+    public:
+        IBOBinder(Functions &f, const VBO &vbo)
+            : m_gl(f)
+        {
+            if (IS_DEBUG_BUILD) {
+                GLint binding = -1;
+                m_gl.glGetIntegerv(GL_ELEMENT_ARRAY_BUFFER_BINDING, &binding);
+                assert(binding == 0);
+            }
+            m_gl.glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, vbo.get());
+        }
+        ~IBOBinder() { m_gl.glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0); }
+        DELETE_CTORS_AND_ASSIGN_OPS(IBOBinder);
+    };
+
+    {
+        IBOBinder ibo_binder{gl, *shared};
+        gl.glDrawElementsInstanced(GL_TRIANGLE_FAN,
+                                   NUM_ELEMENTS,
+                                   GL_UNSIGNED_BYTE,
+                                   nullptr,
+                                   numVerts);
+    }
+}

--- a/src/opengl/legacy/SimpleMesh.h
+++ b/src/opengl/legacy/SimpleMesh.h
@@ -17,6 +17,8 @@
 
 namespace Legacy {
 
+void drawRoomQuad(Functions &gl, GLsizei numVerts);
+
 template<typename VertexType_, typename ProgramType_>
 class NODISCARD SimpleMesh : public IRenderable
 {
@@ -108,7 +110,13 @@ private:
                    const BufferUsageEnum usage)
     {
         const auto numVerts = verts.size();
-        assert(mode == DrawModeEnum::INVALID || numVerts % static_cast<size_t>(mode) == 0);
+
+        static_assert(static_cast<size_t>(DrawModeEnum::POINTS) == 1);
+        static_assert(static_cast<size_t>(DrawModeEnum::LINES) == 2);
+        static_assert(static_cast<size_t>(DrawModeEnum::TRIANGLES) == 3);
+        static_assert(static_cast<size_t>(DrawModeEnum::QUADS) == 4);
+        assert(mode == DrawModeEnum::INVALID || mode == DrawModeEnum::INSTANCED_QUADS
+               || numVerts % static_cast<size_t>(mode) == 0);
 
         if (!m_vbo && numVerts != 0) {
             m_vbo.emplace(m_shared_functions);
@@ -179,11 +187,14 @@ private:
 
         auto attribUnbinder = bindAttribs();
 
-        if (const std::optional<GLenum> &optMode = m_functions.toGLenum(m_drawMode)) {
+        if (m_drawMode == DrawModeEnum::INSTANCED_QUADS) {
+            drawRoomQuad(m_functions, m_numVerts);
+        } else if (const std::optional<GLenum> &optMode = m_functions.toGLenum(m_drawMode)) {
             m_functions.glDrawArrays(optMode.value(), 0, m_numVerts);
         } else {
             assert(false);
         }
     }
 };
+
 } // namespace Legacy

--- a/src/opengl/legacy/VBO.h
+++ b/src/opengl/legacy/VBO.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (C) 2019 The MMapper Authors
 
-#include "../../global/utils.h"
+#include "../../global/EnumIndexedArray.h"
 #include "Legacy.h"
 
 #include <memory>
@@ -57,6 +57,33 @@ public:
     }
 
     void resetAll() { base::clear(); }
+};
+
+class NODISCARD SharedVbos final
+    : private EnumIndexedArray<SharedVbo, SharedVboEnum, NUM_SHARED_VBOS>
+{
+private:
+    using base = EnumIndexedArray<SharedVbo, SharedVboEnum, NUM_SHARED_VBOS>;
+
+public:
+    SharedVbos() = default;
+
+public:
+    NODISCARD SharedVbo get(const SharedVboEnum buffer)
+    {
+        SharedVbo &shared = base::operator[](buffer);
+        if (shared == nullptr) {
+            shared = std::make_shared<VBO>();
+        }
+        return shared;
+    }
+
+    void reset(const SharedVboEnum buffer) { base::operator[](buffer).reset(); }
+
+    void resetAll()
+    {
+        base::for_each([](auto &shared) { shared.reset(); });
+    }
 };
 
 class NODISCARD Program final

--- a/src/resources/mmapper2.qrc
+++ b/src/resources/mmapper2.qrc
@@ -212,6 +212,8 @@
         <file>pixmaps/wall-west.png</file>
         <file>shaders/legacy/font/frag.glsl</file>
         <file>shaders/legacy/font/vert.glsl</file>
+        <file>shaders/legacy/room/tex/acolor/frag.glsl</file>
+        <file>shaders/legacy/room/tex/acolor/vert.glsl</file>
         <file>shaders/legacy/plain/acolor/frag.glsl</file>
         <file>shaders/legacy/plain/acolor/vert.glsl</file>
         <file>shaders/legacy/plain/ucolor/frag.glsl</file>

--- a/src/resources/shaders/legacy/room/tex/acolor/frag.glsl
+++ b/src/resources/shaders/legacy/room/tex/acolor/frag.glsl
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+uniform sampler2DArray uTexture;
+uniform vec4 uColor;
+
+in vec4 vColor;
+in vec3 vTexCoord;
+
+out vec4 vFragmentColor;
+
+void main()
+{
+    vFragmentColor = vColor * uColor * texture(uTexture, vTexCoord);
+}

--- a/src/resources/shaders/legacy/room/tex/acolor/vert.glsl
+++ b/src/resources/shaders/legacy/room/tex/acolor/vert.glsl
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+uniform mat4 uMVP;
+uniform NamedColorsBlock {
+    vec4 uNamedColors[MAX_NAMED_COLORS];
+};
+
+layout(location = 0) in ivec4 aVertTexCol;
+
+out vec4 vColor;
+out vec3 vTexCoord;
+
+void main()
+{
+    // ccw-order assumes it's a triangle fan (as opposed to a triangle strip)
+    const ivec3[4] ioffsets_ccw = ivec3[4](ivec3(0, 0, 0), ivec3(1, 0, 0), ivec3(1, 1, 0), ivec3(0, 1, 0));
+    ivec3 ioffset = ioffsets_ccw[gl_VertexID];
+
+    int texZ = aVertTexCol.w & 0xFF;
+    int colorId = (aVertTexCol.w >> 8) % MAX_NAMED_COLORS;
+
+    vColor = uNamedColors[colorId];
+    vTexCoord = vec3(ioffset.xy, float(texZ));
+    gl_Position = uMVP * vec4(aVertTexCol.xyz + ioffset, 1.0);
+}


### PR DESCRIPTION
Quad meshes are now 75% (as GL_QUADS) to 83% (as GL_TRIANGLES) smaller.

* read named colors from a uniform buffer objects (UBO) for named colors
* consolidate plain and textured rendering into a single shader path
* use lazy mesh generation for room tints and layer boosts

## Summary by Sourcery

Use instanced room quad rendering with a unified textured shader and named-color uniform buffer to reduce VRAM usage for map rendering.

New Features:
- Add instanced room-quad textured mesh and shader that read per-room named colors from a shared uniform buffer.
- Introduce a shared white-pixel array texture to support tint and layer boost rendering via the new instanced path.

Enhancements:
- Refactor room tint and highlight handling to store compact per-room data and generate meshes lazily.
- Centralize OpenGL shared buffer management and uniform-block binding for named colors and shared index buffers.
- Simplify map rendering setup by early-initializing all legacy shaders and exposing a default render state helper.