### PR TITLE
Replace wget with curl for KDE Neon repository

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Add KDE Neon repository
       run: |
-        wget -qO - https://archive.neon.kde.org/public.key | sudo gpg --dearmor -o /usr/share/keyrings/kde-neon.gpg
+        curl -sSfL --retry 5 --retry-delay 5 https://archive.neon.kde.org/public.key | sudo gpg --dearmor --yes -o /usr/share/keyrings/kde-neon.gpg
         echo "deb [signed-by=/usr/share/keyrings/kde-neon.gpg] http://archive.neon.kde.org/user jammy main" | sudo tee /etc/apt/sources.list.d/kde-neon.list
         sudo apt update -qq
 


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Improve robustness of the KDE Neon repository key download in the AppImage GitHub Actions workflow by switching from wget to curl with retries.