### PR TITLE
fix code coverage

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -94,7 +94,7 @@ jobs:
     - if: runner.os == 'macOS'
       name: Install Packages for Mac
       run: |
-        brew install
+        brew install lcov
         echo "MMAPPER_CMAKE_EXTRA=-DCMAKE_PREFIX_PATH=$QT_ROOT_DIR -DUSE_CODE_COVERAGE=true -DPACKAGE_TYPE=Dmg" >> $GITHUB_ENV
 
       #


### PR DESCRIPTION
## Summary by Sourcery

Adjust CI test workflow to correctly generate and upload code coverage reports.

CI:
- Remove unused code coverage configuration on macOS builds.
- Configure lcov to use gcov-13 when resetting and capturing coverage data.
- Update Codecov action configuration to pass the token via inputs instead of environment variables.