### PR TITLE
add atomic saving via .tmp files and ReplaceFileW for Windows

### DIFF
--- a/src/global/io.cpp
+++ b/src/global/io.cpp
@@ -21,6 +21,9 @@
 
 #ifdef Q_OS_WIN
 #include "WinSock.h"
+
+#include <io.h>
+#include <windows.h>
 #endif
 
 namespace io {
@@ -61,7 +64,9 @@ bool fsync(QFile &file) CAN_THROW
 {
     const int handle = file.handle();
 #ifdef Q_OS_WIN
-    return false;
+    if (::FlushFileBuffers(reinterpret_cast<HANDLE>(::_get_osfhandle(handle))) == 0) {
+        throw IOException::withErrorNumber(static_cast<int>(::GetLastError()));
+    }
 #elif defined(Q_OS_MAC)
     if (::fcntl(handle, F_FULLFSYNC) == -1) {
         throw IOException::withCurrentErrno();
@@ -72,6 +77,39 @@ bool fsync(QFile &file) CAN_THROW
     }
 #endif
     return true;
+}
+
+void rename(const QString &from, const QString &to) CAN_THROW
+{
+#ifdef Q_OS_WIN
+    const std::wstring fromW = from.toStdWString();
+    const std::wstring toW = to.toStdWString();
+    if (::ReplaceFileW(toW.c_str(),
+                       fromW.c_str(),
+                       nullptr,
+                       REPLACEFILE_IGNORE_MERGE_ERRORS,
+                       nullptr,
+                       nullptr)
+        == 0) {
+        const auto err = ::GetLastError();
+        if (err == ERROR_FILE_NOT_FOUND) {
+            if (::MoveFileExW(fromW.c_str(),
+                              toW.c_str(),
+                              MOVEFILE_REPLACE_EXISTING | MOVEFILE_COPY_ALLOWED)
+                == 0) {
+                throw IOException::withErrorNumber(static_cast<int>(::GetLastError()));
+            }
+        } else {
+            throw IOException::withErrorNumber(static_cast<int>(err));
+        }
+    }
+#else
+    const auto fromEncoded = QFile::encodeName(from);
+    const auto toEncoded = QFile::encodeName(to);
+    if (::rename(fromEncoded.data(), toEncoded.data()) == -1) {
+        throw IOException::withCurrentErrno();
+    }
+#endif
 }
 
 IOResultEnum fsyncNoexcept(QFile &file) noexcept

--- a/src/global/io.h
+++ b/src/global/io.h
@@ -135,6 +135,8 @@ static_assert(sizeof(ErrorNumberMessage) == 1024);
 
 NODISCARD extern bool fsync(QFile &) CAN_THROW;
 
+extern void rename(const QString &from, const QString &to) CAN_THROW;
+
 NODISCARD extern IOResultEnum fsyncNoexcept(QFile &) noexcept;
 
 NODISCARD extern bool tuneKeepAlive(qintptr socketDescriptor,

--- a/src/mapstorage/filesaver.cpp
+++ b/src/mapstorage/filesaver.cpp
@@ -14,25 +14,18 @@
 
 #include <QIODevice>
 
-static constexpr const bool USE_TMP_SUFFIX = CURRENT_PLATFORM != PlatformEnum::Windows;
-
 static const char *const TMP_FILE_SUFFIX = ".tmp";
 NODISCARD static auto maybe_add_suffix(const QString &filename)
 {
-    return USE_TMP_SUFFIX ? (filename + TMP_FILE_SUFFIX) : filename;
+    return filename + TMP_FILE_SUFFIX;
 }
 
 static void remove_tmp_suffix(const QString &filename) CAN_THROW
 {
-    if (!USE_TMP_SUFFIX) {
-        return;
-    }
+    const QString from = filename + TMP_FILE_SUFFIX;
+    const QString to = filename;
 
-    const auto from = QFile::encodeName(filename + TMP_FILE_SUFFIX);
-    const auto to = QFile::encodeName(filename);
-    if (::rename(from.data(), to.data()) == -1) {
-        throw io::IOException::withCurrentErrno();
-    }
+    io::rename(from, to);
 }
 
 FileSaver::~FileSaver()


### PR DESCRIPTION
## Summary by Sourcery

Add atomic file saving support using temporary files and platform-specific rename semantics, including proper fsync handling on Windows.

Bug Fixes:
- Ensure file data is reliably flushed to disk on Windows by implementing fsync via FlushFileBuffers.
- Perform atomic renames on Windows using ReplaceFileW with a MoveFileExW fallback when the target file does not exist.

Enhancements:
- Unify temporary file save behavior across platforms by always writing to .tmp files and renaming them via a shared io::rename helper.