### PR TITLE
fix heap-use-after-free crash in _dirs

### DIFF
--- a/src/mapdata/shortestpath.cpp
+++ b/src/mapdata/shortestpath.cpp
@@ -125,7 +125,7 @@ void MapData::shortestPathSearch(const RoomHandle &origin,
         const int spindex = utils::pop_top(future_paths).second;
         // REVISIT: Should thisr be a copy or a reference?
         // (can sp_nodes be modified during the lifetime of the reference?)
-        const auto &thisr = sp_nodes[spindex].r;
+        const auto thisr = sp_nodes[spindex].r;
         const auto thisdist = sp_nodes[spindex].dist;
         auto room_id = thisr.getId();
         if (visited.contains(room_id)) {


### PR DESCRIPTION
Fixes https://github.com/MUME/MMapper/issues/519

## Summary by Sourcery

Refactor the shortest-path search to safely compute and emit path results without using invalidated node references, fixing a crash in the pathfinding logic.

Bug Fixes:
- Prevent heap-use-after-free in shortest-path search by avoiding storing pointers into a resizable node container and by validating room handles before use.

Enhancements:
- Rework shortest-path result passing to use an explicit ShortestPathResult struct containing the endpoint room and direction sequence.
- Switch shortest-path internals from Qt containers to STL containers and use typed indices with bounds-friendly defaults.
- Factor terrain and movement cost constants into named constexpr values and simplify cost computation via enum iteration macros.
- Add timing instrumentation to shortestPathSearch for performance visibility.
- Simplify shortest-path emission logic in the parser to consume the new result structure and handle the origin (here) case cleanly.