### PR TITLE
speed up Find Rooms dialog

### DIFF
--- a/src/mainwindow/findroomsdlg.cpp
+++ b/src/mainwindow/findroomsdlg.cpp
@@ -159,7 +159,7 @@ void FindRoomsDlg::slot_findClicked()
             item->setText(1, roomName);
             item->setToolTip(0, toolTip);
             item->setToolTip(1, toolTip);
-        };
+        }
     } catch (const std::exception &ex) {
         qWarning() << "Exception: " << ex.what();
         QMessageBox::critical(this,

--- a/src/mainwindow/findroomsdlg.cpp
+++ b/src/mainwindow/findroomsdlg.cpp
@@ -147,7 +147,8 @@ void FindRoomsDlg::slot_findClicked()
     try {
         RoomFilter filter(text, cs, regex, kind);
         const Map &map = m_mapData.getCurrentMap();
-        map.getRooms().for_each([this, &filter, &map](const auto roomId) {
+        auto found = m_mapData.genericFind(filter);
+        for (const auto roomId : found) {
             const auto &room = map.getRoomHandle(roomId);
             if (!filter.filter(room.getRaw())) {
                 return;
@@ -162,7 +163,7 @@ void FindRoomsDlg::slot_findClicked()
             item->setText(1, roomName);
             item->setToolTip(0, toolTip);
             item->setToolTip(1, toolTip);
-        });
+        };
     } catch (const std::exception &ex) {
         qWarning() << "Exception: " << ex.what();
         QMessageBox::critical(this,

--- a/src/mainwindow/findroomsdlg.cpp
+++ b/src/mainwindow/findroomsdlg.cpp
@@ -150,10 +150,6 @@ void FindRoomsDlg::slot_findClicked()
         auto found = m_mapData.genericFind(filter);
         for (const auto roomId : found) {
             const auto &room = map.getRoomHandle(roomId);
-            if (!filter.filter(room.getRaw())) {
-                return;
-            }
-
             QString id = QString("%1").arg(room.getIdExternal().asUint32());
             QString roomName = room.getName().toQString();
             QString toolTip = constructToolTip(room);

--- a/src/mapdata/GenericFind.cpp
+++ b/src/mapdata/GenericFind.cpp
@@ -3,17 +3,37 @@
 
 #include "GenericFind.h"
 
+#include "../global/Timer.h"
+#include "../global/thread_utils.h"
 #include "../map/Map.h"
 #include "roomfilter.h"
 
 RoomIdSet genericFind(const Map &map, const RoomFilter &f)
 {
-    RoomIdSet result;
-    map.getRooms().for_each([&result, &map, &f](const RoomId id) {
-        const auto &room = map.getRawRoom(id);
-        if (f.filter(room)) {
-            result.insert(id);
-        }
-    });
-    return result;
+    DECL_TIMER(t, "genericFind");
+
+    struct NODISCARD TlFinder
+    {
+        RoomIdSet result;
+    };
+
+    ProgressCounter pc;
+    TlFinder data;
+
+    thread_utils::parallel_for_each_tl<TlFinder>(
+        map.getRooms(),
+        pc,
+        [&map, &f](TlFinder &tl, const RoomId id) {
+            const auto &room = map.getRawRoom(id);
+            if (f.filter(room)) {
+                tl.result.insert(id);
+            }
+        },
+        [&data](auto &tls) {
+            for (auto &tl : tls) {
+                data.result.insertAll(tl.result);
+            }
+        });
+
+    return data.result;
 }


### PR DESCRIPTION
## Summary by Sourcery

Parallelize room search in the generic find routine and reuse it from the Find Rooms dialog to improve performance and centralize filtering logic.

New Features:
- Introduce a generic parallel room search helper that filters rooms across the map and returns matching room IDs.

Enhancements:
- Refactor the Find Rooms dialog to use the shared generic room search instead of performing its own room iteration.
- Add timing instrumentation and progress tracking to the generic room search to monitor performance.