### PR TITLE
overhaul Preferences dialog with search and scroll-sync

### DIFF
--- a/src/preferences/AdvancedGraphics.cpp
+++ b/src/preferences/AdvancedGraphics.cpp
@@ -188,15 +188,18 @@ AdvancedGraphicsGroupBox::AdvancedGraphicsGroupBox(QGroupBox &groupBox)
     };
 
     auto *const checkboxDiag = new QCheckBox("Show Performance Stats");
+    checkboxDiag->setObjectName("checkboxDiag");
     checkboxDiag->setChecked(MapCanvasConfig::getShowPerfStats());
     vertical->addWidget(checkboxDiag);
 
     auto *const checkbox3d = new QCheckBox("3d Mode");
+    checkbox3d->setObjectName("checkbox3d");
     const bool is3dAtInit = MapCanvasConfig::isIn3dMode();
     checkbox3d->setChecked(is3dAtInit);
     vertical->addWidget(checkbox3d);
 
     auto *const autoTilt = new QCheckBox("Auto tilt with zoom");
+    autoTilt->setObjectName("autoTilt");
     autoTilt->setChecked(MapCanvasConfig::isAutoTilt());
     vertical->addWidget(autoTilt);
 

--- a/src/preferences/audiopage.ui
+++ b/src/preferences/audiopage.ui
@@ -2,14 +2,6 @@
 <ui version="4.0">
  <class>AudioPage</class>
  <widget class="QWidget" name="AudioPage">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>400</width>
-    <height>300</height>
-   </rect>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QGroupBox" name="outputGroupBox">
@@ -19,13 +11,26 @@
      <layout class="QGridLayout" name="gridLayoutOutput">
       <item row="0" column="0">
        <widget class="QLabel" name="outputDeviceLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
          <string>Device:</string>
         </property>
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="QComboBox" name="outputDeviceComboBox"/>
+       <widget class="QComboBox" name="outputDeviceComboBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -38,15 +43,42 @@
      <layout class="QGridLayout" name="gridLayoutMusic">
       <item row="1" column="0">
        <widget class="QLabel" name="musicVolumeLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
          <string>Volume:</string>
         </property>
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="AudioVolumeSlider" name="musicVolumeSlider">
+      <widget class="AudioVolumeSlider" name="musicVolumeSlider">
         <property name="audioType">
-         <enum>AudioVolumeSlider::AudioType::Music</enum>
+          <enum>AudioVolumeSlider::AudioType::Music</enum>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="mouseTracking">
+         <bool>true</bool>
+        </property>
+        <property name="tracking">
+         <bool>false</bool>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Orientation::Horizontal</enum>
+        </property>
+        <property name="tickPosition">
+         <enum>QSlider::TickPosition::TicksBelow</enum>
+        </property>
+        <property name="tickInterval">
+         <number>10</number>
         </property>
        </widget>
       </item>
@@ -61,15 +93,42 @@
      <layout class="QGridLayout" name="gridLayoutSounds">
       <item row="1" column="0">
        <widget class="QLabel" name="soundsVolumeLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
          <string>Volume:</string>
         </property>
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="AudioVolumeSlider" name="soundsVolumeSlider">
+      <widget class="AudioVolumeSlider" name="soundsVolumeSlider">
         <property name="audioType">
-         <enum>AudioVolumeSlider::AudioType::Sound</enum>
+          <enum>AudioVolumeSlider::AudioType::Sound</enum>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="mouseTracking">
+         <bool>true</bool>
+        </property>
+        <property name="tracking">
+         <bool>false</bool>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Orientation::Horizontal</enum>
+        </property>
+        <property name="tickPosition">
+         <enum>QSlider::TickPosition::TicksBelow</enum>
+        </property>
+        <property name="tickInterval">
+         <number>10</number>
         </property>
        </widget>
       </item>
@@ -79,7 +138,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>

--- a/src/preferences/autologpage.ui
+++ b/src/preferences/autologpage.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>326</width>
-    <height>384</height>
+    <width>345</width>
+    <height>404</height>
    </rect>
   </property>
   <layout class="QVBoxLayout">
@@ -36,10 +36,10 @@
       <item row="6" column="0" colspan="6">
        <widget class="QFrame" name="autoLogFrame">
         <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
+         <enum>QFrame::Shape::NoFrame</enum>
         </property>
         <property name="frameShadow">
-         <enum>QFrame::Plain</enum>
+         <enum>QFrame::Shadow::Plain</enum>
         </property>
         <property name="lineWidth">
          <number>0</number>
@@ -129,6 +129,9 @@
       </item>
       <item row="2" column="1">
        <widget class="QSpinBox" name="spinBoxDays">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
         <property name="maximum">
          <number>9999999</number>
         </property>
@@ -150,6 +153,9 @@
           <width>0</width>
           <height>0</height>
          </size>
+        </property>
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
         </property>
         <property name="minimum">
          <number>1</number>
@@ -192,11 +198,11 @@
       <item row="3" column="3">
        <spacer name="advancedSpacer">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>40</width>
+          <width>10</width>
           <height>20</height>
          </size>
         </property>
@@ -268,6 +274,9 @@
           <height>0</height>
          </size>
         </property>
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
         <property name="toolTip">
          <string>Rotate logs to keep files small for editors</string>
         </property>
@@ -288,11 +297,11 @@
       <item row="0" column="3">
        <spacer name="horizontalSpacer">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>40</width>
+          <width>10</width>
           <height>20</height>
          </size>
         </property>
@@ -304,7 +313,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>

--- a/src/preferences/clientpage.ui
+++ b/src/preferences/clientpage.ui
@@ -2,14 +2,6 @@
 <ui version="4.0">
  <class>ClientPage</class>
  <widget class="QWidget" name="ClientPage">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>331</width>
-    <height>687</height>
-   </rect>
-  </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
@@ -77,11 +69,11 @@
       <item row="2" column="3">
        <spacer name="horizontalSpacer">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>40</width>
+          <width>10</width>
           <height>20</height>
          </size>
         </property>
@@ -90,10 +82,10 @@
       <item row="0" column="0" colspan="4">
        <widget class="QLabel" name="exampleLabel">
         <property name="frameShape">
-         <enum>QFrame::StyledPanel</enum>
+         <enum>QFrame::Shape::StyledPanel</enum>
         </property>
         <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+         <enum>QFrame::Shadow::Raised</enum>
         </property>
         <property name="text">
          <string>Arglebargle, glop-glyf!?!</string>
@@ -117,6 +109,9 @@
      <layout class="QGridLayout" name="gridLayout_3">
       <item row="4" column="1">
        <widget class="QSpinBox" name="scrollbackSpinBox">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
         <property name="showGroupSeparator" stdset="0">
          <bool>true</bool>
         </property>
@@ -130,6 +125,9 @@
       </item>
       <item row="0" column="1">
        <widget class="QSpinBox" name="columnsSpinBox">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
         <property name="showGroupSeparator" stdset="0">
          <bool>true</bool>
         </property>
@@ -170,6 +168,9 @@
       </item>
       <item row="1" column="1">
        <widget class="QSpinBox" name="rowsSpinBox">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
         <property name="showGroupSeparator" stdset="0">
          <bool>true</bool>
         </property>
@@ -205,7 +206,11 @@
        </widget>
       </item>
       <item row="5" column="1">
-       <widget class="QSpinBox" name="previewSpinBox"/>
+       <widget class="QSpinBox" name="previewSpinBox">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
+       </widget>
       </item>
       <item row="7" column="0" colspan="2">
        <widget class="QCheckBox" name="audibleBellCheckBox">
@@ -238,6 +243,9 @@
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="2" column="1">
        <widget class="QSpinBox" name="tabDictionarySpinBox">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
         <property name="showGroupSeparator" stdset="0">
          <bool>true</bool>
         </property>
@@ -254,6 +262,9 @@
       </item>
       <item row="1" column="1">
        <widget class="QSpinBox" name="inputHistorySpinBox">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
         <property name="showGroupSeparator" stdset="0">
          <bool>true</bool>
         </property>
@@ -291,11 +302,11 @@
       <item row="4" column="1">
        <spacer name="horizontalSpacer_2">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>40</width>
+          <width>10</width>
           <height>20</height>
          </size>
         </property>
@@ -344,7 +355,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>

--- a/src/preferences/configdialog.cpp
+++ b/src/preferences/configdialog.cpp
@@ -20,7 +20,27 @@
 
 #include <QIcon>
 #include <QListWidget>
+#include <QTimer>
 #include <QtWidgets>
+
+namespace {
+QString getSearchableText(const QWidget *widget)
+{
+    if (auto *const cb = qobject_cast<const QCheckBox *>(widget))
+        return cb->text();
+    if (auto *const rb = qobject_cast<const QRadioButton *>(widget))
+        return rb->text();
+    if (auto *const lbl = qobject_cast<const QLabel *>(widget))
+        return lbl->text();
+    if (auto *const pb = qobject_cast<const QPushButton *>(widget))
+        return pb->text();
+    if (auto *const gb = qobject_cast<const QGroupBox *>(widget))
+        return gb->title();
+    return QString();
+}
+
+enum StackPage { Preferences = 0, SearchResults = 1, NoResults = 2 };
+} // namespace
 
 ConfigDialog::ConfigDialog(QWidget *const parent)
     : QDialog(parent)
@@ -28,9 +48,7 @@ ConfigDialog::ConfigDialog(QWidget *const parent)
 {
     ui->setupUi(this);
 
-    setWindowTitle(tr("Config Dialog"));
-
-    createIcons();
+    setWindowTitle(tr("Preferences"));
 
     auto generalPage = new GeneralPage(this);
     auto graphicsPage = new GraphicsPage(this);
@@ -42,30 +60,89 @@ ConfigDialog::ConfigDialog(QWidget *const parent)
     auto mumeProtocolPage = new MumeProtocolPage(this);
     auto pathmachinePage = new PathmachinePage(this);
 
-    m_pagesWidget = new QStackedWidget(this);
+    const auto makeSectionHeader = [](const QString &name,
+                                      QWidget *const headerParent) -> QWidget * {
+        auto *container = new QWidget(headerParent);
+        auto *layout = new QHBoxLayout(container);
+        layout->setContentsMargins(0, 0, 0, 4);
 
-    auto *const pagesWidget = m_pagesWidget;
-    pagesWidget->addWidget(generalPage);
-    pagesWidget->addWidget(graphicsPage);
-    pagesWidget->addWidget(parserPage);
-    pagesWidget->addWidget(clientPage);
-    pagesWidget->addWidget(groupPage);
-    pagesWidget->addWidget(autoLogPage);
-    pagesWidget->addWidget(audioPage);
-    pagesWidget->addWidget(mumeProtocolPage);
-    pagesWidget->addWidget(pathmachinePage);
-    pagesWidget->setCurrentIndex(0);
+        auto *label = new QLabel(name, container);
+        QFont font = label->font();
+        font.setBold(true);
+        font.setPointSize(font.pointSize() + 1);
+        label->setFont(font);
+        layout->addWidget(label);
 
-    ui->pagesScrollArea->setWidget(pagesWidget);
+        auto *line = new QFrame(container);
+        line->setFrameShape(QFrame::HLine);
+        line->setFrameShadow(QFrame::Sunken);
+        layout->addWidget(line, 1);
 
-    ui->contentsWidget->setCurrentItem(ui->contentsWidget->item(0));
+        return container;
+    };
+
+    auto addPage = [this, &makeSectionHeader](QWidget *widget,
+                                              const QString &name,
+                                              const QString &iconPath) {
+        auto *item = new QListWidgetItem(QIcon(iconPath), name, ui->contentsWidget);
+
+        auto *container = new QWidget(this);
+        auto *containerLayout = new QVBoxLayout(container);
+        containerLayout->setContentsMargins(0, 0, 0, 0);
+        containerLayout->addWidget(makeSectionHeader(name, container));
+        containerLayout->addWidget(widget);
+
+        ui->scrollLayout->insertWidget(ui->scrollLayout->indexOf(ui->footerWidget) - 1, container);
+        m_pages.append({name, widget, item, container});
+    };
+
+    addPage(generalPage, tr("General"), ":/icons/generalcfg.png");
+    addPage(graphicsPage, tr("Graphics"), ":/icons/graphicscfg.png");
+    addPage(parserPage, tr("Parser"), ":/icons/parsercfg.png");
+    addPage(clientPage, tr("Integrated Client"), ":/icons/terminal.png");
+    addPage(groupPage, tr("Group Panel"), ":/icons/group-recolor.png");
+    addPage(autoLogPage, tr("Auto Logger"), ":/icons/autologgercfg.png");
+    addPage(audioPage, tr("Audio"), ":/icons/audiocfg.png");
+    addPage(mumeProtocolPage, tr("Mume Protocol"), ":/icons/mumeprotocolcfg.png");
+    addPage(pathmachinePage, tr("Path Machine"), ":/icons/pathmachinecfg.png");
+
+    connect(ui->backToTopBtn, &QPushButton::clicked, this, [this]() {
+        if (!m_pages.isEmpty()) {
+            ui->contentsWidget->setCurrentItem(m_pages.first().item);
+        }
+    });
+
+    ui->mainSplitter->setStretchFactor(0, 0);
+    ui->mainSplitter->setStretchFactor(1, 1);
+
     connect(ui->contentsWidget,
             &QListWidget::currentItemChanged,
             this,
             &ConfigDialog::slot_changePage);
-    connect(ui->closeButton, &QAbstractButton::clicked, this, &QWidget::close);
+    connect(ui->pagesScrollArea->verticalScrollBar(),
+            &QScrollBar::valueChanged,
+            this,
+            &ConfigDialog::slot_onScroll);
+    connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &ConfigDialog::slot_ok);
+    connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &ConfigDialog::slot_cancel);
+
+    m_searchTimer = new QTimer(this);
+    m_searchTimer->setSingleShot(true);
+    m_searchTimer->setInterval(50);
+    connect(m_searchTimer, &QTimer::timeout, this, [this]() { slot_search(ui->searchBar->text()); });
+    connect(ui->searchBar, &QLineEdit::textChanged, m_searchTimer, qOverload<>(&QTimer::start));
+
+    connect(ui->searchResultsList,
+            &QListWidget::itemActivated,
+            this,
+            &ConfigDialog::slot_onResultSelected);
+    connect(ui->searchResultsList,
+            &QListWidget::itemClicked,
+            this,
+            &ConfigDialog::slot_onResultSelected);
 
     connect(generalPage, &GeneralPage::sig_reloadConfig, this, [this]() { emit sig_loadConfig(); });
+
     connect(this, &ConfigDialog::sig_loadConfig, generalPage, &GeneralPage::slot_loadConfig);
     connect(this, &ConfigDialog::sig_loadConfig, graphicsPage, &GraphicsPage::slot_loadConfig);
     connect(this, &ConfigDialog::sig_loadConfig, parserPage, &ParserPage::slot_loadConfig);
@@ -103,46 +180,168 @@ void ConfigDialog::showEvent(QShowEvent *const event)
 {
     // Populate the preference pages from config each time the widget is shown
     emit sig_loadConfig();
-
-    // Move widget to center of parent's location
-    auto pos = parentWidget()->pos();
-    pos.setX(pos.x() + (parentWidget()->width() / 2) - (width() / 2));
-    move(pos);
-
     event->accept();
 }
 
-void ConfigDialog::createIcons()
+void ConfigDialog::scrollToWidget(QWidget *target, bool focus)
 {
-    const QSize iconTargetSize = ui->contentsWidget->iconSize();
+    const int targetY = target->mapTo(ui->scrollAreaWidgetContents, QPoint(0, 0)).y();
 
-    auto addItem = [this, iconTargetSize](const QString &iconPath, const QString &label) {
-        QPixmap pixmap(iconPath);
-        QPixmap scaled = pixmap.scaled(iconTargetSize,
-                                       Qt::KeepAspectRatio,
-                                       Qt::SmoothTransformation);
-
-        auto *item = new QListWidgetItem(QIcon(scaled), label, ui->contentsWidget);
-        item->setTextAlignment(Qt::AlignHCenter);
-        item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
-    };
-
-    addItem(":/icons/generalcfg.png", tr("General"));
-    addItem(":/icons/graphicscfg.png", tr("Graphics"));
-    addItem(":/icons/parsercfg.png", tr("Parser"));
-    addItem(":/icons/terminal.png", tr("Integrated\nMud Client"));
-    addItem(":/icons/group-recolor.png", tr("Group Panel"));
-    addItem(":/icons/autologgercfg.png", tr("Auto\nLogger"));
-    addItem(":/icons/audiocfg.png", tr("Audio"));
-    addItem(":/icons/mumeprotocolcfg.png", tr("Mume\nProtocol"));
-    addItem(":/icons/pathmachinecfg.png", tr("Path\nMachine"));
+    // We need to delay the scrolling slightly to ensure the scroll area has
+    // updated its layout after the stack switch.
+    QTimer::singleShot(0, this, [this, targetY, target, focus]() {
+        ui->pagesScrollArea->verticalScrollBar()->setValue(targetY);
+        if (focus) {
+            target->setFocus();
+        }
+    });
 }
 
-void ConfigDialog::slot_changePage(QListWidgetItem *current, QListWidgetItem *const previous)
+void ConfigDialog::slot_changePage(QListWidgetItem *current, QListWidgetItem *const /*previous*/)
 {
     if (current == nullptr) {
-        current = previous;
+        return;
     }
-    ui->pagesScrollArea->verticalScrollBar()->setSliderPosition(0);
-    m_pagesWidget->setCurrentIndex(ui->contentsWidget->row(current));
+
+    if (!ui->searchBar->text().isEmpty()) {
+        ui->searchBar->clear();
+        // search bar clear will restore Stack index 0
+    }
+
+    for (const auto &page : m_pages) {
+        if (page.item == current) {
+            scrollToWidget(page.container);
+            break;
+        }
+    }
+}
+
+void ConfigDialog::slot_onScroll(int value)
+{
+    if (!ui->searchBar->text().isEmpty()) {
+        return;
+    }
+
+    QListWidgetItem *activeItem = nullptr;
+    for (const auto &page : m_pages) {
+        const int pageY = page.container->mapTo(ui->scrollAreaWidgetContents, QPoint(0, 0)).y();
+        if (pageY <= value + 8) {
+            activeItem = page.item;
+        }
+    }
+
+    // If we reached the bottom, ensure the last item is selected
+    if (value >= ui->pagesScrollArea->verticalScrollBar()->maximum() && !m_pages.isEmpty()) {
+        activeItem = m_pages.last().item;
+    }
+
+    if (activeItem && ui->contentsWidget->currentItem() != activeItem) {
+        const QSignalBlocker blocker{ui->contentsWidget};
+        ui->contentsWidget->setCurrentItem(activeItem);
+    }
+}
+
+void ConfigDialog::slot_ok()
+{
+    getConfig().write();
+    accept();
+}
+
+void ConfigDialog::slot_cancel()
+{
+    setConfig().read();
+    emit sig_loadConfig();
+    reject();
+}
+
+void ConfigDialog::slot_search(const QString &text)
+{
+    ui->searchResultsList->clear();
+
+    if (text.isEmpty()) {
+        ui->rightStack->setCurrentIndex(StackPage::Preferences);
+        for (const auto &page : m_pages) {
+            page.item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
+        }
+        ui->searchBar->setFocus();
+        return;
+    }
+
+    for (const auto &page : m_pages) {
+        bool anyChildMatches = false;
+        const auto children = page.widget->findChildren<QWidget *>();
+
+        QList<QListWidgetItem *> pageResults;
+
+        for (auto *const child : children) {
+            QString matchText = getSearchableText(child);
+            if (!matchText.isEmpty() && matchText.contains(text, Qt::CaseInsensitive)) {
+                matchText.remove('&');
+                auto *const item = new QListWidgetItem(QString("  \xE2\x80\xA2 %1").arg(matchText));
+                item->setData(Qt::UserRole, QVariant::fromValue(static_cast<QObject *>(child)));
+                pageResults.append(item);
+                anyChildMatches = true;
+            }
+        }
+
+        const bool pageMatches = page.name.contains(text, Qt::CaseInsensitive);
+        if (pageMatches || anyChildMatches) {
+            page.item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
+
+            auto *const headerItem = new QListWidgetItem(page.item->icon(), page.name);
+            headerItem->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
+            headerItem->setData(Qt::UserRole,
+                                QVariant::fromValue(static_cast<QObject *>(page.widget)));
+            QFont font = headerItem->font();
+            font.setBold(true);
+            headerItem->setFont(font);
+            ui->searchResultsList->addItem(headerItem);
+
+            for (auto *res : pageResults) {
+                ui->searchResultsList->addItem(res);
+            }
+        } else {
+            page.item->setFlags(Qt::NoItemFlags);
+
+            // If the current sidebar selection is being disabled, clear it
+            if (ui->contentsWidget->currentItem() == page.item) {
+                const QSignalBlocker blocker{ui->contentsWidget};
+                ui->contentsWidget->setCurrentItem(nullptr);
+            }
+        }
+    }
+
+    if (ui->searchResultsList->count() > 0) {
+        ui->rightStack->setCurrentIndex(StackPage::SearchResults);
+    } else {
+        ui->rightStack->setCurrentIndex(StackPage::NoResults);
+    }
+
+    ui->searchBar->setFocus();
+}
+
+void ConfigDialog::slot_onResultSelected(QListWidgetItem *const item)
+{
+    if (item == nullptr) {
+        return;
+    }
+
+    auto *const widget = qobject_cast<QWidget *>(item->data(Qt::UserRole).value<QObject *>());
+    if (widget == nullptr) {
+        return;
+    }
+
+    ui->searchBar->clear();
+    ui->rightStack->setCurrentIndex(StackPage::Preferences);
+
+    // Find which page this widget belongs to
+    for (const auto &page : m_pages) {
+        if (page.widget == widget || page.widget->isAncestorOf(widget)) {
+            const QSignalBlocker blocker{ui->contentsWidget};
+            ui->contentsWidget->setCurrentItem(page.item);
+
+            scrollToWidget(widget, true);
+            break;
+        }
+    }
 }

--- a/src/preferences/configdialog.h
+++ b/src/preferences/configdialog.h
@@ -8,42 +8,57 @@
 #include "../global/macros.h"
 
 #include <QDialog>
-#include <QString>
 
-class QListWidgetItem;
-class QObject;
-class QShowEvent;
-class QStackedWidget;
-class QWidget;
+class QLabel;
+class QSpacerItem;
 
 namespace Ui {
 class ConfigDialog;
 }
 
-class NODISCARD_QOBJECT ConfigDialog final : public QDialog
+class QListWidgetItem;
+class QStackedWidget;
+
+class QTimer;
+
+class ConfigDialog final : public QDialog
 {
     Q_OBJECT
 
 private:
-    Ui::ConfigDialog *const ui;
-    QStackedWidget *m_pagesWidget = nullptr;
+    struct PageInfo
+    {
+        QString name;
+        QWidget *widget;
+        QListWidgetItem *item;
+        QWidget *container; // wraps section header + page widget
+    };
+
+    Ui::ConfigDialog *ui;
+    QList<PageInfo> m_pages;
+    QTimer *m_searchTimer = nullptr;
 
 public:
-    explicit ConfigDialog(QWidget *parent);
-    ~ConfigDialog() final;
+    explicit ConfigDialog(QWidget *parent = nullptr);
+    ~ConfigDialog() override;
+
+private:
+    void scrollToWidget(QWidget *target, bool focus = false);
 
 protected:
     void closeEvent(QCloseEvent *event) override;
     void showEvent(QShowEvent *event) override;
 
-private:
-    void createIcons();
+private slots:
+    void slot_changePage(QListWidgetItem *current, QListWidgetItem * /*previous*/);
+    void slot_onScroll(int value);
+    void slot_ok();
+    void slot_cancel();
+    void slot_search(const QString &text);
+    void slot_onResultSelected(QListWidgetItem *item);
 
 signals:
     void sig_graphicsSettingsChanged();
     void sig_groupSettingsChanged();
     void sig_loadConfig();
-
-public slots:
-    void slot_changePage(QListWidgetItem *current, QListWidgetItem *previous);
 };

--- a/src/preferences/configdialog.ui
+++ b/src/preferences/configdialog.ui
@@ -6,106 +6,198 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>666</width>
-    <height>650</height>
+    <width>900</width>
+    <height>761</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="_4">
+  <layout class="QVBoxLayout" name="mainLayout">
    <item>
-    <layout class="QHBoxLayout" name="_3">
+    <layout class="QHBoxLayout" name="topLayout">
      <item>
-      <widget class="QListWidget" name="contentsWidget">
-       <property name="minimumSize">
-        <size>
-         <width>110</width>
-         <height>0</height>
-        </size>
+      <widget class="QLineEdit" name="searchBar">
+       <property name="placeholderText">
+        <string>Search settings...</string>
        </property>
-       <property name="maximumSize">
-        <size>
-         <width>110</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="iconSize">
-        <size>
-         <width>70</width>
-         <height>70</height>
-        </size>
-       </property>
-       <property name="spacing">
-        <number>9</number>
-       </property>
-       <property name="viewMode">
-        <enum>QListView::IconMode</enum>
+       <property name="clearButtonEnabled">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
-     <item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QSplitter" name="mainSplitter">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <widget class="QListWidget" name="contentsWidget">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="sizeAdjustPolicy">
+       <enum>QAbstractScrollArea::SizeAdjustPolicy::AdjustToContents</enum>
+      </property>
+     </widget>
+     <widget class="QStackedWidget" name="rightStack">
+      <property name="currentIndex">
+       <number>0</number>
+      </property>
       <widget class="QScrollArea" name="pagesScrollArea">
-       <property name="minimumSize">
-        <size>
-         <width>520</width>
-         <height>300</height>
-        </size>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="horizontalScrollBarPolicy">
+        <enum>Qt::ScrollBarPolicy::ScrollBarAsNeeded</enum>
        </property>
        <property name="widgetResizable">
         <bool>true</bool>
        </property>
        <widget class="QWidget" name="scrollAreaWidgetContents">
-        <property name="geometry">
-         <rect>
-          <x>0</x>
-          <y>0</y>
-          <width>518</width>
-          <height>558</height>
-         </rect>
-        </property>
-        <layout class="QHBoxLayout" name="horizontalLayout_3"/>
+        <layout class="QVBoxLayout" name="scrollLayout">
+         <property name="spacing">
+          <number>20</number>
+         </property>
+         <item>
+          <spacer name="verticalSpacer_5">
+           <property name="orientation">
+            <enum>Qt::Orientation::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QWidget" name="footerWidget" native="true">
+           <layout class="QVBoxLayout" name="footerLayout">
+            <property name="spacing">
+             <number>10</number>
+            </property>
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>20</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>20</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="footerLabel">
+              <property name="styleSheet">
+               <string notr="true">color: gray; font-style: italic;</string>
+              </property>
+              <property name="text">
+               <string>The road goes no further.</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignmentFlag::AlignCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item alignment="Qt::AlignmentFlag::AlignCenter">
+             <widget class="QPushButton" name="backToTopBtn">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Back to top</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <spacer name="closeSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>12</width>
-       <height>12</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="_2">
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+      <widget class="QListWidget" name="searchResultsList"/>
+      <widget class="QWidget" name="noResultsPage">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="closeButton">
-       <property name="text">
-        <string>Close</string>
-       </property>
+       <layout class="QVBoxLayout" name="noResultsLayout">
+        <item>
+         <spacer name="verticalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Orientation::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLabel" name="noResultsLabel">
+          <property name="styleSheet">
+           <string notr="true">font-size: 14pt; color: gray; font-weight: bold;</string>
+          </property>
+          <property name="text">
+           <string>No matches found!
+Maybe try searching for something else? 🔎</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignmentFlag::AlignCenter</set>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+          <property name="margin">
+           <number>20</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer_4">
+          <property name="orientation">
+           <enum>Qt::Orientation::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
       </widget>
-     </item>
-    </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/preferences/generalpage.ui
+++ b/src/preferences/generalpage.ui
@@ -6,148 +6,45 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>508</width>
-    <height>944</height>
+    <width>399</width>
+    <height>1093</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form1</string>
   </property>
-  <layout class="QVBoxLayout">
-   <item>
-    <widget class="QGroupBox" name="groupBox_connections">
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="7" column="0">
+    <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
-      <string>Connection</string>
+      <string>Settings Management</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_5">
-      <item row="2" column="0">
-       <widget class="QLabel" name="textLabel4_2">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QPushButton" name="configurationExportButton">
         <property name="text">
-         <string>Local port number:</string>
-        </property>
-        <property name="buddy">
-         <cstring>localPort</cstring>
+         <string>Export...</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="QSpinBox" name="remotePort">
-        <property name="maximum">
-         <number>65535</number>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1" colspan="3">
-       <widget class="QLineEdit" name="remoteName">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="textLabel3_2">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
+      <item>
+       <widget class="QPushButton" name="configurationImportButton">
         <property name="text">
-         <string>Remote port number:</string>
-        </property>
-        <property name="buddy">
-         <cstring>remotePort</cstring>
+         <string>Import...</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
-       <widget class="QSpinBox" name="localPort">
-        <property name="maximum">
-         <number>65535</number>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QCheckBox" name="encryptionCheckBox">
-        <property name="toolTip">
-         <string>Require that your connection to MUME is always secure</string>
-        </property>
+      <item>
+       <widget class="QPushButton" name="configurationResetButton">
         <property name="text">
-         <string>Require encryption</string>
+         <string>Reset to Defaults</string>
         </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="textLabel2_2">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Remote server:</string>
-        </property>
-        <property name="buddy">
-         <cstring>remoteName</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="3">
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Character encoding:</string>
-        </property>
-        <property name="buddy">
-         <cstring>charsetComboBox</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QComboBox" name="charsetComboBox">
-        <item>
-         <property name="text">
-          <string extracomment="Default encoding">Latin-1</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string extracomment="Modern clients only">UTF-8</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string extracomment="No special characters">US-ASCII</string>
-         </property>
-        </item>
        </widget>
       </item>
      </layout>
     </widget>
    </item>
-   <item>
+   <item row="2" column="0">
     <widget class="QGroupBox" name="groupBox_3">
      <property name="title">
       <string>Account</string>
@@ -173,23 +70,310 @@
         </property>
        </widget>
       </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QGroupBox" name="groupBox_modding">
+     <property name="title">
+      <string>Modding</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_modding">
       <item>
-       <spacer name="horizontalSpacer_3">
-        <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
+       <widget class="QLineEdit" name="resourceLineEdit">
+        <property name="placeholderText">
+         <string>Path to resources</string>
         </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="resourcePushButton">
+        <property name="text">
+         <string>Select</string>
         </property>
-       </spacer>
+       </widget>
       </item>
      </layout>
     </widget>
    </item>
-   <item>
+   <item row="4" column="0">
+    <widget class="QGroupBox" name="groupBox_statusbar">
+     <property name="title">
+      <string>Apperance</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <property name="bottomMargin">
+       <number>9</number>
+      </property>
+      <item row="1" column="0" colspan="2">
+       <widget class="QCheckBox" name="displayMumeClockCheckBox">
+        <property name="text">
+         <string>Show Mume clock</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Theme:</string>
+        </property>
+        <property name="buddy">
+         <cstring>themeComboBox</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="themeComboBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
+        <item>
+         <property name="text">
+          <string>System</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Dark</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Light</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="displayXPStatusCheckBox">
+        <property name="text">
+         <string>Show Session XP</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QGroupBox" name="groupBox_4">
+     <property name="title">
+      <string>Proxy</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_7">
+      <item row="0" column="0">
+       <widget class="QLabel" name="textLabel4_2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Port:</string>
+        </property>
+        <property name="buddy">
+         <cstring>localPort</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Character encoding:</string>
+        </property>
+        <property name="buddy">
+         <cstring>charsetComboBox</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="3">
+       <widget class="QCheckBox" name="proxyListensOnAnyInterfaceCheckBox">
+        <property name="toolTip">
+         <string>Allow external traffic to connect to MMapper</string>
+        </property>
+        <property name="text">
+         <string>Expose to local network</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0" colspan="2">
+       <widget class="QCheckBox" name="proxyConnectionStatusCheckBox">
+        <property name="toolTip">
+         <string>Disconnect from the mud client when MUME disconnects</string>
+        </property>
+        <property name="text">
+         <string>Mirror connection status</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1" colspan="2">
+       <widget class="QSpinBox" name="localPort">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
+        <property name="maximum">
+         <number>65535</number>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1" colspan="2">
+       <widget class="QComboBox" name="charsetComboBox">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
+        <item>
+         <property name="text">
+          <string extracomment="Default encoding">Latin-1</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string extracomment="Modern clients only">UTF-8</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string extracomment="No special characters">US-ASCII</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="8" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="groupBox_connections">
+     <property name="title">
+      <string>Remote Server</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_5">
+      <item row="0" column="1" colspan="2">
+       <widget class="QLineEdit" name="remoteName">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="textLabel3_2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Port:</string>
+        </property>
+        <property name="buddy">
+         <cstring>remotePort</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QCheckBox" name="encryptionCheckBox">
+        <property name="toolTip">
+         <string>Require that your connection to MUME is always secure</string>
+        </property>
+        <property name="text">
+         <string>Require encryption</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QSpinBox" name="remotePort">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
+        <property name="maximum">
+         <number>65535</number>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="textLabel2_2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Host:</string>
+        </property>
+        <property name="buddy">
+         <cstring>remoteName</cstring>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QGroupBox" name="groupBox_exits">
+     <property name="title">
+      <string>Emulated Exits</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QCheckBox" name="showHiddenExitFlagsCheckBox">
+        <property name="text">
+         <string>Show hidden exit flags</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="emulatedExitsCheckBox">
+        <property name="text">
+         <string>Show emulated exits</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="showNotesCheckBox">
+        <property name="text">
+         <string>Show notes</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
       <string>Startup</string>
@@ -222,13 +406,6 @@
          <property name="spacing">
           <number>0</number>
          </property>
-         <item row="2" column="0">
-          <widget class="QCheckBox" name="autoLoadCheck">
-           <property name="text">
-            <string>Load world:</string>
-           </property>
-          </widget>
-         </item>
          <item row="2" column="1">
           <widget class="QLineEdit" name="autoLoadFileName">
            <property name="sizePolicy">
@@ -255,6 +432,13 @@
            </property>
           </widget>
          </item>
+         <item row="2" column="0">
+          <widget class="QCheckBox" name="autoLoadCheck">
+           <property name="text">
+            <string>Load world:</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </widget>
       </item>
@@ -268,215 +452,6 @@
      </layout>
     </widget>
    </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_statusbar">
-     <property name="title">
-      <string>Apperance</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_4">
-      <property name="bottomMargin">
-       <number>9</number>
-      </property>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="themeComboBox">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <item>
-         <property name="text">
-          <string>System</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Dark</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Light</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Theme:</string>
-        </property>
-        <property name="buddy">
-         <cstring>themeComboBox</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="QCheckBox" name="displayMumeClockCheckBox">
-        <property name="text">
-         <string>Show Mume clock</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QCheckBox" name="displayXPStatusCheckBox">
-        <property name="text">
-         <string>Show Session XP</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_modding">
-     <property name="title">
-      <string>Modding</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_modding">
-      <item>
-       <widget class="QLineEdit" name="resourceLineEdit">
-        <property name="placeholderText">
-         <string>Path to resources</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="resourcePushButton">
-        <property name="text">
-         <string>Select</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_exits">
-     <property name="title">
-      <string>Emulated Exits</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_6">
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="emulatedExitsCheckBox">
-        <property name="text">
-         <string>Show emulated exits</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QCheckBox" name="showHiddenExitFlagsCheckBox">
-        <property name="text">
-         <string>Show hidden exit flags</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="showNotesCheckBox">
-        <property name="text">
-         <string>Show notes</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="title">
-      <string>Advanced</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="2" column="0">
-       <widget class="QPushButton" name="configurationResetButton">
-        <property name="text">
-         <string>Reset to Default Settings</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QCheckBox" name="proxyConnectionStatusCheckBox">
-        <property name="toolTip">
-         <string>Disconnect from the mud client when MUME disconnects</string>
-        </property>
-        <property name="text">
-         <string>Proxy connection status</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QPushButton" name="configurationImportButton">
-        <property name="text">
-         <string>Import Settings...</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="proxyListensOnAnyInterfaceCheckBox">
-        <property name="toolTip">
-         <string>Allow external traffic to connect to MMapper</string>
-        </property>
-        <property name="text">
-         <string>Proxy listens on any interface</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QPushButton" name="configurationExportButton">
-        <property name="text">
-         <string>Export Settings...</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <spacer name="horizontalSpacer_4">
-        <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="2" column="1" colspan="2">
-       <spacer name="horizontalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Orientation::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
   </layout>
  </widget>
  <tabstops>
@@ -485,6 +460,8 @@
   <tabstop>encryptionCheckBox</tabstop>
   <tabstop>localPort</tabstop>
   <tabstop>charsetComboBox</tabstop>
+  <tabstop>proxyListensOnAnyInterfaceCheckBox</tabstop>
+  <tabstop>proxyConnectionStatusCheckBox</tabstop>
   <tabstop>autoLogin</tabstop>
   <tabstop>setPassword</tabstop>
   <tabstop>checkForUpdateCheckBox</tabstop>
@@ -496,11 +473,9 @@
   <tabstop>displayXPStatusCheckBox</tabstop>
   <tabstop>resourceLineEdit</tabstop>
   <tabstop>resourcePushButton</tabstop>
-  <tabstop>emulatedExitsCheckBox</tabstop>
   <tabstop>showHiddenExitFlagsCheckBox</tabstop>
+  <tabstop>emulatedExitsCheckBox</tabstop>
   <tabstop>showNotesCheckBox</tabstop>
-  <tabstop>proxyListensOnAnyInterfaceCheckBox</tabstop>
-  <tabstop>proxyConnectionStatusCheckBox</tabstop>
   <tabstop>configurationExportButton</tabstop>
   <tabstop>configurationImportButton</tabstop>
   <tabstop>configurationResetButton</tabstop>

--- a/src/preferences/graphicspage.ui
+++ b/src/preferences/graphicspage.ui
@@ -2,14 +2,6 @@
 <ui version="4.0">
  <class>GraphicsPage</class>
  <widget class="QWidget" name="GraphicsPage">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>445</width>
-    <height>507</height>
-   </rect>
-  </property>
   <property name="sizePolicy">
    <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>0</horstretch>
@@ -25,10 +17,7 @@
   <property name="windowTitle">
    <string>Form1</string>
   </property>
-  <layout class="QVBoxLayout">
-   <property name="spacing">
-    <number>6</number>
-   </property>
+  <layout class="QGridLayout" name="gridLayout">
    <property name="leftMargin">
     <number>9</number>
    </property>
@@ -41,90 +30,20 @@
    <property name="bottomMargin">
     <number>9</number>
    </property>
-   <item>
-    <widget class="QGroupBox" name="groupBox_OpenGL">
-     <property name="title">
-      <string>OpenGL</string>
+   <item row="6" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
-     <layout class="QGridLayout">
-      <property name="leftMargin">
-       <number>9</number>
-      </property>
-      <property name="topMargin">
-       <number>9</number>
-      </property>
-      <property name="rightMargin">
-       <number>9</number>
-      </property>
-      <property name="bottomMargin">
-       <number>9</number>
-      </property>
-      <property name="spacing">
-       <number>6</number>
-      </property>
-      <item row="2" column="2">
-       <spacer name="horizontalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="1" column="2">
-       <widget class="QComboBox" name="antialiasingSamplesComboBox">
-        <item>
-         <property name="text">
-          <string>0</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>2</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>4</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>8</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>16</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QCheckBox" name="trilinearFilteringCheckBox">
-        <property name="text">
-         <string>Trilinear filtering</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Anti-aliasing samples:</string>
-        </property>
-        <property name="buddy">
-         <cstring>antialiasingSamplesComboBox</cstring>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
-   <item>
+   <item row="1" column="0">
     <widget class="QGroupBox" name="groupBox_Room">
      <property name="title">
       <string>Room Details</string>
@@ -162,7 +81,185 @@
      </layout>
     </widget>
    </item>
-   <item>
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="groupBox_OpenGL">
+     <property name="title">
+      <string>OpenGL</string>
+     </property>
+     <layout class="QGridLayout">
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
+      <property name="topMargin">
+       <number>9</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
+      <property name="bottomMargin">
+       <number>9</number>
+      </property>
+      <property name="spacing">
+       <number>6</number>
+      </property>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Anti-aliasing samples:</string>
+        </property>
+        <property name="buddy">
+         <cstring>antialiasingSamplesComboBox</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QComboBox" name="antialiasingSamplesComboBox">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
+        <item>
+         <property name="text">
+          <string>0</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>2</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>4</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>8</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>16</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="trilinearFilteringCheckBox">
+        <property name="text">
+         <string>Trilinear filtering</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Orientation::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>10</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QGroupBox" name="groupBox_Colour">
+     <property name="title">
+      <string>Colors</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
+      <property name="topMargin">
+       <number>9</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
+      <property name="bottomMargin">
+       <number>9</number>
+      </property>
+      <property name="spacing">
+       <number>6</number>
+      </property>
+      <item row="3" column="0">
+       <widget class="QLabel" name="connectionNormalLabel">
+        <property name="text">
+         <string>Normal Connection:</string>
+        </property>
+        <property name="buddy">
+         <cstring>connectionNormalPushButton</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="darkLabel">
+        <property name="text">
+         <string>Dark w/o Sundeath:</string>
+        </property>
+        <property name="buddy">
+         <cstring>darkPushButton</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QPushButton" name="connectionNormalPushButton">
+        <property name="text">
+         <string>Select</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QPushButton" name="bgChangeColor">
+        <property name="text">
+         <string>Select</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="darkLitLabel">
+        <property name="text">
+         <string>Light w/o Sundeath:</string>
+        </property>
+        <property name="buddy">
+         <cstring>darkLitPushButton</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="bgLabel">
+        <property name="text">
+         <string>Background:</string>
+        </property>
+        <property name="buddy">
+         <cstring>bgChangeColor</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QPushButton" name="darkLitPushButton">
+        <property name="text">
+         <string>Select</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QPushButton" name="darkPushButton">
+        <property name="text">
+         <string>Select</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="0">
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
       <string>Mapping Hints</string>
@@ -192,112 +289,7 @@
      </layout>
     </widget>
    </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_Colour">
-     <property name="title">
-      <string>Colors</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_3">
-      <property name="leftMargin">
-       <number>9</number>
-      </property>
-      <property name="topMargin">
-       <number>9</number>
-      </property>
-      <property name="rightMargin">
-       <number>9</number>
-      </property>
-      <property name="bottomMargin">
-       <number>9</number>
-      </property>
-      <property name="spacing">
-       <number>6</number>
-      </property>
-      <item row="2" column="1">
-       <widget class="QPushButton" name="darkLitPushButton">
-        <property name="text">
-         <string>Select</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="bgLabel">
-        <property name="text">
-         <string>Background:</string>
-        </property>
-        <property name="buddy">
-         <cstring>bgChangeColor</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="darkLabel">
-        <property name="text">
-         <string>Dark w/o Sundeath:</string>
-        </property>
-        <property name="buddy">
-         <cstring>darkPushButton</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="0" column="1">
-       <widget class="QPushButton" name="bgChangeColor">
-        <property name="text">
-         <string>Select</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="connectionNormalLabel">
-        <property name="text">
-         <string>Normal Connection:</string>
-        </property>
-        <property name="buddy">
-         <cstring>connectionNormalPushButton</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QPushButton" name="darkPushButton">
-        <property name="text">
-         <string>Select</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="darkLitLabel">
-        <property name="text">
-         <string>Light w/o Sundeath:</string>
-        </property>
-        <property name="buddy">
-         <cstring>darkLitPushButton</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QPushButton" name="connectionNormalPushButton">
-        <property name="text">
-         <string>Select</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
+   <item row="4" column="0">
     <widget class="QGroupBox" name="groupBox_Weather">
      <property name="title">
       <string>Weather and Atmosphere</string>
@@ -305,6 +297,12 @@
      <layout class="QGridLayout" name="gridLayout_Weather">
       <item row="0" column="0">
        <widget class="QLabel" name="weatherAtmosphereLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
          <string>Atmosphere Intensity:</string>
         </property>
@@ -312,16 +310,25 @@
       </item>
       <item row="0" column="1">
        <widget class="QSlider" name="weatherAtmosphereSlider">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
         <property name="maximum">
          <number>100</number>
+        </property>
+        <property name="tracking">
+         <bool>false</bool>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
        </widget>
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="weatherPrecipitationLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
          <string>Precipitation Intensity:</string>
         </property>
@@ -329,16 +336,25 @@
       </item>
       <item row="1" column="1">
        <widget class="QSlider" name="weatherPrecipitationSlider">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
         <property name="maximum">
          <number>100</number>
+        </property>
+        <property name="tracking">
+         <bool>false</bool>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
        </widget>
       </item>
       <item row="2" column="0">
        <widget class="QLabel" name="weatherTimeOfDayLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
          <string>Time of Day Intensity:</string>
         </property>
@@ -346,36 +362,26 @@
       </item>
       <item row="2" column="1">
        <widget class="QSlider" name="weatherTimeOfDaySlider">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
         <property name="maximum">
          <number>100</number>
+        </property>
+        <property name="tracking">
+         <bool>false</bool>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
        </widget>
       </item>
      </layout>
     </widget>
    </item>
-   <item>
+   <item row="5" column="0">
     <widget class="QGroupBox" name="groupBox_Advanced">
      <property name="title">
       <string>Advanced Settings</string>
      </property>
     </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>

--- a/src/preferences/grouppage.ui
+++ b/src/preferences/grouppage.ui
@@ -2,14 +2,6 @@
 <ui version="4.0">
  <class>GroupPage</class>
  <widget class="QWidget" name="GroupPage">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>329</width>
-    <height>262</height>
-   </rect>
-  </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
@@ -36,11 +28,11 @@
       <item row="0" column="5">
        <spacer name="horizontalSpacer">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>40</width>
+          <width>10</width>
           <height>20</height>
          </size>
         </property>
@@ -96,11 +88,11 @@
       <item row="1" column="1">
        <spacer name="horizontalSpacer_2">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>40</width>
+          <width>10</width>
           <height>20</height>
          </size>
         </property>
@@ -119,7 +111,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>

--- a/src/preferences/parserpage.ui
+++ b/src/preferences/parserpage.ui
@@ -27,11 +27,11 @@
       <item row="0" column="3">
        <spacer name="horizontalSpacer">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>40</width>
+          <width>10</width>
           <height>20</height>
          </size>
         </property>
@@ -56,10 +56,10 @@
          </font>
         </property>
         <property name="frameShape">
-         <enum>QFrame::StyledPanel</enum>
+         <enum>QFrame::Shape::StyledPanel</enum>
         </property>
         <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+         <enum>QFrame::Shadow::Raised</enum>
         </property>
         <property name="text">
          <string>roomname</string>
@@ -121,10 +121,10 @@
          </font>
         </property>
         <property name="frameShape">
-         <enum>QFrame::StyledPanel</enum>
+         <enum>QFrame::Shape::StyledPanel</enum>
         </property>
         <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+         <enum>QFrame::Shadow::Raised</enum>
         </property>
         <property name="text">
          <string>roomdesc</string>
@@ -179,11 +179,11 @@
       <item row="0" column="2">
        <spacer name="horizontalSpacer_2">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>40</width>
+          <width>10</width>
           <height>20</height>
          </size>
         </property>
@@ -201,11 +201,11 @@
       <item row="0" column="1">
        <spacer name="horizontalSpacer_3">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>40</width>
+          <width>10</width>
           <height>20</height>
          </size>
         </property>
@@ -231,7 +231,7 @@
    <item>
     <spacer>
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>

--- a/src/preferences/pathmachinepage.ui
+++ b/src/preferences/pathmachinepage.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>403</width>
+    <width>421</width>
     <height>350</height>
    </rect>
   </property>
@@ -71,6 +71,9 @@
       </item>
       <item row="2" column="1" colspan="2">
        <widget class="QDoubleSpinBox" name="acceptBestRelativeDoubleSpinBox">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
         <property name="decimals">
          <number>4</number>
         </property>
@@ -81,6 +84,9 @@
       </item>
       <item row="4" column="1" colspan="2">
        <widget class="QDoubleSpinBox" name="newRoomPenaltyDoubleSpinBox">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
         <property name="decimals">
          <number>4</number>
         </property>
@@ -105,6 +111,9 @@
       </item>
       <item row="5" column="1" colspan="2">
        <widget class="QDoubleSpinBox" name="correctPositionBonusDoubleSpinBox">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
         <property name="decimals">
          <number>4</number>
         </property>
@@ -122,6 +131,9 @@
       </item>
       <item row="3" column="1" colspan="2">
        <widget class="QDoubleSpinBox" name="acceptBestAbsoluteDoubleSpinBox">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
         <property name="decimals">
          <number>4</number>
         </property>
@@ -132,6 +144,9 @@
       </item>
       <item row="1" column="1">
        <widget class="QSpinBox" name="matchingToleranceSpinBox">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
         <property name="maximum">
          <number>100</number>
         </property>
@@ -146,6 +161,9 @@
       </item>
       <item row="0" column="1">
        <widget class="QSpinBox" name="maxPaths">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
         <property name="maximum">
          <number>100000</number>
         </property>
@@ -167,6 +185,9 @@
       </item>
       <item row="6" column="1">
        <widget class="QDoubleSpinBox" name="multipleConnectionsPenaltyDoubleSpinBox">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
         <property name="decimals">
          <number>4</number>
         </property>
@@ -181,7 +202,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>


### PR DESCRIPTION
Transition the ConfigDialog from a QStackedWidget to a unified scrollable view with a debounced search and bidirectional sidebar synchronization.

- Add 50ms debounced search with item-specific result mapping.
- Implement scroll-to-widget navigation for search results and sidebar items.
- Synchronize sidebar selection based on current scroll position using QSignalBlocker.
- Refactor ConfigDialog to use a unified scroll layout with section headers.
- Improve UX with "Back to top" navigation and proper focus policies for widgets.
- Standardize UI layouts and size policies across all preference pages.

## Summary by Sourcery

Overhaul the Preferences dialog to use a unified scrollable layout with integrated search and improved navigation.

New Features:
- Add a debounced search field that filters preference pages and lists matching controls with clickable results.
- Provide clickable search results and sidebar items that scroll directly to the corresponding preference section or control.
- Introduce a sidebar-synchronized scrolling experience that keeps the active section selection in sync with scroll position.
- Add a "Back to top" control for quickly returning to the first preference section.

Enhancements:
- Refactor the ConfigDialog from a stacked-page widget to a single scrollable layout with section headers for each preference page.
- Unify dialog button handling with explicit OK/Cancel behavior that writes or reloads configuration as appropriate.
- Standardize and adjust preference page widgets and headers to better support search, focus management, and layout consistency.