### PR TITLE
refactor texture initialization for modders

### DIFF
--- a/src/opengl/OpenGL.h
+++ b/src/opengl/OpenGL.h
@@ -172,7 +172,8 @@ public:
     void setTextureLookup(MMTextureId, SharedMMTexture);
 
 public:
-    void initArrayFromFiles(const SharedMMTexture &array, const std::vector<QString> &input);
-    void initArrayFromImages(const SharedMMTexture &array,
-                             const std::vector<std::vector<QImage>> &input);
+    void uploadArrayLayer(const SharedMMTexture &array,
+                          int layer,
+                          const std::vector<QImage> &images);
+    void generateMipmaps(const SharedMMTexture &array);
 };

--- a/tests/TestGlobal.cpp
+++ b/tests/TestGlobal.cpp
@@ -24,6 +24,7 @@
 #include "../src/global/int_cast.h"
 #include "../src/global/string_view_utils.h"
 #include "../src/global/unquote.h"
+#include "../src/global/utils.h"
 
 #include <tuple>
 
@@ -293,6 +294,55 @@ void TestGlobal::indexedVectorWithDefaultTest()
 void TestGlobal::lineUtilsTest()
 {
     test::testLineUtils();
+}
+
+void TestGlobal::powerOfTwoTest()
+{
+    using namespace utils;
+
+    // Test isPowerOfTwo
+    QVERIFY(isPowerOfTwo(1u));
+    QVERIFY(isPowerOfTwo(2u));
+    QVERIFY(isPowerOfTwo(4u));
+    QVERIFY(isPowerOfTwo(1024u));
+    QVERIFY(!isPowerOfTwo(0u));
+    QVERIFY(!isPowerOfTwo(3u));
+    QVERIFY(!isPowerOfTwo(1023u));
+
+    // Test nextPowerOfTwo uint8_t
+    QCOMPARE(nextPowerOfTwo<uint8_t>(0), 1u);
+    QCOMPARE(nextPowerOfTwo<uint8_t>(1), 1u);
+    QCOMPARE(nextPowerOfTwo<uint8_t>(2), 2u);
+    QCOMPARE(nextPowerOfTwo<uint8_t>(3), 4u);
+    QCOMPARE(nextPowerOfTwo<uint8_t>(127), 128u);
+    QCOMPARE(nextPowerOfTwo<uint8_t>(128), 128u);
+    QCOMPARE(nextPowerOfTwo<uint8_t>(129), 128u); // Clamped!
+    QCOMPARE(nextPowerOfTwo<uint8_t>(255), 128u); // Clamped!
+
+    // Test nextPowerOfTwo uint32_t
+    QCOMPARE(nextPowerOfTwo<uint32_t>(0), 1u);
+    QCOMPARE(nextPowerOfTwo<uint32_t>(1023), 1024u);
+    QCOMPARE(nextPowerOfTwo<uint32_t>(1024), 1024u);
+    QCOMPARE(nextPowerOfTwo<uint32_t>(1025), 2048u);
+    constexpr uint32_t maxP2_32 = 1u << 31;
+    QCOMPARE(nextPowerOfTwo<uint32_t>(maxP2_32 - 1), maxP2_32);
+    QCOMPARE(nextPowerOfTwo<uint32_t>(maxP2_32), maxP2_32);
+    QCOMPARE(nextPowerOfTwo<uint32_t>(maxP2_32 + 1), maxP2_32);
+    QCOMPARE(nextPowerOfTwo<uint32_t>(0xFFFFFFFFu), maxP2_32);
+
+    // Test nearestPowerOfTwo uint8_t
+    QCOMPARE(nearestPowerOfTwo<uint8_t>(0), 1u);
+    QCOMPARE(nearestPowerOfTwo<uint8_t>(1), 1u);
+    QCOMPARE(nearestPowerOfTwo<uint8_t>(2), 2u);
+    QCOMPARE(nearestPowerOfTwo<uint8_t>(3), 4u); // Ties round up
+    QCOMPARE(nearestPowerOfTwo<uint8_t>(5), 4u);
+    QCOMPARE(nearestPowerOfTwo<uint8_t>(6), 8u); // Ties round up
+    QCOMPARE(nearestPowerOfTwo<uint8_t>(7), 8u);
+
+    // Test nearestPowerOfTwo near max
+    QCOMPARE(nearestPowerOfTwo<uint8_t>(128), 128u);
+    QCOMPARE(nearestPowerOfTwo<uint8_t>(129), 128u);
+    QCOMPARE(nearestPowerOfTwo<uint8_t>(255), 128u);
 }
 
 namespace { // anonymous

--- a/tests/TestGlobal.h
+++ b/tests/TestGlobal.h
@@ -31,6 +31,7 @@ private Q_SLOTS:
     static void hideQDebugTest();
     static void indexedVectorWithDefaultTest();
     static void lineUtilsTest();
+    static void powerOfTwoTest();
     static void signal2Test();
     static void stringViewTest();
     static void taggedStringTest();


### PR DESCRIPTION
## Summary by Sourcery

Refactor texture array initialization to support more flexible, modder‑friendly inputs while centralizing measurement, validation, and logging of texture groups.

New Features:
- Introduce generic power-of-two utility helpers (nextPowerOfTwo and nearestPowerOfTwo) for integral types, with comprehensive unit tests.

Bug Fixes:
- Enforce square, power-of-two dimensions for image-based textures at initialization time, failing fast when constraints are violated.

Enhancements:
- Rework MapCanvas texture array creation to select common target sizes per group, support mixed dimensions via resizing for file-backed textures, and centralize group measurements and logging.
- Unify texture array upload by introducing OpenGL::uploadArrayLayer and OpenGL::generateMipmaps, replacing separate file- and image-based array initialization paths.
- Improve global logging of texture measurement statistics, including per-group and global size distributions, to aid modders in debugging texture packs.
- Allow appendAll helper to accept both single textures and collections, simplifying group assembly for array creation.

Tests:
- Add TestGlobal::powerOfTwoTest validating isPowerOfTwo, nextPowerOfTwo, and nearestPowerOfTwo across edge cases and multiple integer widths.