### PR TITLE
enable PWA support for Wasm deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && \
     libgl1-mesa-dev \
     libglib2.0-0 \
     libxkbcommon-dev \
+    librsvg2-bin \
     ninja-build \
     pkg-config \
     python3 \

--- a/cmake/WasmHtml.cmake
+++ b/cmake/WasmHtml.cmake
@@ -12,7 +12,7 @@
 #         -DFAVICON_SRC=<path/mmapper-lo-release.svg>
 #         -P WasmHtml.cmake
 
-foreach(var HTML_FILE LOGO_SRC FAVICON_SRC)
+foreach(var HTML_FILE LOGO_SRC FAVICON_SRC THEME_COLOR)
     if(NOT ${var})
         message(FATAL_ERROR "${var} not specified for WasmHtml.cmake")
     endif()
@@ -20,10 +20,10 @@ endforeach()
 
 file(READ "${HTML_FILE}" HTML_CONTENT)
 
-# Inject favicon link and COI service worker script after <head>
+# Inject favicon link, PWA manifest, and COI service worker script after <head>
 string(REPLACE
     "<head>"
-    "<head>\n    <link rel=\"icon\" href=\"favicon.svg\" type=\"image/svg+xml\">\n    <script src=\"./coi-serviceworker.js\"></script>"
+    "<head>\n    <link rel=\"icon\" href=\"favicon.svg\" type=\"image/svg+xml\">\n    <link rel=\"manifest\" href=\"manifest.json\">\n    <meta name=\"theme-color\" content=\"${THEME_COLOR}\">\n    <script src=\"./coi-serviceworker.js\"></script>"
     HTML_CONTENT "${HTML_CONTENT}"
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -856,15 +856,52 @@ endif()
 
 if(EMSCRIPTEN)
     add_dependencies(mmapper assets_manifest)
+    if(MMAPPER_BETA)
+        set(MMAPPER_THEME_COLOR "#5281c4")
+    else()
+        set(MMAPPER_THEME_COLOR "#32a6de")
+    endif()
+
+    configure_file(resources/wasm/manifest.json.in ${CMAKE_CURRENT_BINARY_DIR}/manifest.json @ONLY)
+
+    set(ICON_SVG "${CMAKE_SOURCE_DIR}/src/resources/icons/mmapper-hi-${MMAPPER_BRAND_SUFFIX}.svg")
+    set(ICON_192 "${CMAKE_CURRENT_BINARY_DIR}/icon-192.png")
+    set(ICON_512 "${CMAKE_CURRENT_BINARY_DIR}/icon-512.png")
+
+    find_program(RSVG_CONVERT rsvg-convert)
+    if(RSVG_CONVERT)
+        add_custom_command(
+            OUTPUT "${ICON_192}" "${ICON_512}"
+            COMMAND "${RSVG_CONVERT}" -w 192 -h 192 "${ICON_SVG}" -o "${ICON_192}"
+            COMMAND "${RSVG_CONVERT}" -w 512 -h 512 "${ICON_SVG}" -o "${ICON_512}"
+            DEPENDS "${ICON_SVG}"
+            COMMENT "Generating PNG icons from SVG"
+            VERBATIM
+        )
+        add_custom_target(mmapper_icons DEPENDS "${ICON_192}" "${ICON_512}")
+        add_dependencies(mmapper mmapper_icons)
+    else()
+        message(WARNING "rsvg-convert not found. PWA icons will not be generated.")
+    endif()
+
     add_custom_command(TARGET mmapper POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/manifest.json" "$<TARGET_FILE_DIR:mmapper>/manifest.json"
         COMMAND ${CMAKE_COMMAND}
             "-DHTML_FILE=$<TARGET_FILE_DIR:mmapper>/mmapper.html"
             "-DLOGO_SRC=${CMAKE_SOURCE_DIR}/src/resources/icons/mmapper-hi-${MMAPPER_BRAND_SUFFIX}.svg"
             "-DFAVICON_SRC=${CMAKE_SOURCE_DIR}/src/resources/icons/mmapper-lo-${MMAPPER_BRAND_SUFFIX}.svg"
+            "-DTHEME_COLOR=${MMAPPER_THEME_COLOR}"
             -P "${CMAKE_SOURCE_DIR}/cmake/WasmHtml.cmake"
-        COMMENT "Patching Wasm HTML"
+        COMMENT "Patching Wasm HTML and deploying PWA assets"
         VERBATIM
     )
+    if(RSVG_CONVERT)
+        add_custom_command(TARGET mmapper POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different "${ICON_192}" "$<TARGET_FILE_DIR:mmapper>/icon-192.png"
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different "${ICON_512}" "$<TARGET_FILE_DIR:mmapper>/icon-512.png"
+            VERBATIM
+        )
+    endif()
 endif()
 
 if(WITH_ZLIB AND NOT EMSCRIPTEN)
@@ -984,10 +1021,20 @@ if(EMSCRIPTEN)
             "$<TARGET_FILE_DIR:mmapper>/qtloader.js"
             "$<TARGET_FILE_DIR:mmapper>/logo.svg"
             "$<TARGET_FILE_DIR:mmapper>/favicon.svg"
+            "$<TARGET_FILE_DIR:mmapper>/manifest.json"
             "$<TARGET_FILE_DIR:mmapper>/coi-serviceworker.js"
         DESTINATION "."
         COMPONENT applications
     )
+    if(RSVG_CONVERT)
+        install(
+            FILES
+                "$<TARGET_FILE_DIR:mmapper>/icon-192.png"
+                "$<TARGET_FILE_DIR:mmapper>/icon-512.png"
+            DESTINATION "."
+            COMPONENT applications
+        )
+    endif()
     install(
         FILES "$<TARGET_FILE_DIR:mmapper>/mmapper.html"
         DESTINATION "."

--- a/src/resources/wasm/manifest.json.in
+++ b/src/resources/wasm/manifest.json.in
@@ -1,0 +1,21 @@
+{
+  "name": "MUME Mapper",
+  "short_name": "MMapper",
+  "description": "MMapper is a graphical mapping tool that enhances the MUME (Multi-Users in Middle Earth) game experience.",
+  "start_url": "./",
+  "display": "standalone",
+  "background_color": "@MMAPPER_THEME_COLOR@",
+  "theme_color": "@MMAPPER_THEME_COLOR@",
+  "icons": [
+    {
+      "src": "icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}


### PR DESCRIPTION
- Added librsvg2-bin to Dockerfile for icon generation
- Created PWA manifest template with dynamic theme colors
- Integrated icon generation (192x192, 512x512) into CMake pipeline
- Updated WasmHtml.cmake to inject manifest and theme-color tags
- Set start_url to "./" to match deployment structure

## Summary by Sourcery

Enable PWA support and asset generation for the WebAssembly build and deployment.

New Features:
- Introduce a PWA manifest and theme color configuration for the WebAssembly deployment.
- Generate WebAssembly PWA icons from SVG assets as part of the CMake build pipeline.

Enhancements:
- Inject manifest, theme-color, and service worker tags into the generated Wasm HTML.
- Package the PWA manifest and icons in installation artifacts for the WebAssembly build.

Build:
- Add librsvg2-bin to the Docker image to support SVG-to-PNG icon generation.