### PR TITLE
expose audio output device selection in preferences

### DIFF
--- a/src/configuration/configuration.cpp
+++ b/src/configuration/configuration.cpp
@@ -268,6 +268,7 @@ ConstString KEY_PROXY_LOCAL_PORT = "Local port number";
 ConstString KEY_MAP_MODE = "Map Mode";
 ConstString KEY_MUSIC_VOLUME = "Music volume";
 ConstString KEY_SOUND_VOLUME = "Sound volume";
+ConstString KEY_AUDIO_OUTPUT_DEVICE = "Audio output device";
 ConstString KEY_MAXIMUM_NUMBER_OF_PATHS = "maximum number of paths";
 ConstString KEY_MULTIPLE_CONNECTIONS_PENALTY = "multiple connections penalty";
 ConstString KEY_MUME_START_EPOCH = "Mume start epoch";
@@ -761,6 +762,7 @@ void Configuration::AudioSettings::read(const QSettings &conf)
     m_unlocked = (CURRENT_PLATFORM != PlatformEnum::Wasm);
     m_musicVolume = std::clamp(conf.value(KEY_MUSIC_VOLUME, 50).toInt(), 0, 100);
     m_soundVolume = std::clamp(conf.value(KEY_SOUND_VOLUME, 50).toInt(), 0, 100);
+    m_outputDeviceId = conf.value(KEY_AUDIO_OUTPUT_DEVICE).toByteArray();
 }
 
 void Configuration::IntegratedMudClientSettings::read(const QSettings &conf)
@@ -939,6 +941,7 @@ void Configuration::AudioSettings::write(QSettings &conf) const
 {
     conf.setValue(KEY_MUSIC_VOLUME, m_musicVolume);
     conf.setValue(KEY_SOUND_VOLUME, m_soundVolume);
+    conf.setValue(KEY_AUDIO_OUTPUT_DEVICE, m_outputDeviceId);
 }
 
 void Configuration::IntegratedMudClientSettings::write(QSettings &conf) const

--- a/src/configuration/configuration.h
+++ b/src/configuration/configuration.h
@@ -350,6 +350,7 @@ public:
         ChangeMonitor m_changeMonitor;
         int m_musicVolume = 50;
         int m_soundVolume = 50;
+        QByteArray m_outputDeviceId;
         bool m_unlocked = false;
 
     public:
@@ -369,6 +370,13 @@ public:
         void setSoundVolume(const int volume)
         {
             m_soundVolume = volume;
+            m_changeMonitor.notifyAll();
+        }
+
+        NODISCARD const QByteArray &getOutputDeviceId() const { return m_outputDeviceId; }
+        void setOutputDeviceId(const QByteArray &id)
+        {
+            m_outputDeviceId = id;
             m_changeMonitor.notifyAll();
         }
 

--- a/src/media/AudioManager.h
+++ b/src/media/AudioManager.h
@@ -33,4 +33,5 @@ public:
 
 private:
     void updateVolumes();
+    void updateOutputDevices();
 };

--- a/src/media/MusicManager.cpp
+++ b/src/media/MusicManager.cpp
@@ -7,6 +7,7 @@
 #include "MediaLibrary.h"
 
 #ifndef MMAPPER_NO_AUDIO
+#include <QAudioDevice>
 #include <QAudioOutput>
 #include <QMediaPlayer>
 #include <QUrl>
@@ -209,6 +210,15 @@ void MusicManager::slot_onMediaChanged()
 }
 
 #ifndef MMAPPER_NO_AUDIO
+void MusicManager::updateOutputDevice(const QAudioDevice &device)
+{
+    for (int i = 0; i < 2; ++i) {
+        if (m_channels[i].audioOutput->device() != device) {
+            m_channels[i].audioOutput->setDevice(device);
+        }
+    }
+}
+
 void MusicManager::applyPendingPosition(int channelIndex)
 {
     auto &ch = m_channels[channelIndex];

--- a/src/media/MusicManager.h
+++ b/src/media/MusicManager.h
@@ -8,6 +8,10 @@
 #include <QObject>
 #include <QString>
 
+#ifndef MMAPPER_NO_AUDIO
+#include <QAudioDevice>
+#endif
+
 class QMediaPlayer;
 class QAudioOutput;
 class QTimer;
@@ -49,6 +53,9 @@ public:
     void playMusic(const QString &musicFile);
     void stopMusic();
     void updateVolumes();
+#ifndef MMAPPER_NO_AUDIO
+    void updateOutputDevice(const QAudioDevice &device);
+#endif
 
 public slots:
     void slot_onMediaChanged();

--- a/src/media/SfxManager.cpp
+++ b/src/media/SfxManager.cpp
@@ -7,6 +7,7 @@
 #include "MediaLibrary.h"
 
 #ifndef MMAPPER_NO_AUDIO
+#include <QAudioDevice>
 #include <QAudioOutput>
 #include <QMediaPlayer>
 #endif
@@ -62,3 +63,12 @@ void SfxManager::updateVolume()
     m_output->setVolume(static_cast<float>(getConfig().audio.getSoundVolume()) / 100.0f);
 #endif
 }
+
+#ifndef MMAPPER_NO_AUDIO
+void SfxManager::updateOutputDevice(const QAudioDevice &device)
+{
+    if (m_output->device() != device) {
+        m_output->setDevice(device);
+    }
+}
+#endif

--- a/src/media/SfxManager.h
+++ b/src/media/SfxManager.h
@@ -8,6 +8,10 @@
 #include <QSet>
 #include <QString>
 
+#ifndef MMAPPER_NO_AUDIO
+#include <QAudioDevice>
+#endif
+
 class MediaLibrary;
 class QAudioOutput;
 
@@ -26,4 +30,7 @@ public:
 
     void playSound(const QString &soundName);
     void updateVolume();
+#ifndef MMAPPER_NO_AUDIO
+    void updateOutputDevice(const QAudioDevice &device);
+#endif
 };

--- a/src/preferences/audiopage.cpp
+++ b/src/preferences/audiopage.cpp
@@ -4,7 +4,13 @@
 #include "audiopage.h"
 
 #include "../configuration/configuration.h"
+#include "../global/SignalBlocker.h"
 #include "ui_audiopage.h"
+
+#ifndef MMAPPER_NO_AUDIO
+#include <QAudioDevice>
+#include <QMediaDevices>
+#endif
 
 AudioPage::AudioPage(QWidget *const parent)
     : QWidget(parent)
@@ -12,6 +18,7 @@ AudioPage::AudioPage(QWidget *const parent)
 {
     ui->setupUi(this);
 
+    slot_updateDevices();
     slot_loadConfig();
 
     connect(ui->musicVolumeSlider,
@@ -22,8 +29,18 @@ AudioPage::AudioPage(QWidget *const parent)
             &QSlider::valueChanged,
             this,
             &AudioPage::slot_soundsVolumeChanged);
+    connect(ui->outputDeviceComboBox,
+            &QComboBox::currentIndexChanged,
+            this,
+            &AudioPage::slot_outputDeviceChanged);
+
+#ifndef MMAPPER_NO_AUDIO
+    auto *const mediaDevices = new QMediaDevices(this);
+    connect(mediaDevices, &QMediaDevices::audioOutputsChanged, this, &AudioPage::slot_updateDevices);
+#endif
 
     if constexpr (NO_AUDIO) {
+        ui->outputDeviceComboBox->setEnabled(false);
         ui->musicVolumeSlider->setEnabled(false);
         ui->soundsVolumeSlider->setEnabled(false);
     }
@@ -36,9 +53,20 @@ AudioPage::~AudioPage()
 
 void AudioPage::slot_loadConfig()
 {
+    SignalBlocker musicBlocker(*ui->musicVolumeSlider);
+    SignalBlocker soundsBlocker(*ui->soundsVolumeSlider);
+    SignalBlocker outputBlocker(*ui->outputDeviceComboBox);
+
     const auto &settings = getConfig().audio;
     ui->musicVolumeSlider->setValue(settings.getMusicVolume());
     ui->soundsVolumeSlider->setValue(settings.getSoundVolume());
+
+    int index = ui->outputDeviceComboBox->findData(settings.getOutputDeviceId());
+    if (index != -1) {
+        ui->outputDeviceComboBox->setCurrentIndex(index);
+    } else {
+        ui->outputDeviceComboBox->setCurrentIndex(0);
+    }
 }
 
 void AudioPage::slot_musicVolumeChanged(int value)
@@ -53,4 +81,48 @@ void AudioPage::slot_soundsVolumeChanged(int value)
     auto &settings = setConfig().audio;
     settings.setSoundVolume(value);
     settings.setUnlocked();
+}
+
+void AudioPage::slot_outputDeviceChanged(int index)
+{
+    if (index < 0) {
+        return;
+    }
+    auto &settings = setConfig().audio;
+    settings.setOutputDeviceId(ui->outputDeviceComboBox->itemData(index).toByteArray());
+}
+
+void AudioPage::slot_updateDevices()
+{
+    SignalBlocker blocker(*ui->outputDeviceComboBox);
+    QByteArray currentId = ui->outputDeviceComboBox->currentData().toByteArray();
+    if (currentId.isEmpty()) {
+        currentId = getConfig().audio.getOutputDeviceId();
+    }
+
+    ui->outputDeviceComboBox->clear();
+    ui->outputDeviceComboBox->addItem(tr("System Default"), QByteArray());
+
+#ifndef MMAPPER_NO_AUDIO
+    const QList<QAudioDevice> devices = QMediaDevices::audioOutputs();
+    bool found = false;
+    for (const QAudioDevice &device : devices) {
+        ui->outputDeviceComboBox->addItem(device.description(), device.id());
+        if (device.id() == currentId) {
+            found = true;
+        }
+    }
+
+    if (!currentId.isEmpty() && !found) {
+        ui->outputDeviceComboBox->addItem(tr("%1 (missing)").arg(QString::fromUtf8(currentId)),
+                                          currentId);
+    }
+#endif
+
+    int index = ui->outputDeviceComboBox->findData(currentId);
+    if (index != -1) {
+        ui->outputDeviceComboBox->setCurrentIndex(index);
+    } else {
+        ui->outputDeviceComboBox->setCurrentIndex(0);
+    }
 }

--- a/src/preferences/audiopage.h
+++ b/src/preferences/audiopage.h
@@ -25,4 +25,6 @@ public slots:
     void slot_loadConfig();
     void slot_musicVolumeChanged(int);
     void slot_soundsVolumeChanged(int);
+    void slot_outputDeviceChanged(int);
+    void slot_updateDevices();
 };

--- a/src/preferences/audiopage.ui
+++ b/src/preferences/audiopage.ui
@@ -12,6 +12,25 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <widget class="QGroupBox" name="outputGroupBox">
+     <property name="title">
+      <string>Output</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayoutOutput">
+      <item row="0" column="0">
+       <widget class="QLabel" name="outputDeviceLabel">
+        <property name="text">
+         <string>Device:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="outputDeviceComboBox"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="musicGroupBox">
      <property name="title">
       <string>Music</string>


### PR DESCRIPTION
## Summary by Sourcery

Add configurable audio output device selection and propagate it through configuration, UI, and audio managers.

New Features:
- Expose audio output device selection in the audio preferences UI, including persistence of the chosen device.
- Apply the configured audio output device to both music and sound effects playback, with automatic fallback to the system default device and handling of missing devices.

Enhancements:
- Refresh the list of available audio output devices when system audio outputs change and initialize it on startup.
- Guard audio-device-related logic behind existing no-audio compile-time flags and prevent interaction with device selection when audio is disabled.