### PR TITLE
add timers panel

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -591,6 +591,12 @@ set(mmapper_SRCS
     syntax/Value.h
     timers/CTimers.cpp
     timers/CTimers.h
+    timers/TimerModel.cpp
+    timers/TimerModel.h
+    timers/TimerDelegate.cpp
+    timers/TimerDelegate.h
+    timers/TimerWidget.cpp
+    timers/TimerWidget.h
     viewers/AnsiViewWindow.cpp
     viewers/AnsiViewWindow.h
     viewers/LaunchAsyncViewer.h

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -32,6 +32,8 @@
 #include "../proxy/connectionlistener.h"
 #include "../roompanel/RoomManager.h"
 #include "../roompanel/RoomWidget.h"
+#include "../timers/CTimers.h"
+#include "../timers/TimerWidget.h"
 #include "../viewers/TopLevelWindows.h"
 #include "AudioVolumeSlider.h"
 #include "MapZoomSlider.h"
@@ -218,6 +220,16 @@ MainWindow::MainWindow()
     addDockWidget(Qt::RightDockWidgetArea, m_dockDialogDescription);
     m_dockDialogDescription->setWidget(m_descriptionWidget);
 
+    m_timers = new CTimers(this);
+    m_timerWidget = new TimerWidget(deref(m_timers), this);
+    m_dockDialogTimers = new QDockWidget(tr("Timers Panel"), this);
+    m_dockDialogTimers->setObjectName("DockWidgetTimers");
+    m_dockDialogTimers->setFeatures(QDockWidget::DockWidgetMovable
+                                    | QDockWidget::DockWidgetFloatable
+                                    | QDockWidget::DockWidgetClosable);
+    m_dockDialogTimers->setWidget(m_timerWidget);
+    m_dockDialogTimers->hide();
+
     m_mumeClock = new MumeClock(getConfig().mumeClock.startEpoch, deref(m_gameObserver), this);
     if constexpr (!NO_UPDATER) {
         m_updateDialog = new UpdateDialog(this);
@@ -246,6 +258,7 @@ MainWindow::MainWindow()
                                         deref(m_prespammedPath),
                                         deref(m_groupManager),
                                         deref(m_mumeClock),
+                                        deref(m_timers),
                                         deref(getCanvas()),
                                         deref(m_gameObserver),
                                         this);
@@ -259,6 +272,7 @@ MainWindow::MainWindow()
     m_dockDialogClient->setFeatures(QDockWidget::DockWidgetMovable
                                     | QDockWidget::DockWidgetFloatable
                                     | QDockWidget::DockWidgetClosable);
+    addDockWidget(Qt::RightDockWidgetArea, m_dockDialogTimers);
     addDockWidget(Qt::LeftDockWidgetArea, m_dockDialogClient);
     m_dockDialogClient->setWidget(m_clientWidget);
 
@@ -1194,6 +1208,7 @@ void MainWindow::setupMenuBar()
     sidepanels->addAction(m_dockDialogRoom->toggleViewAction());
     sidepanels->addAction(m_dockDialogAdventure->toggleViewAction());
     sidepanels->addAction(m_dockDialogDescription->toggleViewAction());
+    sidepanels->addAction(m_dockDialogTimers->toggleViewAction());
     viewMenu->addSeparator();
     viewMenu->addAction(zoomInAct);
     viewMenu->addAction(zoomOutAct);

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -52,6 +52,7 @@ class Mmapper2Group;
 class Mmapper2PathMachine;
 class MumeClock;
 class PrespammedPath;
+class CTimers;
 class QAction;
 class QActionGroup;
 class QCloseEvent;
@@ -71,6 +72,7 @@ class RoomWidget;
 class UpdateDialog;
 class DescriptionWidget;
 class MediaLibrary;
+class TimerWidget;
 struct MapLoadData;
 class MapDestination;
 
@@ -90,6 +92,7 @@ private:
     QDockWidget *m_dockDialogGroup = nullptr;
     QDockWidget *m_dockDialogAdventure = nullptr;
     QDockWidget *m_dockDialogDescription = nullptr;
+    QDockWidget *m_dockDialogTimers = nullptr;
 
     std::unique_ptr<GameObserver> m_gameObserver;
     AutoLogger *m_logger = nullptr;
@@ -98,6 +101,7 @@ private:
     MapData *m_mapData = nullptr;
     PrespammedPath *m_prespammedPath = nullptr;
     MumeClock *m_mumeClock = nullptr;
+    CTimers *m_timers = nullptr;
 
     // Pandora Ported
     FindRoomsDlg *m_findRoomsDlg = nullptr;
@@ -116,6 +120,7 @@ private:
     AudioManager *m_audioManager = nullptr;
 
     DescriptionWidget *m_descriptionWidget = nullptr;
+    TimerWidget *m_timerWidget = nullptr;
     std::unique_ptr<HotkeyManager> m_hotkeyManager;
 
     QPointer<QMenu> m_contextMenu;
@@ -279,6 +284,7 @@ public:
     ~MainWindow() final;
 
     NODISCARD HotkeyManager &getHotkeyManager() const { return deref(m_hotkeyManager); }
+    NODISCARD CTimers &getTimers() const { return deref(m_timers); }
 
     NODISCARD bool saveFile(const QString &fileName, SaveModeEnum mode, SaveFormatEnum format);
     void loadFile(std::shared_ptr<MapSource> source);

--- a/src/parser/abstractparser.h
+++ b/src/parser/abstractparser.h
@@ -149,11 +149,11 @@ public:
 
 public:
     // accessed by initActionMap
-    CTimers timers;
+    CTimers &timers;
 
 public:
-    explicit ParserCommonData(QObject *parent)
-        : timers{parent}
+    explicit ParserCommonData(CTimers &t)
+        : timers{t}
     {}
 };
 

--- a/src/proxy/connectionlistener.cpp
+++ b/src/proxy/connectionlistener.cpp
@@ -36,6 +36,7 @@ ConnectionListener::ConnectionListener(MapData &md,
                                        PrespammedPath &pp,
                                        Mmapper2Group &gm,
                                        MumeClock &mc,
+                                       CTimers &ct,
                                        MapCanvas &mca,
                                        GameObserver &go,
                                        QObject *const parent)
@@ -45,6 +46,7 @@ ConnectionListener::ConnectionListener(MapData &md,
     , m_prespammedPath{pp}
     , m_groupManager{gm}
     , m_mumeClock{mc}
+    , m_timers{ct}
     , m_mapCanvas{mca}
     , m_gameOberver{go}
 {}
@@ -107,6 +109,7 @@ void ConnectionListener::startClient(std::unique_ptr<AbstractSocket> socket)
                                    m_prespammedPath,
                                    m_groupManager,
                                    m_mumeClock,
+                                   m_timers,
                                    m_mapCanvas,
                                    m_gameOberver,
                                    std::move(socket),

--- a/src/proxy/connectionlistener.h
+++ b/src/proxy/connectionlistener.h
@@ -23,6 +23,7 @@ class MapData;
 class Mmapper2Group;
 class Mmapper2PathMachine;
 class MumeClock;
+class CTimers;
 class PrespammedPath;
 class Proxy;
 class QObject;
@@ -58,6 +59,7 @@ private:
     PrespammedPath &m_prespammedPath;
     Mmapper2Group &m_groupManager;
     MumeClock &m_mumeClock;
+    CTimers &m_timers;
     MapCanvas &m_mapCanvas;
     GameObserver &m_gameOberver;
     using ServerList = std::vector<QPointer<ConnectionListenerTcpServer>>;
@@ -70,6 +72,7 @@ public:
                                 PrespammedPath &,
                                 Mmapper2Group &,
                                 MumeClock &,
+                                CTimers &,
                                 MapCanvas &,
                                 GameObserver &,
                                 QObject *parent);

--- a/src/proxy/proxy.cpp
+++ b/src/proxy/proxy.cpp
@@ -135,13 +135,14 @@ QPointer<Proxy> Proxy::allocInit(MapData &md,
                                  PrespammedPath &pp,
                                  Mmapper2Group &gm,
                                  MumeClock &mc,
+                                 CTimers &ct,
                                  MapCanvas &mca,
                                  GameObserver &go,
                                  std::unique_ptr<AbstractSocket> userSocket,
                                  ConnectionListener &listener)
 {
     auto proxy = makeQPointer<Proxy>(
-        Badge<Proxy>{}, md, pm, pp, gm, mc, mca, go, std::move(userSocket), listener);
+        Badge<Proxy>{}, md, pm, pp, gm, mc, ct, mca, go, std::move(userSocket), listener);
     deref(proxy).init();
     return proxy;
 }
@@ -152,6 +153,7 @@ Proxy::Proxy(Badge<Proxy>,
              PrespammedPath &pp,
              Mmapper2Group &gm,
              MumeClock &mc,
+             CTimers &ct,
              MapCanvas &mca,
              GameObserver &go,
              std::unique_ptr<AbstractSocket> userSocket,
@@ -162,6 +164,7 @@ Proxy::Proxy(Badge<Proxy>,
     , m_prespammedPath(pp)
     , m_groupManager(gm)
     , m_mumeClock(mc)
+    , m_timers(ct)
     , m_mapCanvas(mca)
     , m_gameObserver(go)
     // REVISIT: It would be better to just pass in the MainWindow directly.
@@ -709,12 +712,8 @@ void Proxy::allocParser()
     auto &gmcp = pipe.apis.proxyGmcp = std::make_unique<ProxyUserGmcpApi>(*this);
     auto &out = pipe.outputs.parserXmlOutputs = std::make_unique<LocalParserOutputs>(*this);
 
-    // REVISIIT: does CTimers actually need a parent?
-    // if so, figure out what and allocate it into the pipeline if necessary?
-    QObject *fakeCTimersParent = nullptr;
-
     auto &parserCommon = pipe.common.parserCommonData;
-    parserCommon = std::make_unique<ParserCommonData>(fakeCTimersParent);
+    parserCommon = std::make_unique<ParserCommonData>(m_timers);
 
     /* this duplication is ridiculous, but it's painful to tease these two apart
      * because compiling takes so long. */

--- a/src/proxy/proxy.h
+++ b/src/proxy/proxy.h
@@ -74,6 +74,7 @@ private:
     PrespammedPath &m_prespammedPath;
     Mmapper2Group &m_groupManager;
     MumeClock &m_mumeClock;
+    CTimers &m_timers;
     MapCanvas &m_mapCanvas;
     GameObserver &m_gameObserver;
     MainWindow &m_mainWindow;
@@ -171,6 +172,7 @@ public:
                                                PrespammedPath &,
                                                Mmapper2Group &,
                                                MumeClock &,
+                                               CTimers &,
                                                MapCanvas &,
                                                GameObserver &,
                                                std::unique_ptr<AbstractSocket>,
@@ -183,6 +185,7 @@ public:
                    PrespammedPath &,
                    Mmapper2Group &,
                    MumeClock &,
+                   CTimers &,
                    MapCanvas &,
                    GameObserver &,
                    std::unique_ptr<AbstractSocket>,

--- a/src/timers/CTimers.cpp
+++ b/src/timers/CTimers.cpp
@@ -6,12 +6,14 @@
 #include "../global/thread_utils.h"
 #include "../global/utils.h"
 
+#include <algorithm>
 #include <chrono>
 #include <iomanip>
 #include <iostream>
 #include <optional>
 #include <sstream>
 #include <string>
+#include <tuple>
 #include <vector>
 
 namespace { // anonymous
@@ -53,7 +55,18 @@ TTimer::TTimer(std::string name, std::string desc)
 
 int64_t TTimer::elapsedMs() const
 {
+    if (m_expired) {
+        return m_duration;
+    }
     return nowMs() - m_start;
+}
+
+int64_t TTimer::remainingMs() const
+{
+    if (m_expired) {
+        return 0;
+    }
+    return std::max<int64_t>(0, m_duration - elapsedMs());
 }
 
 CTimers::CTimers(QObject *const parent)
@@ -67,86 +80,202 @@ CTimers::CTimers(QObject *const parent)
 void CTimers::addTimer(std::string name, std::string desc)
 {
     ABORT_IF_NOT_ON_MAIN_THREAD();
-    m_timers.emplace_back(std::move(name), std::move(desc));
+    std::ignore = removeTimer(name);
+
+    // Insert before first expired timer
+    auto it = std::find_if(m_allTimers.begin(), m_allTimers.end(), [](const TTimer &t) {
+        return t.isExpired();
+    });
+    m_allTimers.emplace(it, std::move(name), std::move(desc));
+
+    emit sig_timerAdded();
 }
 
 bool CTimers::removeCountdown(const std::string &name)
 {
     ABORT_IF_NOT_ON_MAIN_THREAD();
-    return utils::listRemoveIf(m_countdowns, [&name](const TTimer &timer) -> bool {
-        return timer.getName() == name;
+    const bool removed = utils::listRemoveIf(m_allTimers, [&name](const TTimer &timer) -> bool {
+        return timer.isCountdown() && timer.getName() == name;
     });
+    if (removed) {
+        restartCountdownTimer();
+        emit sig_timerRemoved();
+    }
+    return removed;
 }
 
 bool CTimers::removeTimer(const std::string &name)
 {
     ABORT_IF_NOT_ON_MAIN_THREAD();
-    return utils::listRemoveIf(m_timers, [&name](const TTimer &timer) -> bool {
-        return timer.getName() == name;
+    const bool removed = utils::listRemoveIf(m_allTimers, [&name](const TTimer &timer) -> bool {
+        return !timer.isCountdown() && timer.getName() == name;
     });
+    if (removed) {
+        emit sig_timerRemoved();
+    }
+    return removed;
 }
 
 void CTimers::addCountdown(std::string name, std::string desc, int64_t timeMs)
 {
     ABORT_IF_NOT_ON_MAIN_THREAD();
-    m_countdowns.emplace_back(std::move(name), std::move(desc), timeMs);
+    std::ignore = removeCountdown(name);
 
-    // See if we need to restart the timer
-    if (m_timer.isActive()) {
-        std::chrono::milliseconds left = m_timer.remainingTimeAsDuration();
-        if (timeMs < left.count()) {
-            m_timer.stop();
-            m_timer.start(static_cast<int>(timeMs));
+    // Insert before first expired timer
+    auto it = std::find_if(m_allTimers.begin(), m_allTimers.end(), [](const TTimer &t) {
+        return t.isExpired();
+    });
+    m_allTimers.emplace(it, std::move(name), std::move(desc), timeMs);
+
+    restartCountdownTimer();
+    emit sig_timerAdded();
+}
+
+void CTimers::stopTimer(const std::string &name)
+{
+    ABORT_IF_NOT_ON_MAIN_THREAD();
+    for (auto it = m_allTimers.begin(); it != m_allTimers.end(); ++it) {
+        if (!it->isCountdown() && it->getName() == name) {
+            it->setExpired(true);
+            // Move to end
+            m_allTimers.splice(m_allTimers.end(), m_allTimers, it);
+            emit sig_timersUpdated();
+            break;
         }
-        return;
     }
+}
 
-    // Start the timer
-    m_timer.start(static_cast<int>(timeMs));
+void CTimers::stopCountdown(const std::string &name)
+{
+    ABORT_IF_NOT_ON_MAIN_THREAD();
+    for (auto it = m_allTimers.begin(); it != m_allTimers.end(); ++it) {
+        if (it->isCountdown() && it->getName() == name) {
+            it->setExpired(true);
+            // Move to end
+            m_allTimers.splice(m_allTimers.end(), m_allTimers, it);
+            restartCountdownTimer();
+            emit sig_timersUpdated();
+            break;
+        }
+    }
+}
+
+void CTimers::resetTimer(const std::string &name)
+{
+    ABORT_IF_NOT_ON_MAIN_THREAD();
+    for (auto it = m_allTimers.begin(); it != m_allTimers.end(); ++it) {
+        if (!it->isCountdown() && it->getName() == name) {
+            *it = TTimer(it->getName(), it->getDescription());
+            // Move before first expired timer
+            auto itExp = std::find_if(m_allTimers.begin(), m_allTimers.end(), [](const TTimer &t) {
+                return t.isExpired();
+            });
+            m_allTimers.splice(itExp, m_allTimers, it);
+            emit sig_timersUpdated();
+            break;
+        }
+    }
+}
+
+void CTimers::resetCountdown(const std::string &name)
+{
+    ABORT_IF_NOT_ON_MAIN_THREAD();
+    for (auto it = m_allTimers.begin(); it != m_allTimers.end(); ++it) {
+        if (it->isCountdown() && it->getName() == name) {
+            *it = TTimer(it->getName(), it->getDescription(), it->durationMs());
+            // Move before first expired timer
+            auto itExp = std::find_if(m_allTimers.begin(), m_allTimers.end(), [](const TTimer &t) {
+                return t.isExpired();
+            });
+            m_allTimers.splice(itExp, m_allTimers, it);
+            restartCountdownTimer();
+            emit sig_timersUpdated();
+            break;
+        }
+    }
+}
+
+void CTimers::clearExpired()
+{
+    ABORT_IF_NOT_ON_MAIN_THREAD();
+    const bool removed = utils::erase_if(m_allTimers, [](const TTimer &t) { return t.isExpired(); })
+                         > 0;
+    if (removed) {
+        emit sig_timerRemoved();
+    }
 }
 
 void CTimers::slot_finishCountdownTimer()
 {
     ABORT_IF_NOT_ON_MAIN_THREAD();
 
-    static auto get_diff = [](const TTimer &t) -> int64_t { return t.durationMs() - t.elapsedMs(); };
-
     // See if we need to restart the timer
     {
         std::vector<std::string> updates;
-        utils::erase_if(m_countdowns, [&updates](TTimer &t) -> bool {
-            if (get_diff(t) > 0) {
-                return false;
+        bool anyFinished = false;
+
+        auto it = m_allTimers.begin();
+        while (it != m_allTimers.end()) {
+            if (!it->isCountdown() || it->isExpired() || it->remainingMs() > 0) {
+                ++it;
+                continue;
             }
+
+            it->setExpired(true);
+            anyFinished = true;
+
             std::ostringstream ostr;
-            ostr << "Countdown timer " << t.getName();
-            if (!t.getDescription().empty()) {
-                ostr << " <" << t.getDescription() << ">";
+            ostr << "Countdown timer " << it->getName();
+            if (!it->getDescription().empty()) {
+                ostr << " <" << it->getDescription() << ">";
             }
-            // why does this include a newline?
             ostr << " finished.\n";
             updates.emplace_back(std::move(ostr).str());
-            return true;
-        });
+
+            // Move to end
+            auto toMove = it;
+            ++it;
+            m_allTimers.splice(m_allTimers.end(), m_allTimers, toMove);
+        }
+
         for (const std::string &s : updates) {
             emit sig_sendTimersUpdateToUser(s);
         }
+        if (anyFinished) {
+            emit sig_timersUpdated();
+        }
     }
 
-    // Why do we return before stopping the timer?
-    if (m_countdowns.empty()) {
+    restartCountdownTimer();
+}
+
+void CTimers::restartCountdownTimer()
+{
+    ABORT_IF_NOT_ON_MAIN_THREAD();
+
+    m_timer.stop();
+
+    static auto get_diff = [](const TTimer &t) -> int64_t { return t.remainingMs(); };
+
+    std::vector<TTimer> activeCountdowns;
+    for (const auto &t : m_allTimers) {
+        if (t.isCountdown() && !t.isExpired()) {
+            activeCountdowns.push_back(t);
+        }
+    }
+
+    if (activeCountdowns.empty()) {
         return;
     }
 
-    // Why do we stop unconditionally and then restart?
-    if (m_timer.isActive()) {
-        m_timer.stop();
-    }
-
-    const int64_t next = *utils::find_min_computed(m_countdowns, get_diff);
+    const int64_t next = *utils::find_min_computed(activeCountdowns, get_diff);
     // Restart the timer
     if (next > 0) {
         m_timer.start(static_cast<int>(next));
+    } else {
+        // Should not really happen as we just set expired ones to true,
+        // but let's be safe and trigger finish again if there's an immediate one.
+        QTimer::singleShot(0, this, &CTimers::slot_finishCountdownTimer);
     }
 }
 
@@ -154,13 +283,23 @@ std::string CTimers::getTimers() const
 {
     ABORT_IF_NOT_ON_MAIN_THREAD();
 
-    if (m_timers.empty()) {
+    bool any = false;
+    for (const auto &t : m_allTimers) {
+        if (!t.isCountdown()) {
+            any = true;
+            break;
+        }
+    }
+
+    if (!any) {
         return "";
     }
 
     std::ostringstream ostr;
     ostr << "Timers:" << std::endl;
-    for (const auto &timer : m_timers) {
+    for (const auto &timer : m_allTimers) {
+        if (timer.isCountdown())
+            continue;
         const auto elapsed = msToMinSec(timer.elapsedMs());
         ostr << "- " << timer.getName();
         if (!timer.getDescription().empty()) {
@@ -175,13 +314,23 @@ std::string CTimers::getCountdowns() const
 {
     ABORT_IF_NOT_ON_MAIN_THREAD();
 
-    if (m_countdowns.empty()) {
+    bool any = false;
+    for (const auto &t : m_allTimers) {
+        if (t.isCountdown()) {
+            any = true;
+            break;
+        }
+    }
+
+    if (!any) {
         return "";
     }
 
     std::ostringstream ostr;
     ostr << "Countdowns:" << std::endl;
-    for (const auto &countdown : m_countdowns) {
+    for (const auto &countdown : m_allTimers) {
+        if (!countdown.isCountdown())
+            continue;
         const auto elapsed = msToMinSec(countdown.elapsedMs());
         const auto left = msToMinSec(countdown.durationMs() - countdown.elapsedMs());
         ostr << "- " << countdown.getName();
@@ -202,6 +351,27 @@ void CTimers::clear()
 {
     ABORT_IF_NOT_ON_MAIN_THREAD();
 
-    m_countdowns.clear();
-    m_timers.clear();
+    m_allTimers.clear();
+    m_timer.stop();
+    emit sig_timerRemoved();
+}
+
+void CTimers::moveTimer(int from, int to)
+{
+    ABORT_IF_NOT_ON_MAIN_THREAD();
+
+    if (from < 0 || from >= static_cast<int>(m_allTimers.size()))
+        return;
+    if (to < 0 || to > static_cast<int>(m_allTimers.size()))
+        return;
+
+    auto itFrom = m_allTimers.begin();
+    std::advance(itFrom, from);
+
+    auto itTo = m_allTimers.begin();
+    std::advance(itTo, to);
+
+    m_allTimers.splice(itTo, m_allTimers, itFrom);
+
+    emit sig_timersUpdated();
 }

--- a/src/timers/CTimers.h
+++ b/src/timers/CTimers.h
@@ -19,13 +19,17 @@ private:
     std::string m_desc;
     int64_t m_start = 0;
     int64_t m_duration = 0;
+    bool m_expired = false;
 
 public:
     explicit TTimer(std::string name, std::string desc, int64_t durationMs);
     explicit TTimer(std::string name, std::string desc);
     TTimer() = delete;
     ~TTimer() = default;
-    DEFAULT_MOVES_DELETE_COPIES(TTimer);
+    DEFAULT_MOVE_CTOR(TTimer);
+    DEFAULT_COPY_CTOR(TTimer);
+    DEFAULT_MOVE_ASSIGN_OP(TTimer);
+    DEFAULT_COPY_ASSIGN_OP(TTimer);
 
 public:
     NODISCARD const std::string &getName() const { return m_name; }
@@ -34,6 +38,12 @@ public:
 public:
     NODISCARD int64_t durationMs() const { return m_duration; }
     NODISCARD int64_t elapsedMs() const;
+    NODISCARD int64_t remainingMs() const;
+    NODISCARD int64_t startTimeMs() const { return m_start; }
+
+    NODISCARD bool isCountdown() const { return m_duration > 0; }
+    NODISCARD bool isExpired() const { return m_expired; }
+    void setExpired(bool expired) { m_expired = expired; }
 };
 
 class NODISCARD_QOBJECT CTimers final : public QObject
@@ -41,8 +51,7 @@ class NODISCARD_QOBJECT CTimers final : public QObject
     Q_OBJECT
 
 private:
-    std::list<TTimer> m_timers;
-    std::list<TTimer> m_countdowns;
+    std::list<TTimer> m_allTimers;
     QTimer m_timer;
 
 public:
@@ -60,14 +69,31 @@ public:
     NODISCARD bool removeTimer(const std::string &name);
     NODISCARD bool removeCountdown(const std::string &name);
 
+    void stopTimer(const std::string &name);
+    void stopCountdown(const std::string &name);
+    void resetTimer(const std::string &name);
+    void resetCountdown(const std::string &name);
+
+    void clearExpired();
+
     // for stat command representation
     NODISCARD std::string getStatCommandEntry() const;
 
     void clear();
 
+    void moveTimer(int from, int to);
+
+    NODISCARD const std::list<TTimer> &allTimers() const { return m_allTimers; }
+
 signals:
     void sig_sendTimersUpdateToUser(const std::string &str);
+    void sig_timerAdded();
+    void sig_timerRemoved();
+    void sig_timersUpdated();
 
 public slots:
     void slot_finishCountdownTimer();
+
+private:
+    void restartCountdownTimer();
 };

--- a/src/timers/TimerDelegate.cpp
+++ b/src/timers/TimerDelegate.cpp
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 The MMapper Authors
+
+#include "TimerDelegate.h"
+
+#include "TimerModel.h"
+
+#include <QAbstractItemModel>
+#include <QAbstractItemView>
+#include <QColor>
+#include <QPainter>
+#include <QTableView>
+
+TimerDelegate::TimerDelegate(QObject *parent)
+    : QStyledItemDelegate(parent)
+{}
+
+void TimerDelegate::paint(QPainter *painter,
+                          const QStyleOptionViewItem &option,
+                          const QModelIndex &index) const
+{
+    QVariant progressVar = index.data(TimerModel::ProgressRole);
+    if (progressVar.isValid()) {
+        double progress = progressVar.toDouble();
+
+        painter->save();
+
+        // Calculate progress bar width relative to the whole row
+        const QTableView *view = qobject_cast<const QTableView *>(option.widget);
+        if (view) {
+            QRect rowRect;
+            int colCount = view->model()->columnCount();
+            for (int i = 0; i < colCount; ++i) {
+                if (!view->isColumnHidden(i)) {
+                    rowRect = rowRect.united(view->visualRect(view->model()->index(index.row(), i)));
+                }
+            }
+
+            int totalWidth = rowRect.width();
+            int filledWidth = static_cast<int>(static_cast<double>(totalWidth) * progress);
+            QRect progressRect(rowRect.x(), rowRect.y(), filledWidth, rowRect.height());
+
+            // Intersect row-level progress with current cell
+            QRect cellProgressRect = progressRect.intersected(option.rect);
+
+            if (cellProgressRect.isValid()) {
+                QColor color;
+                if (progress > 0.5) {
+                    // Green to Yellow
+                    double factor = (progress - 0.5) * 2.0;
+                    color = QColor::fromRgbF(static_cast<float>(1.0 - factor), 1.0f, 0.0f, 0.3f);
+                } else {
+                    // Yellow to Red
+                    double factor = progress * 2.0;
+                    color = QColor::fromRgbF(1.0f, static_cast<float>(factor), 0.0f, 0.3f);
+                }
+                painter->fillRect(cellProgressRect, color);
+            }
+        }
+
+        painter->restore();
+    }
+
+    QStyledItemDelegate::paint(painter, option, index);
+}

--- a/src/timers/TimerDelegate.h
+++ b/src/timers/TimerDelegate.h
@@ -1,0 +1,19 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 The MMapper Authors
+
+#include "../global/macros.h"
+
+#include <QStyledItemDelegate>
+
+class NODISCARD_QOBJECT TimerDelegate final : public QStyledItemDelegate
+{
+    Q_OBJECT
+
+public:
+    explicit TimerDelegate(QObject *parent = nullptr);
+
+    void paint(QPainter *painter,
+               const QStyleOptionViewItem &option,
+               const QModelIndex &index) const override;
+};

--- a/src/timers/TimerModel.cpp
+++ b/src/timers/TimerModel.cpp
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 The MMapper Authors
+
+#include "TimerModel.h"
+
+#include "../global/TextUtils.h"
+#include "CTimers.h"
+
+#include <tuple>
+#include <vector>
+
+#include <QColor>
+#include <QDateTime>
+#include <QMimeData>
+
+namespace {
+QString formatMs(int64_t ms)
+{
+    bool negative = ms < 0;
+    if (negative)
+        ms = -ms;
+    int64_t totalSecs = ms / 1000;
+    int64_t h = totalSecs / 3600;
+    int64_t m = (totalSecs / 60) % 60;
+    int64_t s = totalSecs % 60;
+
+    QString res;
+    if (h > 0) {
+        res += QString::number(h) + ":";
+    }
+    res += QString("%1:%2").arg(m, 2, 10, QChar('0')).arg(s, 2, 10, QChar('0'));
+    return negative ? "-" + res : res;
+}
+} // namespace
+
+TimerModel::TimerModel(CTimers &timers, QObject *parent)
+    : QAbstractTableModel(parent)
+    , m_timers(timers)
+{
+    m_refreshTimer.setSingleShot(true);
+    connect(&m_timers, &CTimers::sig_timerAdded, this, &TimerModel::updateTimerList);
+    connect(&m_timers, &CTimers::sig_timerRemoved, this, &TimerModel::updateTimerList);
+    connect(&m_timers, &CTimers::sig_timersUpdated, this, &TimerModel::updateTimerList);
+
+    connect(&m_refreshTimer, &QTimer::timeout, this, [this]() {
+        if (m_allTimers.empty())
+            return;
+        emit dataChanged(index(0, ColName),
+                         index(static_cast<int>(m_allTimers.size()) - 1, ColCount - 1),
+                         {Qt::DisplayRole, ProgressRole});
+        startRefreshTimer();
+    });
+
+    updateTimerList();
+}
+
+int TimerModel::rowCount(const QModelIndex &parent) const
+{
+    if (parent.isValid())
+        return 0;
+    return static_cast<int>(m_allTimers.size());
+}
+
+int TimerModel::columnCount(const QModelIndex &parent) const
+{
+    if (parent.isValid())
+        return 0;
+    return ColCount;
+}
+
+QVariant TimerModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid() || index.row() < 0
+        || static_cast<size_t>(index.row()) >= m_allTimers.size()) {
+        return QVariant();
+    }
+
+    const TTimer *timer = m_allTimers[static_cast<size_t>(index.row())];
+
+    if (role == Qt::DisplayRole || role == Qt::ToolTipRole) {
+        switch (index.column()) {
+        case ColName: {
+            QString name = mmqt::toQStringUtf8(timer->getName());
+            if (!timer->getDescription().empty()) {
+                name += " <" + mmqt::toQStringUtf8(timer->getDescription()) + ">";
+            }
+            return name;
+        }
+        case ColTime:
+            if (timer->isCountdown()) {
+                return formatMs(timer->remainingMs());
+            } else {
+                return formatMs(timer->elapsedMs());
+            }
+        }
+    } else if (role == Qt::ForegroundRole) {
+        if (timer->isExpired()) {
+            return QColor(Qt::red);
+        }
+    } else if (role == Qt::TextAlignmentRole) {
+        if (index.column() == ColTime) {
+            return QVariant(static_cast<int>(Qt::AlignCenter));
+        }
+    } else if (role == ProgressRole) {
+        if (timer->isCountdown() && timer->durationMs() > 0) {
+            return static_cast<double>(timer->remainingMs())
+                   / static_cast<double>(timer->durationMs());
+        }
+        return QVariant();
+    }
+
+    return QVariant();
+}
+
+QVariant TimerModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if (orientation == Qt::Horizontal && role == Qt::DisplayRole) {
+        switch (section) {
+        case ColName:
+            return tr("Name");
+        case ColTime:
+            return tr("Time");
+        }
+    }
+    return QVariant();
+}
+
+Qt::ItemFlags TimerModel::flags(const QModelIndex &index) const
+{
+    Qt::ItemFlags defaultFlags = QAbstractTableModel::flags(index);
+    if (index.isValid()) {
+        return Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled | defaultFlags;
+    } else {
+        return Qt::ItemIsDropEnabled | defaultFlags;
+    }
+}
+
+Qt::DropActions TimerModel::supportedDropActions() const
+{
+    return Qt::MoveAction;
+}
+
+QStringList TimerModel::mimeTypes() const
+{
+    return {"application/x-mmapper-timer-index"};
+}
+
+QMimeData *TimerModel::mimeData(const QModelIndexList &indexes) const
+{
+    if (indexes.isEmpty())
+        return nullptr;
+
+    auto *data = new QMimeData();
+    data->setData("application/x-mmapper-timer-index", QByteArray::number(indexes.at(0).row()));
+    return data;
+}
+
+bool TimerModel::dropMimeData(
+    const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent)
+{
+    std::ignore = column;
+    if (action != Qt::MoveAction)
+        return false;
+
+    if (!data->hasFormat("application/x-mmapper-timer-index"))
+        return false;
+
+    int from = data->data("application/x-mmapper-timer-index").toInt();
+    int to = row;
+
+    if (row == -1) {
+        if (parent.isValid()) {
+            to = parent.row();
+        } else {
+            to = rowCount();
+        }
+    }
+
+    if (from == to || from == to - 1)
+        return false;
+
+    m_timers.moveTimer(from, to);
+    return true;
+}
+
+const TTimer *TimerModel::timerAt(int row) const
+{
+    if (row < 0 || static_cast<size_t>(row) >= m_allTimers.size())
+        return nullptr;
+    return m_allTimers[static_cast<size_t>(row)];
+}
+
+void TimerModel::updateTimerList()
+{
+    beginResetModel();
+    m_allTimers.clear();
+
+    const auto &timers = m_timers.allTimers();
+    std::vector<const TTimer *> active;
+    std::vector<const TTimer *> expired;
+
+    for (const auto &t : timers) {
+        if (t.isExpired()) {
+            expired.push_back(&t);
+        } else {
+            active.push_back(&t);
+        }
+    }
+
+    m_allTimers.insert(m_allTimers.end(), active.begin(), active.end());
+    m_allTimers.insert(m_allTimers.end(), expired.begin(), expired.end());
+
+    endResetModel();
+
+    if (m_allTimers.empty()) {
+        m_refreshTimer.stop();
+    } else if (!m_refreshTimer.isActive()) {
+        startRefreshTimer();
+    }
+}
+
+void TimerModel::startRefreshTimer()
+{
+    // 50ms provides smooth 20fps updates for the progress bar
+    m_refreshTimer.start(50);
+}

--- a/src/timers/TimerModel.h
+++ b/src/timers/TimerModel.h
@@ -1,0 +1,57 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 The MMapper Authors
+
+#include "../global/macros.h"
+
+#include <vector>
+
+#include <QAbstractTableModel>
+#include <QStringList>
+#include <QTimer>
+
+class CTimers;
+class TTimer;
+class QMimeData;
+
+class NODISCARD_QOBJECT TimerModel final : public QAbstractTableModel
+{
+    Q_OBJECT
+
+private:
+    CTimers &m_timers;
+    std::vector<const TTimer *> m_allTimers;
+    QTimer m_refreshTimer;
+
+public:
+    enum Column { ColName = 0, ColTime, ColCount };
+    enum Role { ProgressRole = Qt::UserRole + 1 };
+
+public:
+    explicit TimerModel(CTimers &timers, QObject *parent = nullptr);
+
+    NODISCARD int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    NODISCARD int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+    NODISCARD QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+    NODISCARD QVariant headerData(int section,
+                                  Qt::Orientation orientation,
+                                  int role = Qt::DisplayRole) const override;
+
+    NODISCARD Qt::ItemFlags flags(const QModelIndex &index) const override;
+    NODISCARD Qt::DropActions supportedDropActions() const override;
+    NODISCARD QStringList mimeTypes() const override;
+    NODISCARD QMimeData *mimeData(const QModelIndexList &indexes) const override;
+    bool dropMimeData(const QMimeData *data,
+                      Qt::DropAction action,
+                      int row,
+                      int column,
+                      const QModelIndex &parent) override;
+
+    NODISCARD const TTimer *timerAt(int row) const;
+
+private slots:
+    void updateTimerList();
+
+private:
+    void startRefreshTimer();
+};

--- a/src/timers/TimerWidget.cpp
+++ b/src/timers/TimerWidget.cpp
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 The MMapper Authors
+
+#include "TimerWidget.h"
+
+#include "CTimers.h"
+#include "TimerDelegate.h"
+#include "TimerModel.h"
+
+#include <QHeaderView>
+#include <QMenu>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+TimerWidget::TimerWidget(CTimers &timers, QWidget *parent)
+    : QWidget(parent)
+    , m_timers(timers)
+{
+    auto *layout = new QVBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(0);
+
+    m_model = new TimerModel(m_timers, this);
+    m_view = new QTableView(this);
+    m_view->setModel(m_model);
+    auto *delegate = new TimerDelegate(this);
+    for (int i = 0; i < TimerModel::ColCount; ++i) {
+        m_view->setItemDelegateForColumn(i, delegate);
+    }
+    m_view->horizontalHeader()->setStretchLastSection(false);
+    m_view->horizontalHeader()->setSectionResizeMode(TimerModel::ColName, QHeaderView::Stretch);
+    m_view->horizontalHeader()->setSectionResizeMode(TimerModel::ColTime,
+                                                     QHeaderView::ResizeToContents);
+    m_view->verticalHeader()->setVisible(false);
+    m_view->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_view->setContextMenuPolicy(Qt::CustomContextMenu);
+    m_view->setShowGrid(false);
+    m_view->setAlternatingRowColors(true);
+
+    m_view->setDragEnabled(true);
+    m_view->setAcceptDrops(true);
+    m_view->setDropIndicatorShown(true);
+    m_view->setDragDropMode(QAbstractItemView::InternalMove);
+
+    layout->addWidget(m_view);
+
+    connect(m_view, &QTableView::customContextMenuRequested, this, &TimerWidget::showContextMenu);
+}
+
+void TimerWidget::showContextMenu(const QPoint &pos)
+{
+    QMenu menu(this);
+
+    QModelIndex index = m_view->indexAt(pos);
+    if (index.isValid()) {
+        const TTimer *timer = m_model->timerAt(index.row());
+        if (timer) {
+            std::string name = timer->getName();
+            bool isCountdown = timer->isCountdown();
+
+            auto *actReset = menu.addAction(tr("Reset"));
+            connect(actReset, &QAction::triggered, this, [this, name, isCountdown]() {
+                if (isCountdown)
+                    m_timers.resetCountdown(name);
+                else
+                    m_timers.resetTimer(name);
+            });
+
+            auto *actStop = menu.addAction(tr("Stop"));
+            actStop->setEnabled(!timer->isExpired());
+            connect(actStop, &QAction::triggered, this, [this, name, isCountdown]() {
+                if (isCountdown)
+                    m_timers.stopCountdown(name);
+                else
+                    m_timers.stopTimer(name);
+            });
+
+            menu.addSeparator();
+
+            auto *actDelete = menu.addAction(tr("Delete"));
+            connect(actDelete, &QAction::triggered, this, [this, name, isCountdown]() {
+                if (isCountdown)
+                    std::ignore = m_timers.removeCountdown(name);
+                else
+                    std::ignore = m_timers.removeTimer(name);
+            });
+
+            menu.addSeparator();
+        }
+    }
+
+    auto *actClearExpired = menu.addAction(tr("Clear Expired"));
+    connect(actClearExpired, &QAction::triggered, this, &TimerWidget::clearExpired);
+
+    menu.exec(m_view->viewport()->mapToGlobal(pos));
+}
+
+void TimerWidget::clearExpired()
+{
+    m_timers.clearExpired();
+}

--- a/src/timers/TimerWidget.h
+++ b/src/timers/TimerWidget.h
@@ -1,0 +1,29 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 The MMapper Authors
+
+#include "../global/macros.h"
+
+#include <QTableView>
+#include <QWidget>
+
+class CTimers;
+class TimerModel;
+class QMenu;
+
+class NODISCARD_QOBJECT TimerWidget final : public QWidget
+{
+    Q_OBJECT
+
+private:
+    CTimers &m_timers;
+    TimerModel *m_model = nullptr;
+    QTableView *m_view = nullptr;
+
+public:
+    explicit TimerWidget(CTimers &timers, QWidget *parent = nullptr);
+
+private slots:
+    void showContextMenu(const QPoint &pos);
+    void clearExpired();
+};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -239,6 +239,8 @@ add_test(NAME TestAdventure COMMAND TestAdventure)
 set(timer_test
         ../src/timers/CTimers.cpp
         ../src/timers/CTimers.h
+        ../src/timers/TimerModel.cpp
+        ../src/timers/TimerModel.h
 )
 set(TestTimer TestCTimers.cpp)
 add_executable(TestTimer ${timer_test} ${TestTimer})

--- a/tests/TestCTimers.cpp
+++ b/tests/TestCTimers.cpp
@@ -5,6 +5,7 @@
 
 #include "../src/global/TextUtils.h"
 #include "../src/timers/CTimers.h"
+#include "../src/timers/TimerModel.h"
 
 #include <tuple>
 
@@ -128,6 +129,138 @@ void TestCTimers::testMultipleTimersAndCountdowns()
     QString countdownsList = mmqt::toQStringUtf8(timers.getCountdowns());
     QVERIFY(!timersList.contains("Timer1"));
     QVERIFY(!countdownsList.contains("Countdown1"));
+}
+
+void TestCTimers::testStopResetTimers()
+{
+    CTimers timers(nullptr);
+    timers.addTimer("T1", "D1");
+    timers.addCountdown("C1", "D2", 10000);
+
+    // Stop
+    timers.stopTimer("T1");
+    timers.stopCountdown("C1");
+
+    for (const auto &t : timers.allTimers()) {
+        if (t.getName() == "T1" || t.getName() == "C1")
+            QVERIFY(t.isExpired());
+    }
+
+    // Reset
+    timers.resetTimer("T1");
+    timers.resetCountdown("C1");
+
+    for (const auto &t : timers.allTimers()) {
+        if (t.getName() == "T1" || t.getName() == "C1")
+            QVERIFY(!t.isExpired());
+    }
+}
+
+void TestCTimers::testSignals()
+{
+    CTimers timers(nullptr);
+    QSignalSpy spyAdded(&timers, &CTimers::sig_timerAdded);
+    QSignalSpy spyRemoved(&timers, &CTimers::sig_timerRemoved);
+    QSignalSpy spyUpdated(&timers, &CTimers::sig_timersUpdated);
+
+    timers.addTimer("T1", "D1");
+    QCOMPARE(spyAdded.count(), 1);
+
+    timers.addCountdown("C1", "D2", 10000);
+    QCOMPARE(spyAdded.count(), 2);
+
+    timers.stopTimer("T1");
+    QCOMPARE(spyUpdated.count(), 1);
+
+    std::ignore = timers.removeTimer("T1");
+    QCOMPARE(spyRemoved.count(), 1);
+
+    timers.clear();
+    QCOMPARE(spyRemoved.count(), 2);
+}
+
+void TestCTimers::testClearExpired()
+{
+    CTimers timers(nullptr);
+    timers.addTimer("T1", "D1");
+    timers.addCountdown("C1", "D2", 10000);
+
+    timers.stopTimer("T1");
+    timers.stopCountdown("C1");
+
+    timers.clearExpired();
+
+    QVERIFY(timers.allTimers().empty());
+}
+
+void TestCTimers::testModelBasicProperties()
+{
+    CTimers timers(nullptr);
+    TimerModel model(timers, nullptr);
+
+    QCOMPARE(model.rowCount(), 0);
+    QCOMPARE(model.columnCount(), 2);
+
+    timers.addTimer("T1", "D1");
+    QCOMPARE(model.rowCount(), 1);
+
+    timers.addCountdown("C1", "D2", 10000);
+    QCOMPARE(model.rowCount(), 2);
+}
+
+void TestCTimers::testModelDataRetrieval()
+{
+    CTimers timers(nullptr);
+    TimerModel model(timers, nullptr);
+
+    timers.addTimer("T1", "D1");
+
+    QCOMPARE(model.data(model.index(0, 0), Qt::DisplayRole).toString(), QString("T1 <D1>"));
+
+    QVariant timeVal = model.data(model.index(0, 1), Qt::DisplayRole);
+    QVERIFY(timeVal.isValid());
+}
+
+void TestCTimers::testModelUpdates()
+{
+    CTimers timers(nullptr);
+    TimerModel model(timers, nullptr);
+
+    QSignalSpy spyReset(&model, &TimerModel::modelReset);
+
+    timers.addTimer("T1", "D1");
+    QCOMPARE(spyReset.count(), 1);
+
+    std::ignore = timers.removeTimer("T1");
+    QCOMPARE(spyReset.count(), 2);
+
+    timers.clear();
+    QCOMPARE(spyReset.count(), 3);
+}
+
+void TestCTimers::testMoveTimer()
+{
+    CTimers timers(nullptr);
+    timers.addTimer("T1", "D1");
+    timers.addTimer("T2", "D2");
+    timers.addTimer("T3", "D3");
+
+    // Order: T1, T2, T3
+    timers.moveTimer(0, 2); // Move T1 to position 2 (before T3)
+    // Order should be: T2, T1, T3
+    auto all = timers.allTimers();
+    auto it = all.begin();
+    QCOMPARE(QString::fromStdString(it->getName()), QString("T2"));
+    ++it;
+    QCOMPARE(QString::fromStdString(it->getName()), QString("T1"));
+    ++it;
+    QCOMPARE(QString::fromStdString(it->getName()), QString("T3"));
+
+    timers.moveTimer(2, 0); // Move T3 to position 0
+    // Order should be: T3, T2, T1
+    all = timers.allTimers();
+    it = all.begin();
+    QCOMPARE(QString::fromStdString(it->getName()), QString("T3"));
 }
 
 QTEST_MAIN(TestCTimers)

--- a/tests/TestCTimers.h
+++ b/tests/TestCTimers.h
@@ -21,4 +21,13 @@ private Q_SLOTS:
     void testCountdownCompletion();
     void testClearFunctionality();
     void testMultipleTimersAndCountdowns();
+    void testStopResetTimers();
+    void testSignals();
+    void testClearExpired();
+
+    // TimerModel tests
+    void testModelBasicProperties();
+    void testModelDataRetrieval();
+    void testModelUpdates();
+    void testMoveTimer();
 };


### PR DESCRIPTION
## Summary by Sourcery

Introduce a unified timer management system and a dockable timers panel with a model/view UI, integrating timers into the main window and proxy pipeline.

New Features:
- Add a dockable timers panel with a table-based UI for viewing and managing timers and countdowns.
- Provide a Qt model, delegate, and widget for displaying timers with live updates, drag-and-drop reordering, and context menu actions.

Enhancements:
- Refactor CTimers to manage timers and countdowns in a single list with support for stopping, resetting, reordering, and clearing expired timers, and expose signals for UI updates.
- Pass a shared CTimers instance through the main window, proxy, parser, and connection listener to centralize timer handling.

Build:
- Register new timer UI sources (model, delegate, widget) and tests in the build configuration.

Tests:
- Extend timer tests to cover new stop/reset behavior, signal emissions, clearing of expired timers, model behavior, and timer reordering.