### PR TITLE
Add weather clock and fix weather parsing

### DIFF
--- a/src/clock/mumeclockwidget.cpp
+++ b/src/clock/mumeclockwidget.cpp
@@ -38,6 +38,10 @@ MumeClockWidget::MumeClockWidget(GameObserver &observer, MumeClock &clock, QWidg
                                                 });
     observer.sig2_seasonChanged.connect(m_lifetime,
                                         [this](MumeSeasonEnum season) { updateSeason(season); });
+    observer.sig2_weatherChanged.connect(m_lifetime, [this](PromptWeatherEnum weather) {
+        updateWeather(weather);
+    });
+    observer.sig2_fogChanged.connect(m_lifetime, [this](PromptFogEnum fog) { updateFog(fog); });
     observer.sig2_tick.connect(m_lifetime,
                                [this](const MumeMoment &moment) { updateCountdown(moment); });
 
@@ -47,6 +51,8 @@ MumeClockWidget::MumeClockWidget(GameObserver &observer, MumeClock &clock, QWidg
     updateMoonVisibility(moment.moonVisibility());
     updateSeason(moment.toSeason());
     updateCountdown(moment);
+    updateWeather(PromptWeatherEnum::NICE);
+    updateFog(PromptFogEnum::NO_FOG);
 }
 
 MumeClockWidget::~MumeClockWidget() = default;
@@ -158,6 +164,60 @@ void MumeClockWidget::updateSeason(MumeSeasonEnum season)
     }
     seasonLabel->setStyleSheet(styleSheet);
     seasonLabel->setText(text);
+}
+
+void MumeClockWidget::updateWeather(PromptWeatherEnum weather)
+{
+    switch (weather) {
+    case PromptWeatherEnum::CLOUDS:
+        weatherLabel->setText(QString::fromUtf8("\xE2\x98\x81"));
+        weatherLabel->setStatusTip("Cloudy");
+        weatherLabel->setVisible(true);
+        break;
+    case PromptWeatherEnum::RAIN:
+        weatherLabel->setText(QString::fromUtf8("\xF0\x9F\x8C\xA7"));
+        weatherLabel->setStatusTip("Rainy");
+        weatherLabel->setVisible(true);
+        break;
+    case PromptWeatherEnum::HEAVY_RAIN:
+        weatherLabel->setText(QString::fromUtf8("\xE2\x9B\x88"));
+        weatherLabel->setStatusTip("Heavy Rain");
+        weatherLabel->setVisible(true);
+        break;
+    case PromptWeatherEnum::SNOW:
+        weatherLabel->setText(QString::fromUtf8("\xE2\x9D\x84"));
+        weatherLabel->setStatusTip("Snowy");
+        weatherLabel->setVisible(true);
+        break;
+    case PromptWeatherEnum::NICE:
+    default:
+        weatherLabel->setText("");
+        weatherLabel->setStatusTip("");
+        weatherLabel->setVisible(false);
+        break;
+    }
+}
+
+void MumeClockWidget::updateFog(PromptFogEnum fog)
+{
+    switch (fog) {
+    case PromptFogEnum::LIGHT_FOG:
+        fogLabel->setText(QString::fromUtf8("\xF0\x9F\x8C\xAB"));
+        fogLabel->setStatusTip("Light Fog");
+        fogLabel->setVisible(true);
+        break;
+    case PromptFogEnum::HEAVY_FOG:
+        fogLabel->setText(QString::fromUtf8("\xF0\x9F\x8C\xAB\xF0\x9F\x8C\xAB"));
+        fogLabel->setStatusTip("Heavy Fog");
+        fogLabel->setVisible(true);
+        break;
+    case PromptFogEnum::NO_FOG:
+    default:
+        fogLabel->setText("");
+        fogLabel->setStatusTip("");
+        fogLabel->setVisible(false);
+        break;
+    }
 }
 
 void MumeClockWidget::updateCountdown(const MumeMoment &moment)

--- a/src/clock/mumeclockwidget.h
+++ b/src/clock/mumeclockwidget.h
@@ -38,5 +38,7 @@ private:
     void updateMoonPhase(MumeMoonPhaseEnum phase);
     void updateMoonVisibility(MumeMoonVisibilityEnum visibility);
     void updateSeason(MumeSeasonEnum season);
+    void updateWeather(PromptWeatherEnum weather);
+    void updateFog(PromptFogEnum fog);
     void updateStatusTips(const MumeMoment &moment);
 };

--- a/src/clock/mumeclockwidget.ui
+++ b/src/clock/mumeclockwidget.ui
@@ -67,6 +67,20 @@
       </widget>
      </item>
      <item>
+      <widget class="QLabel" name="weatherLabel">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="fogLabel">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QLabel" name="timeLabel">
        <property name="text">
         <string>Clock not set</string>

--- a/src/global/JsonObj.cpp
+++ b/src/global/JsonObj.cpp
@@ -50,7 +50,7 @@ NODISCARD OptJsonNull JsonObj::getNull(const QString &name) const
 {
     if (m_obj.contains(name)) {
         if (auto &&tmp = m_obj.value(name); tmp.isNull()) {
-            return OptJsonNull{};
+            return JsonNull{};
         }
     }
     return std::nullopt;

--- a/src/parser/mumexmlparser-gmcp.cpp
+++ b/src/parser/mumexmlparser-gmcp.cpp
@@ -313,13 +313,14 @@ void MumeXmlParser::parseGmcpCharVitals(const JsonObj &obj)
         } else {
             qWarning().noquote() << "prompt has unknown fog flag:" << *fog;
         }
-    } else if (!obj.getNull("fog")) {
+        m_observer.observeFog(promptFlags.getFogType());
+    } else if (obj.getNull("fog")) {
         if (verbose_debugging) {
             qInfo().noquote() << "fog null";
         }
         promptFlags.setFogType(PromptFogEnum::NO_FOG);
+        m_observer.observeFog(promptFlags.getFogType());
     }
-    m_observer.observeFog(promptFlags.getFogType());
 
     if (auto light = obj.getString("light")) {
         if (verbose_debugging) {
@@ -354,13 +355,14 @@ void MumeXmlParser::parseGmcpCharVitals(const JsonObj &obj)
         } else {
             qWarning().noquote() << "prompt has unknown weather flag:" << *weather;
         }
-    } else if (!obj.getNull("weather")) {
+        m_observer.observeWeather(promptFlags.getWeatherType());
+    } else if (obj.getNull("weather")) {
         if (verbose_debugging) {
             qInfo().noquote() << "weather null";
         }
         promptFlags.setWeatherType(PromptWeatherEnum::NICE);
+        m_observer.observeWeather(promptFlags.getWeatherType());
     }
-    m_observer.observeWeather(promptFlags.getWeatherType());
 }
 
 void MumeXmlParser::parseGmcpEventMoved(const JsonObj &obj)


### PR DESCRIPTION
## Summary by Sourcery

Add weather and fog display to the clock widget and ensure GMCP weather/fog updates and JSON null handling propagate correctly to observers.

New Features:
- Display current weather and fog conditions on the clock widget using dedicated labels and icons.

Bug Fixes:
- Fix GMCP parsing so weather and fog observer notifications are only sent when flags are present or explicitly null.
- Correct JsonObj::getNull to return a populated optional when a JSON field exists and is explicitly null.