### PR TITLE
draw the names of group members in rooms other than the player

### DIFF
--- a/src/display/Characters.h
+++ b/src/display/Characters.h
@@ -107,6 +107,7 @@ private:
         std::vector<ColorVert> m_pathPoints;
         std::vector<ColorVert> m_pathLineQuads;
         std::vector<FontVert3d> m_screenSpaceArrows;
+        std::vector<GLText> m_names;
         std::map<Coordinate, int, CoordCompare> m_coordCounts;
 
     public:
@@ -115,15 +116,17 @@ private:
         DELETE_CTORS_AND_ASSIGN_OPS(CharFakeGL);
 
     public:
-        void reallyDraw(OpenGL &gl, const MapCanvasTextures &textures)
+        void reallyDraw(OpenGL &gl, const MapCanvasTextures &textures, GLFont &font)
         {
             reallyDrawCharacters(gl, textures);
             reallyDrawPaths(gl);
+            reallyDrawNames(gl, font);
         }
 
     private:
         void reallyDrawCharacters(OpenGL &gl, const MapCanvasTextures &textures);
         void reallyDrawPaths(OpenGL &gl);
+        void reallyDrawNames(OpenGL &gl, GLFont &font);
 
     public:
         void setColor(const Color color) { m_color = color; }
@@ -151,6 +154,10 @@ private:
         void drawArrow(bool fill, bool beacon);
         void drawBox(const Coordinate &coord, bool fill, bool beacon, bool isFar);
         void addScreenSpaceArrow(const glm::vec3 &pos, float degrees, const Color color, bool fill);
+        void addName(const Coordinate &c,
+                     const std::string &name,
+                     const Color color,
+                     const MapScreen &mapScreen);
         void drawPathSegment(const glm::vec3 &p1, const glm::vec3 &p2, const Color color);
 
         // with blending, without depth; always size 8
@@ -209,13 +216,18 @@ public:
 public:
     void drawCharacter(const Coordinate &coordinate, const Color color, bool fill = true);
 
+    void drawName(const Coordinate &c, const std::string &name, const Color color)
+    {
+        getOpenGL().addName(c, name, color, m_mapScreen);
+    }
+
     void drawPreSpammedPath(const Coordinate &coordinate,
                             const std::vector<Coordinate> &path,
                             const Color color);
 
 public:
-    void reallyDraw(OpenGL &gl, const MapCanvasTextures &textures)
+    void reallyDraw(OpenGL &gl, const MapCanvasTextures &textures, GLFont &font)
     {
-        m_fakeGL.reallyDraw(gl, textures);
+        m_fakeGL.reallyDraw(gl, textures, font);
     }
 };

--- a/src/display/MapCanvasData.h
+++ b/src/display/MapCanvasData.h
@@ -145,6 +145,7 @@ public:
     NODISCARD glm::vec3 getCenter() const;
     NODISCARD bool isRoomVisible(const Coordinate &c, float margin) const;
     NODISCARD glm::vec3 getProxyLocation(const glm::vec3 &pos, float margin) const;
+    NODISCARD const MapCanvasViewport &getViewport() const { return m_viewport; }
 
 private:
     NODISCARD VisiblityResultEnum testVisibility(const glm::vec3 &input_pos, float margin) const;

--- a/src/display/mapcanvas.h
+++ b/src/display/mapcanvas.h
@@ -206,7 +206,7 @@ protected:
     void initializeGL() override;
     void paintGL() override;
 
-    void drawGroupCharacters(CharacterBatch &characterBatch);
+    void drawGroupCharacters(CharacterBatch &characterBatch, ServerRoomId yourServerId);
 
     void resizeGL(int width, int height) override;
     void mousePressEvent(QMouseEvent *event) override;


### PR DESCRIPTION
## Summary by Sourcery

Render group members’ names for players located in other rooms on the map canvas, using room visibility and proxy positions to place labels appropriately.

New Features:
- Display the names of non-local group members in their respective rooms on the map, including when their rooms are off-screen.

Enhancements:
- Integrate additional OpenGL and group management dependencies to support rendering remote group member name labels during character painting.