### PR TITLE
bump Wasm to Qt 6.10.2

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -27,8 +27,9 @@ jobs:
     - name: Install Qt for Wasm
       uses: jurplel/install-qt-action@v4
       with:
-        version: 6.5.3
-        host: mac
+        version: 6.10.2
+        target: wasm
+        host: all_os
         arch: wasm_multithread
         cache: true
         modules: 'qtwebsockets'
@@ -36,7 +37,7 @@ jobs:
     - name: Setup emsdk
       uses: mymindstorm/setup-emsdk@v14
       with:
-        version: 3.1.25
+        version: 4.0.7
 
     - name: Configure and Build
       shell: bash
@@ -74,7 +75,6 @@ jobs:
       run: |
         mkdir -p demo
         cp build/src/mmapper.js demo/
-        cp build/src/mmapper.worker.js demo/
         cp build/src/mmapper.wasm demo/
         cp build/src/qtloader.js demo/
         cp build/src/qtlogo.svg demo/


### PR DESCRIPTION
## Summary by Sourcery

Update the WebAssembly build workflow to use newer Qt and Emscripten toolchain versions and align configuration with the updated Qt for WebAssembly packaging.

Build:
- Bump Qt for WebAssembly in the GitHub Actions workflow from 6.5.3 to 6.10.2 and adjust host/target settings.
- Update the configured Emscripten SDK version in the WebAssembly build workflow from 3.1.25 to 4.0.7.
- Stop copying the now-unneeded mmapper.worker.js artifact in the WebAssembly build packaging step.