### PR TITLE
refactor MSAA resolve for WebGL2 and GLES3 compatability

### DIFF
--- a/src/opengl/OpenGL.cpp
+++ b/src/opengl/OpenGL.cpp
@@ -196,34 +196,9 @@ void OpenGL::renderColoredTextured(const DrawModeEnum type,
 
 void OpenGL::renderPlainFullScreenQuad(const GLRenderState &renderState)
 {
-    using MeshType = Legacy::PlainMesh<glm::vec3>;
-    static std::weak_ptr<MeshType> g_mesh;
-    auto sharedMesh = g_mesh.lock();
-    if (sharedMesh == nullptr) {
-        if (IS_DEBUG_BUILD) {
-            qDebug() << "allocating shared mesh for renderPlainFullScreenQuad";
-        }
-        auto &sharedFuncs = getSharedFunctions();
-        auto &funcs = deref(sharedFuncs);
-        g_mesh = sharedMesh
-            = std::make_shared<MeshType>(sharedFuncs,
-                                         funcs.getShaderPrograms().getPlainUColorShader());
-        funcs.addSharedMesh(Badge<OpenGL>{}, sharedMesh);
-        MeshType &mesh = deref(sharedMesh);
-
-        // screen is [-1,+1]^3.
-        const auto fullScreenQuad = std::vector{glm::vec3{-1, -1, 0},
-                                                glm::vec3{+1, -1, 0},
-                                                glm::vec3{+1, +1, 0},
-                                                glm::vec3{-1, +1, 0}};
-        mesh.setStatic(DrawModeEnum::QUADS, fullScreenQuad);
-    }
-
-    MeshType &mesh = deref(sharedMesh);
-    const auto oldProj = getProjectionMatrix();
-    setProjectionMatrix(glm::mat4(1));
-    mesh.render(renderState.withDepthFunction(std::nullopt));
-    setProjectionMatrix(oldProj);
+    auto &gl = getFunctions();
+    gl.renderFullScreenTriangle(gl.getShaderPrograms().getFullScreenShader(),
+                                renderState.withDepthFunction(std::nullopt));
 }
 
 void OpenGL::cleanup()

--- a/src/opengl/legacy/FBO.cpp
+++ b/src/opengl/legacy/FBO.cpp
@@ -81,25 +81,26 @@ void FBO::release()
     }
 }
 
-void FBO::blitToDefault()
+void FBO::resolve()
 {
     if (!m_resolvedFbo) {
-        return; // Nothing to blit from
+        return; // Nothing to resolve to
     }
 
     // If we have a valid multisampling FBO, resolve it to the resolved FBO first.
     if (m_multisamplingFbo && m_multisamplingFbo->isValid()) {
+        // NOTE: In WebGL2/GLES 3.0 environments, resolving a multisampled framebuffer
+        // requires GL_NEAREST.
         QOpenGLFramebufferObject::blitFramebuffer(m_resolvedFbo.get(),
                                                   m_multisamplingFbo.get(),
                                                   GL_COLOR_BUFFER_BIT,
-                                                  GL_LINEAR);
+                                                  GL_NEAREST);
     }
+}
 
-    // Now blit the (potentially resolved) FBO to the default framebuffer.
-    QOpenGLFramebufferObject::blitFramebuffer(nullptr,
-                                              m_resolvedFbo.get(),
-                                              GL_COLOR_BUFFER_BIT,
-                                              GL_NEAREST);
+GLuint FBO::resolvedTextureId() const
+{
+    return m_resolvedFbo ? m_resolvedFbo->texture() : 0;
 }
 
 } // namespace Legacy

--- a/src/opengl/legacy/FBO.h
+++ b/src/opengl/legacy/FBO.h
@@ -25,7 +25,9 @@ public:
     void configure(const Viewport &physicalViewport, int samples);
     void bind();
     void release();
-    void blitToDefault();
+    void resolve();
+
+    NODISCARD GLuint resolvedTextureId() const;
 
 private:
     std::unique_ptr<QOpenGLFramebufferObject> m_multisamplingFbo;

--- a/src/opengl/legacy/Meshes.h
+++ b/src/opengl/legacy/Meshes.h
@@ -27,10 +27,10 @@ private:
     {
         GLuint vertPos = INVALID_ATTRIB_LOCATION;
 
-        NODISCARD static Attribs getLocations(AbstractShaderProgram &fontShader)
+        NODISCARD static Attribs getLocations(AbstractShaderProgram &shader)
         {
             Attribs result;
-            result.vertPos = fontShader.getAttribLocation("aVert");
+            result.vertPos = shader.getAttribLocation("aVert");
             return result;
         }
     };

--- a/src/opengl/legacy/Shaders.cpp
+++ b/src/opengl/legacy/Shaders.cpp
@@ -36,6 +36,8 @@ RoomQuadTexShader::~RoomQuadTexShader() = default;
 
 FontShader::~FontShader() = default;
 PointShader::~PointShader() = default;
+BlitShader::~BlitShader() = default;
+FullScreenShader::~FullScreenShader() = default;
 
 void ShaderPrograms::early_init()
 {
@@ -48,6 +50,8 @@ void ShaderPrograms::early_init()
 
     std::ignore = getFontShader();
     std::ignore = getPointShader();
+    std::ignore = getBlitShader();
+    std::ignore = getFullScreenShader();
 }
 
 void ShaderPrograms::resetAll()
@@ -61,6 +65,8 @@ void ShaderPrograms::resetAll()
 
     m_font.reset();
     m_point.reset();
+    m_blit.reset();
+    m_fullscreen.reset();
 }
 
 // essentially a private member of ShaderPrograms
@@ -125,6 +131,16 @@ const std::shared_ptr<FontShader> &ShaderPrograms::getFontShader()
 const std::shared_ptr<PointShader> &ShaderPrograms::getPointShader()
 {
     return getInitialized<PointShader>(m_point, getFunctions(), "point");
+}
+
+const std::shared_ptr<BlitShader> &ShaderPrograms::getBlitShader()
+{
+    return getInitialized<BlitShader>(m_blit, getFunctions(), "blit");
+}
+
+const std::shared_ptr<FullScreenShader> &ShaderPrograms::getFullScreenShader()
+{
+    return getInitialized<FullScreenShader>(m_fullscreen, getFunctions(), "fullscreen");
 }
 
 } // namespace Legacy

--- a/src/opengl/legacy/Shaders.h
+++ b/src/opengl/legacy/Shaders.h
@@ -129,6 +129,33 @@ private:
     }
 };
 
+struct NODISCARD BlitShader final : public AbstractShaderProgram
+{
+public:
+    using AbstractShaderProgram::AbstractShaderProgram;
+
+    ~BlitShader() final;
+
+private:
+    void virt_setUniforms(const glm::mat4 & /*mvp*/,
+                          const GLRenderState::Uniforms & /*uniforms*/) final
+    {}
+};
+
+struct NODISCARD FullScreenShader final : public AbstractShaderProgram
+{
+public:
+    using AbstractShaderProgram::AbstractShaderProgram;
+
+    ~FullScreenShader() final;
+
+private:
+    void virt_setUniforms(const glm::mat4 & /*mvp*/, const GLRenderState::Uniforms &uniforms) final
+    {
+        setColor("uColor", uniforms.color);
+    }
+};
+
 /* owned by Functions */
 struct NODISCARD ShaderPrograms final
 {
@@ -147,6 +174,8 @@ private:
 private:
     std::shared_ptr<FontShader> m_font;
     std::shared_ptr<PointShader> m_point;
+    std::shared_ptr<BlitShader> m_blit;
+    std::shared_ptr<FullScreenShader> m_fullscreen;
 
 public:
     explicit ShaderPrograms(Functions &functions)
@@ -177,6 +206,8 @@ public:
 public:
     NODISCARD const std::shared_ptr<FontShader> &getFontShader();
     NODISCARD const std::shared_ptr<PointShader> &getPointShader();
+    NODISCARD const std::shared_ptr<BlitShader> &getBlitShader();
+    NODISCARD const std::shared_ptr<FullScreenShader> &getFullScreenShader();
 
 public:
     void early_init();

--- a/src/opengl/legacy/VAO.h
+++ b/src/opengl/legacy/VAO.h
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (C) 2025 The MMapper Authors
 
+#include "../../global/EnumIndexedArray.h"
 #include "Legacy.h"
+
+#include <memory>
 
 namespace Legacy {
 
@@ -28,6 +31,36 @@ public:
 
 public:
     NODISCARD explicit operator bool() const { return m_vao != INVALID_VAOID; }
+};
+
+using SharedVao = std::shared_ptr<VAO>;
+using WeakVao = std::weak_ptr<VAO>;
+
+class NODISCARD SharedVaos final
+    : private EnumIndexedArray<SharedVao, SharedVaoEnum, NUM_SHARED_VAOS>
+{
+private:
+    using base = EnumIndexedArray<SharedVao, SharedVaoEnum, NUM_SHARED_VAOS>;
+
+public:
+    SharedVaos() = default;
+
+public:
+    NODISCARD SharedVao get(const SharedVaoEnum vao)
+    {
+        SharedVao &shared = base::operator[](vao);
+        if (shared == nullptr) {
+            shared = std::make_shared<VAO>();
+        }
+        return shared;
+    }
+
+    void reset(const SharedVaoEnum vao) { base::operator[](vao).reset(); }
+
+    void resetAll()
+    {
+        base::for_each([](auto &shared) { shared.reset(); });
+    }
 };
 
 } // namespace Legacy

--- a/src/resources/mmapper2.qrc
+++ b/src/resources/mmapper2.qrc
@@ -224,5 +224,9 @@
         <file>shaders/legacy/tex/acolor/vert.glsl</file>
         <file>shaders/legacy/tex/ucolor/frag.glsl</file>
         <file>shaders/legacy/tex/ucolor/vert.glsl</file>
+        <file>shaders/legacy/blit/frag.glsl</file>
+        <file>shaders/legacy/blit/vert.glsl</file>
+        <file>shaders/legacy/fullscreen/frag.glsl</file>
+        <file>shaders/legacy/fullscreen/vert.glsl</file>
     </qresource>
 </RCC>

--- a/src/resources/shaders/legacy/blit/frag.glsl
+++ b/src/resources/shaders/legacy/blit/frag.glsl
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+uniform sampler2D uTexture;
+
+in vec2 vTexCoord;
+
+out vec4 vFragmentColor;
+
+void main()
+{
+    vFragmentColor = texture(uTexture, vTexCoord);
+}

--- a/src/resources/shaders/legacy/blit/vert.glsl
+++ b/src/resources/shaders/legacy/blit/vert.glsl
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+out vec2 vTexCoord;
+
+void main()
+{
+    vTexCoord = vec2((gl_VertexID << 1) & 2, gl_VertexID & 2);
+    gl_Position = vec4(vTexCoord * 2.0 - 1.0, 0.0, 1.0);
+}

--- a/src/resources/shaders/legacy/fullscreen/frag.glsl
+++ b/src/resources/shaders/legacy/fullscreen/frag.glsl
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+uniform vec4 uColor;
+
+out vec4 vFragmentColor;
+
+void main()
+{
+    vFragmentColor = uColor;
+}

--- a/src/resources/shaders/legacy/fullscreen/vert.glsl
+++ b/src/resources/shaders/legacy/fullscreen/vert.glsl
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+void main()
+{
+    gl_Position = vec4(vec2((gl_VertexID << 1) & 2, gl_VertexID & 2) * 2.0 - 1.0, 0.0, 1.0);
+}


### PR DESCRIPTION
- Fix blit limits by resolving to FBO and drawing via vertex-less quad
- MSAA resolve uses GL_NEAREST for WebGL2 and ES3 support
- Use gl_VertexID and EmptyVAO to skip VBO traffic for blit and full screen layer fades

## Summary by Sourcery

Resolve multisampled framebuffers into a texture and render them via a fullscreen triangle using new blit/fullscreen shaders and shared VAOs for WebGL2/GLES3 compatibility.

New Features:
- Introduce shared VAO management and an empty shared VAO for fullscreen rendering paths.
- Add dedicated blit and fullscreen shader programs and associated GLSL vertex/fragment shaders for texture blitting and solid-color fullscreen draws.
- Expose a renderFullScreenTriangle helper to render fullscreen passes without vertex buffers using gl_VertexID.

Bug Fixes:
- Resolve multisampled framebuffers with GL_NEAREST and sample from the resolved texture to ensure MSAA resolve works correctly on WebGL2 and GLES3 platforms.

Enhancements:
- Replace direct FBO-to-default blits with a resolve-to-texture then fullscreen draw flow to avoid blit size/limit issues.
- Refactor fullscreen quad rendering to a simpler fullscreen triangle using an empty VAO instead of a reusable mesh and VBOs.