### PR TITLE
add audio toolbar and AudioVolumeSlider widget

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -242,6 +242,8 @@ set(mmapper_SRCS
     group/mmapper2group.h
     logger/autologger.cpp
     logger/autologger.h
+    mainwindow/AudioVolumeSlider.cpp
+    mainwindow/AudioVolumeSlider.h
     mainwindow/MapZoomSlider.cpp
     mainwindow/MapZoomSlider.h
     mainwindow/UpdateDialog.cpp

--- a/src/group/mmapper2group.cpp
+++ b/src/group/mmapper2group.cpp
@@ -30,7 +30,7 @@ Mmapper2Group::Mmapper2Group(QObject *const parent)
     , m_groupManagerApi{std::make_unique<GroupManagerApi>(*this)}
 {}
 
-Mmapper2Group::~Mmapper2Group() {}
+Mmapper2Group::~Mmapper2Group() = default;
 
 SharedGroupChar Mmapper2Group::getSelf()
 {

--- a/src/mainwindow/AudioVolumeSlider.cpp
+++ b/src/mainwindow/AudioVolumeSlider.cpp
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+#include "AudioVolumeSlider.h"
+
+#include "../configuration/configuration.h"
+#include "../global/SignalBlocker.h"
+
+#include <QWheelEvent>
+
+AudioVolumeSlider::AudioVolumeSlider(QWidget *const parent)
+    : QSlider(Qt::Orientation::Horizontal, parent)
+{
+    init();
+}
+
+AudioVolumeSlider::AudioVolumeSlider(AudioType type, QWidget *const parent)
+    : QSlider(Qt::Orientation::Horizontal, parent)
+    , m_type(type)
+{
+    init();
+}
+
+AudioVolumeSlider::~AudioVolumeSlider() = default;
+
+void AudioVolumeSlider::init()
+{
+    setRange(0, 100);
+    connect(this, &QSlider::valueChanged, this, [this](int value) { updateToConfig(value); });
+
+    setConfig().audio.registerChangeCallback(m_lifetime, [this]() { updateFromConfig(); });
+
+    if constexpr (NO_AUDIO) {
+        setEnabled(false);
+    }
+    setAudioType(m_type);
+}
+
+void AudioVolumeSlider::setAudioType(AudioType type)
+{
+    if (m_type == type && toolTip().length() > 0) {
+        return;
+    }
+
+    m_type = type;
+    updateFromConfig();
+
+    switch (m_type) {
+    case AudioType::Music:
+        setToolTip(tr("Music Volume"));
+        break;
+    case AudioType::Sound:
+        setToolTip(tr("Sound Volume"));
+        break;
+    }
+}
+
+void AudioVolumeSlider::updateFromConfig()
+{
+    int actualVolume = 0;
+    switch (m_type) {
+    case AudioType::Music:
+        actualVolume = getConfig().audio.getMusicVolume();
+        break;
+    case AudioType::Sound:
+        actualVolume = getConfig().audio.getSoundVolume();
+        break;
+    }
+
+    if (value() != actualVolume) {
+        const SignalBlocker block{*this};
+        setValue(actualVolume);
+    }
+}
+
+void AudioVolumeSlider::updateToConfig(int value)
+{
+    auto &audioSettings = setConfig().audio;
+    switch (m_type) {
+    case AudioType::Music:
+        if (audioSettings.getMusicVolume() != value) {
+            audioSettings.setMusicVolume(value);
+            audioSettings.setUnlocked();
+        }
+        break;
+    case AudioType::Sound:
+        if (audioSettings.getSoundVolume() != value) {
+            audioSettings.setSoundVolume(value);
+            audioSettings.setUnlocked();
+        }
+        break;
+    }
+}
+
+void AudioVolumeSlider::wheelEvent(QWheelEvent *event)
+{
+    event->ignore();
+}

--- a/src/mainwindow/AudioVolumeSlider.h
+++ b/src/mainwindow/AudioVolumeSlider.h
@@ -1,0 +1,42 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+#include "../global/RuleOf5.h"
+#include "../global/Signal2.h"
+#include "../global/macros.h"
+
+#include <QSlider>
+
+class NODISCARD_QOBJECT AudioVolumeSlider final : public QSlider
+{
+    Q_OBJECT
+    Q_PROPERTY(AudioType audioType READ audioType WRITE setAudioType)
+
+public:
+    enum class NODISCARD AudioType : uint8_t { Music, Sound };
+    Q_ENUM(AudioType)
+
+private:
+    Signal2Lifetime m_lifetime;
+    AudioType m_type = AudioType::Music;
+
+public:
+    explicit AudioVolumeSlider(QWidget *parent = nullptr);
+    explicit AudioVolumeSlider(AudioType type, QWidget *parent = nullptr);
+    ~AudioVolumeSlider() final;
+    DELETE_CTORS_AND_ASSIGN_OPS(AudioVolumeSlider);
+
+public:
+    NODISCARD AudioType audioType() const { return m_type; }
+    void setAudioType(AudioType type);
+
+    void updateFromConfig();
+
+protected:
+    void wheelEvent(QWheelEvent *event) override;
+
+private:
+    void init();
+    void updateToConfig(int value);
+};

--- a/src/mainwindow/MapZoomSlider.cpp
+++ b/src/mainwindow/MapZoomSlider.cpp
@@ -6,6 +6,8 @@
 #include "../display/mapwindow.h"
 #include "../global/SignalBlocker.h"
 
+#include <QWheelEvent>
+
 MapZoomSlider::~MapZoomSlider() = default;
 
 int MapZoomSlider::calcPos(const float zoom) noexcept
@@ -48,4 +50,9 @@ void MapZoomSlider::setFromActual()
         const SignalBlocker block{*this};
         setValue(clamp(rounded));
     }
+}
+
+void MapZoomSlider::wheelEvent(QWheelEvent *event)
+{
+    event->ignore();
 }

--- a/src/mainwindow/MapZoomSlider.h
+++ b/src/mainwindow/MapZoomSlider.h
@@ -31,6 +31,9 @@ public:
 
     void setFromActual();
 
+protected:
+    void wheelEvent(QWheelEvent *event) override;
+
 private:
     static int clamp(int val) { return std::clamp(val, min, max); }
 };

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -33,6 +33,7 @@
 #include "../roompanel/RoomManager.h"
 #include "../roompanel/RoomWidget.h"
 #include "../viewers/TopLevelWindows.h"
+#include "AudioVolumeSlider.h"
 #include "MapZoomSlider.h"
 #include "UpdateDialog.h"
 #include "aboutdialog.h"
@@ -1185,6 +1186,7 @@ void MainWindow::setupMenuBar()
     toolbars->addAction(roomToolBar->toggleViewAction());
     toolbars->addAction(connectionToolBar->toggleViewAction());
     toolbars->addAction(settingsToolBar->toggleViewAction());
+    toolbars->addAction(audioToolBar->toggleViewAction());
     QMenu *sidepanels = viewMenu->addMenu(tr("&Side Panels"));
     sidepanels->addAction(m_dockDialogLog->toggleViewAction());
     sidepanels->addAction(m_dockDialogClient->toggleViewAction());
@@ -1428,6 +1430,15 @@ void MainWindow::setupToolBars()
     settingsToolBar->setObjectName("PreferencesToolBar");
     settingsToolBar->addAction(preferencesAct);
     settingsToolBar->hide();
+
+    audioToolBar = addToolBar(tr("Audio"));
+    audioToolBar->setObjectName("AudioToolBar");
+    audioToolBar->addWidget(
+        new AudioVolumeSlider(AudioVolumeSlider::AudioType::Music, audioToolBar));
+    audioToolBar->addSeparator();
+    audioToolBar->addWidget(
+        new AudioVolumeSlider(AudioVolumeSlider::AudioType::Sound, audioToolBar));
+    audioToolBar->hide();
 }
 
 void MainWindow::setupStatusBar()

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -135,6 +135,7 @@ private:
     QToolBar *roomToolBar = nullptr;
     QToolBar *connectionToolBar = nullptr;
     QToolBar *settingsToolBar = nullptr;
+    QToolBar *audioToolBar = nullptr;
 
     QMenu *fileMenu = nullptr;
     QMenu *editMenu = nullptr;

--- a/src/media/DescriptionWidget.h
+++ b/src/media/DescriptionWidget.h
@@ -19,8 +19,8 @@ class NODISCARD_QOBJECT DescriptionWidget final : public QWidget
 private:
     MediaLibrary &m_library;
 
-    QLabel *m_label;
-    QTextEdit *m_textEdit;
+    QLabel *m_label = nullptr;
+    QTextEdit *m_textEdit = nullptr;
 
 private:
     QCache<QString, QImage> m_imageCache;

--- a/src/media/MediaLibrary.h
+++ b/src/media/MediaLibrary.h
@@ -33,8 +33,8 @@ private:
 public:
     explicit MediaLibrary(QObject *parent = nullptr);
 
-    QString findAudio(const QString &subDir, const QString &name) const;
-    QString findImage(const QString &subDir, const QString &name) const;
+    NODISCARD QString findAudio(const QString &subDir, const QString &name) const;
+    NODISCARD QString findImage(const QString &subDir, const QString &name) const;
 
     void fetchAsync(const QString &path, std::function<void(const QByteArray &)> callback);
 

--- a/src/media/MusicManager.cpp
+++ b/src/media/MusicManager.cpp
@@ -124,7 +124,7 @@ void MusicManager::shutdown()
 #endif
 }
 
-void MusicManager::playMusic(const QString &musicFile)
+void MusicManager::playMusic(MAYBE_UNUSED const QString &musicFile)
 {
 #ifndef MMAPPER_NO_AUDIO
     if (musicFile.isEmpty() || NO_AUDIO) {

--- a/src/media/MusicManager.h
+++ b/src/media/MusicManager.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (C) 2026 The MMapper Authors
 
+#include "../global/RuleOf5.h"
 #include "../global/macros.h"
 
 #include <QCache>
@@ -36,7 +37,7 @@ private:
         float fadeVolume = 0.0f;
     };
 
-    MusicChannel m_channels[2];
+    MusicChannel m_channels[2]; // TODO: use std::array or MMapper::Array
     int m_activeChannel = 0;
     QCache<QString, qint64> m_cachedPositions;
     QCache<QString, QTemporaryFile> m_wasmFiles;
@@ -52,6 +53,7 @@ private:
 public:
     explicit MusicManager(MediaLibrary &library, QObject *parent = nullptr);
     ~MusicManager() override;
+    DELETE_CTORS_AND_ASSIGN_OPS(MusicManager);
 
     void playMusic(const QString &musicFile);
     void stopMusic();

--- a/src/media/SfxManager.cpp
+++ b/src/media/SfxManager.cpp
@@ -98,7 +98,7 @@ void SfxManager::playFromData(const QByteArray &data, const QString &soundName)
 #endif
 }
 
-void SfxManager::startEffect(const QUrl &url, const QString &tmpToDelete)
+void SfxManager::startEffect(MAYBE_UNUSED const QUrl &url, MAYBE_UNUSED const QString &tmpToDelete)
 {
 #ifndef MMAPPER_NO_AUDIO
     auto *effect = new QMediaPlayer(this);

--- a/src/media/SfxManager.h
+++ b/src/media/SfxManager.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (C) 2026 The MMapper Authors
 
+#include "../global/RuleOf5.h"
 #include "../global/macros.h"
 
 #include <QObject>
@@ -22,13 +23,14 @@ class NODISCARD_QOBJECT SfxManager final : public QObject
 
 private:
 #ifndef MMAPPER_NO_AUDIO
-    QAudioOutput *m_output;
+    QAudioOutput *m_output = nullptr;
 #endif
     MediaLibrary &m_library;
 
 public:
     explicit SfxManager(MediaLibrary &library, QObject *parent = nullptr);
     ~SfxManager() override;
+    DELETE_CTORS_AND_ASSIGN_OPS(SfxManager);
 
     void shutdown();
     void playSound(const QString &soundName);

--- a/src/preferences/AdvancedGraphics.cpp
+++ b/src/preferences/AdvancedGraphics.cpp
@@ -24,7 +24,7 @@
 #include <QVector>
 #include <QWidget>
 
-SliderSpinboxButton::~SliderSpinboxButton() {}
+SliderSpinboxButton::~SliderSpinboxButton() = default;
 
 template<int D>
 class NODISCARD FpSlider final : public QSlider

--- a/src/preferences/audiopage.cpp
+++ b/src/preferences/audiopage.cpp
@@ -5,6 +5,7 @@
 
 #include "../configuration/configuration.h"
 #include "../global/SignalBlocker.h"
+#include "../mainwindow/AudioVolumeSlider.h"
 #include "ui_audiopage.h"
 
 #ifndef MMAPPER_NO_AUDIO
@@ -21,14 +22,6 @@ AudioPage::AudioPage(QWidget *const parent)
     slot_updateDevices();
     slot_loadConfig();
 
-    connect(ui->musicVolumeSlider,
-            &QSlider::valueChanged,
-            this,
-            &AudioPage::slot_musicVolumeChanged);
-    connect(ui->soundsVolumeSlider,
-            &QSlider::valueChanged,
-            this,
-            &AudioPage::slot_soundsVolumeChanged);
     connect(ui->outputDeviceComboBox,
             &QComboBox::currentIndexChanged,
             this,
@@ -41,8 +34,6 @@ AudioPage::AudioPage(QWidget *const parent)
 
     if constexpr (NO_AUDIO) {
         ui->outputDeviceComboBox->setEnabled(false);
-        ui->musicVolumeSlider->setEnabled(false);
-        ui->soundsVolumeSlider->setEnabled(false);
     }
 }
 
@@ -58,8 +49,8 @@ void AudioPage::slot_loadConfig()
     SignalBlocker outputBlocker(*ui->outputDeviceComboBox);
 
     const auto &settings = getConfig().audio;
-    ui->musicVolumeSlider->setValue(settings.getMusicVolume());
-    ui->soundsVolumeSlider->setValue(settings.getSoundVolume());
+    ui->musicVolumeSlider->updateFromConfig();
+    ui->soundsVolumeSlider->updateFromConfig();
 
     int index = ui->outputDeviceComboBox->findData(settings.getOutputDeviceId());
     if (index != -1) {
@@ -67,20 +58,6 @@ void AudioPage::slot_loadConfig()
     } else {
         ui->outputDeviceComboBox->setCurrentIndex(0);
     }
-}
-
-void AudioPage::slot_musicVolumeChanged(int value)
-{
-    auto &settings = setConfig().audio;
-    settings.setMusicVolume(value);
-    settings.setUnlocked();
-}
-
-void AudioPage::slot_soundsVolumeChanged(int value)
-{
-    auto &settings = setConfig().audio;
-    settings.setSoundVolume(value);
-    settings.setUnlocked();
 }
 
 void AudioPage::slot_outputDeviceChanged(int index)

--- a/src/preferences/audiopage.h
+++ b/src/preferences/audiopage.h
@@ -23,8 +23,6 @@ public:
 
 public slots:
     void slot_loadConfig();
-    void slot_musicVolumeChanged(int);
-    void slot_soundsVolumeChanged(int);
     void slot_outputDeviceChanged(int);
     void slot_updateDevices();
 };

--- a/src/preferences/audiopage.ui
+++ b/src/preferences/audiopage.ui
@@ -44,12 +44,9 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QSlider" name="musicVolumeSlider">
-        <property name="maximum">
-         <number>100</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+       <widget class="AudioVolumeSlider" name="musicVolumeSlider">
+        <property name="audioType">
+         <enum>AudioVolumeSlider::AudioType::Music</enum>
         </property>
        </widget>
       </item>
@@ -70,12 +67,9 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QSlider" name="soundsVolumeSlider">
-        <property name="maximum">
-         <number>100</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+       <widget class="AudioVolumeSlider" name="soundsVolumeSlider">
+        <property name="audioType">
+         <enum>AudioVolumeSlider::AudioType::Sound</enum>
         </property>
        </widget>
       </item>
@@ -97,6 +91,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>AudioVolumeSlider</class>
+   <extends>QSlider</extends>
+   <header>mainwindow/AudioVolumeSlider.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -146,6 +146,8 @@ add_test(NAME TestProxy COMMAND TestProxy)
 # MainWindow
 set(mainwindow_SRCS
     ../src/global/Version.h
+    ../src/mainwindow/AudioVolumeSlider.cpp
+    ../src/mainwindow/AudioVolumeSlider.h
     ../src/mainwindow/UpdateDialog.cpp
     ../src/mainwindow/UpdateDialog.h
     )

--- a/tests/TestMainWindow.cpp
+++ b/tests/TestMainWindow.cpp
@@ -3,10 +3,13 @@
 
 #include "TestMainWindow.h"
 
+#include "../src/configuration/configuration.h"
 #include "../src/global/Version.h"
+#include "../src/mainwindow/AudioVolumeSlider.h"
 #include "../src/mainwindow/UpdateDialog.h"
 
 #include <QDebug>
+#include <QScopeGuard>
 #include <QtTest/QtTest>
 
 const char *getMMapperVersion()
@@ -47,6 +50,41 @@ void TestMainWindow::updaterTest()
     CompareVersion newerPatch{"2.9.0"};
     QVERIFY2(newerPatch > current, "Newer major version is greater than older version");
     QVERIFY2((current > newerPatch) == false, "Older version is not newer than newer patch version");
+}
+
+void TestMainWindow::audioToolbarTest()
+{
+    setEnteredMain();
+
+    const int originalMusic = getConfig().audio.getMusicVolume();
+    const int originalSound = getConfig().audio.getSoundVolume();
+
+    // Ensure we restore configuration
+    auto cleanup = qScopeGuard([=]() {
+        setConfig().audio.setMusicVolume(originalMusic);
+        setConfig().audio.setSoundVolume(originalSound);
+    });
+
+    AudioVolumeSlider musicSlider(AudioVolumeSlider::AudioType::Music);
+    AudioVolumeSlider soundSlider(AudioVolumeSlider::AudioType::Sound);
+
+    // Initial value should match current config defaults
+    QCOMPARE(musicSlider.value(), getConfig().audio.getMusicVolume());
+    QCOMPARE(soundSlider.value(), getConfig().audio.getSoundVolume());
+
+    // Update config -> slider updates
+    setConfig().audio.setMusicVolume(75);
+    QCOMPARE(musicSlider.value(), 75);
+
+    setConfig().audio.setSoundVolume(25);
+    QCOMPARE(soundSlider.value(), 25);
+
+    // Update slider -> config updates
+    musicSlider.setValue(90);
+    QCOMPARE(getConfig().audio.getMusicVolume(), 90);
+
+    soundSlider.setValue(10);
+    QCOMPARE(getConfig().audio.getSoundVolume(), 10);
 }
 
 QTEST_MAIN(TestMainWindow)

--- a/tests/TestMainWindow.h
+++ b/tests/TestMainWindow.h
@@ -17,4 +17,5 @@ public:
 private:
 private Q_SLOTS:
     void updaterTest();
+    void audioToolbarTest();
 };


### PR DESCRIPTION
## Summary by Sourcery

Introduce a reusable AudioVolumeSlider widget and integrate an audio toolbar into the main window while tightening audio-related ownership, configuration wiring, and slider behavior.

New Features:
- Add an audio toolbar to the main window with separate music and sound volume controls backed by configuration.
- Introduce a reusable AudioVolumeSlider widget that synchronizes music and sound volume with the global audio configuration and can be used across the UI.

Enhancements:
- Refactor the audio preferences page to use AudioVolumeSlider instances instead of manual slider–configuration wiring.
- Disable mouse wheel handling on zoom and audio sliders to avoid accidental value changes when scrolling.
- Strengthen media and audio manager classes with explicit Rule-of-5 helpers, nodiscard annotations, defaulted destructors, and safer member initialization.
- Guard the AudioVolumeSlider against configuration changes via a lifetime-tracked callback to keep UI volume controls in sync with settings.

Build:
- Register the new AudioVolumeSlider sources in the main application and test CMake targets.

Tests:
- Extend TestMainWindow with an audioToolbarTest to verify that AudioVolumeSlider instances stay in sync with configuration changes in both directions.