### PR TITLE
build: enable ASAN on Windows and configure Windows Clang CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -30,8 +30,6 @@ jobs:
           compiler: 'gcc'
         - os: macos-latest
           compiler: 'msvc'
-        - os: windows-2022
-          compiler: 'clang'
     steps:
     - uses: actions/checkout@v6
       with:
@@ -119,6 +117,16 @@ jobs:
         cache: true
         modules: 'qtwebsockets qtmultimedia'
         tools: 'tools_mingw1310'
+    - if: runner.os == 'Windows' && matrix.compiler == 'clang'
+      name: Install Qt for Windows (LLVM-MinGW)
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: '6.8.3'
+        dir: 'C:\'
+        arch: win64_llvm_mingw
+        cache: true
+        modules: 'qtwebsockets qtmultimedia'
+        tools: 'tools_llvm_mingw1706'
 
       #
       # Build
@@ -135,9 +143,22 @@ jobs:
           echo "C:/Qt/Tools/mingw1310_64/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           $env:PATH = "C:\Qt\Tools\mingw1310_64\bin;$env:PATH"
         }
+        if ('${{ matrix.compiler }}' -eq 'clang') {
+          $llvmDir = Get-ChildItem -Path "C:\Qt\Tools" -Filter "llvm-mingw*" -Directory | Sort-Object Name -Descending | Select-Object -First 1
+          if ($null -ne $llvmDir) {
+            $llvmBin = Join-Path $llvmDir.FullName "bin"
+            echo "$($llvmBin.Replace('\', '/'))" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+            $env:PATH = "$llvmBin;$env:PATH"
+            $env:CC = Join-Path $llvmBin "clang.exe"
+            $env:CXX = Join-Path $llvmBin "clang++.exe"
+          } else {
+            Write-Error "LLVM-MinGW toolchain not found"
+            exit 1
+          }
+        }
         $packageDir = ($env:GITHUB_WORKSPACE -replace '\\', '/') + "/artifact"
         $launcher = ${{ matrix.compiler == 'msvc' && 'sccache' || 'ccache' }}
-        cmake -DCMAKE_BUILD_TYPE=Debug -G 'Ninja' -DWITH_MAP=OFF -DCPACK_PACKAGE_DIRECTORY="$packageDir" -DCMAKE_PREFIX_PATH=$env:QT_ROOT_DIR -DWITH_WEBSOCKET=ON -DWITH_QTKEYCHAIN=ON -DPACKAGE_TYPE=Nsis -DCMAKE_C_COMPILER_LAUNCHER="$launcher" -DCMAKE_CXX_COMPILER_LAUNCHER="$launcher" -S .. || exit -1
+        cmake -DCMAKE_BUILD_TYPE=Debug -G 'Ninja' -DWITH_MAP=OFF -DCPACK_PACKAGE_DIRECTORY="$packageDir" -DCMAKE_PREFIX_PATH=$env:QT_ROOT_DIR -DWITH_WEBSOCKET=ON -DWITH_QTKEYCHAIN=ON -DPACKAGE_TYPE=Nsis -DCMAKE_C_COMPILER_LAUNCHER="$launcher" -DCMAKE_CXX_COMPILER_LAUNCHER="$launcher" -S .. || exit 1
         cmake --build . --parallel
     - if: runner.os == 'Linux' || runner.os == 'macOS'
       name: Build MMapper for Linux and Mac

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,7 +331,7 @@ if(CMAKE_COMPILER_IS_GNUCXX)
             add_compile_options(-fsanitize=address)
             add_link_options(-fsanitize=address)
 
-	    message(STATUS "Building with GCC undefined behavior sanitizer")
+            message(STATUS "Building with GCC undefined behavior sanitizer")
             add_compile_options(-fsanitize=undefined)
             add_link_options(-fsanitize=undefined)
         endif()
@@ -397,14 +397,12 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     endif()
 
     if(MMAPPER_IS_DEBUG)
-        if(NOT WIN32)
-            # segfaults in ASAN initializer on 32-bit Ubuntu 18.04.1 with clang 6.0
-            # note: apparently -fsanitize=address can't be used with gnu libc 2.25+
-            # Ubuntu 18.04.1 has libc 2.27.
-            message(STATUS "Building with Clang address sanitizer")
-            add_compile_options(-fsanitize=address)
-            add_link_options(-fsanitize=address)
-        endif()
+        # segfaults in ASAN initializer on 32-bit Ubuntu 18.04.1 with clang 6.0
+        # note: apparently -fsanitize=address can't be used with gnu libc 2.25+
+        # Ubuntu 18.04.1 has libc 2.27.
+        message(STATUS "Building with Clang address sanitizer")
+        add_compile_options(-fsanitize=address)
+        add_link_options(-fsanitize=address)
 
         if(TRUE)
             message(STATUS "Building with Clang undefined behavior sanitizer")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -472,6 +472,24 @@ if(MSVC)
     add_compile_options(/Zc:__cplusplus)
     add_compile_options(/utf-8)
     add_compile_options(/permissive-)
+
+    if(MMAPPER_IS_DEBUG)
+        message(STATUS "Building with MSVC address sanitizer")
+        add_compile_options(/fsanitize=address)
+        add_compile_options(/Oy-) # Disable frame-pointer omission
+
+        # ASAN is incompatible with /RTC (Runtime Checks)
+        # CMake defaults to /RTC1 for Debug builds. We need to remove it.
+        string(REPLACE "/RTC1" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+        string(REPLACE "/RTC1" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+
+        # Linker flags for ASAN
+        add_link_options(/fsanitize=address)
+        set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} /INCREMENTAL:NO")
+        set(CMAKE_SHARED_LINKER_FLAGS_DEBUG "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} /INCREMENTAL:NO")
+        set(CMAKE_MODULE_LINKER_FLAGS_DEBUG "${CMAKE_MODULE_LINKER_FLAGS_DEBUG} /INCREMENTAL:NO")
+    endif()
+
     if(CMAKE_BUILD_TYPE_UPPER MATCHES "^RELWITHDEBINFO$")
         # improve performance
         string(REPLACE "/Ob1" "/Ob2" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,9 +397,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     endif()
 
     if(MMAPPER_IS_DEBUG)
-        # segfaults in ASAN initializer on 32-bit Ubuntu 18.04.1 with clang 6.0
-        # note: apparently -fsanitize=address can't be used with gnu libc 2.25+
-        # Ubuntu 18.04.1 has libc 2.27.
         message(STATUS "Building with Clang address sanitizer")
         add_compile_options(-fsanitize=address)
         add_link_options(-fsanitize=address)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1147,7 +1147,10 @@ if(WIN32)
     endif()
 
     # Bundle Library Files
-    set(WINDEPLOYQT_ARGS ${WINDEPLOYQT_ARGS} --compiler-runtime --no-translations --no-system-d3d-compiler --no-opengl-sw --verbose 1)
+    set(WINDEPLOYQT_ARGS ${WINDEPLOYQT_ARGS} --no-translations --no-system-d3d-compiler --no-opengl-sw --verbose 1)
+    if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        set(WINDEPLOYQT_ARGS ${WINDEPLOYQT_ARGS} --compiler-runtime)
+    endif()
     find_program(WINDEPLOYQT_APP windeployqt HINTS ${QTDIR} ENV QTDIR PATH_SUFFIXES .)
     message(" - windeployqt path: ${WINDEPLOYQT_APP}")
     message(" - windeployqt args: ${WINDEPLOYQT_ARGS}")


### PR DESCRIPTION
- Enable Clang Address Sanitizer (ASAN) on Windows by removing the !WIN32 check.
- Add MSVC ASAN support in CMake, handling /RTC1 and /INCREMENTAL incompatibilities.
- Enable the Windows Clang build matrix job in GitHub Actions.
- Set up LLVM-MinGW toolchain and Qt installation steps for Windows Clang CI.
- Fix windeployqt flags to omit --compiler-runtime when using Clang on Windows.

## Summary by Sourcery

Enable address sanitizer support across Windows toolchains and extend CI to cover Windows Clang builds with appropriate Qt and deployment configuration.

New Features:
- Enable Clang address sanitizer for debug builds on all supported platforms, including Windows.
- Add MSVC address sanitizer support for debug builds with compatible compiler and linker flags.

Enhancements:
- Adjust Windows deployment configuration to avoid passing --compiler-runtime to windeployqt when using Clang.
- Improve GCC and Clang sanitizer-related CMake configuration formatting and messages.

CI:
- Configure GitHub Actions to install and use the LLVM-MinGW toolchain and Qt for Windows Clang builds.
- Set up environment and compiler selection for Windows Clang jobs in the build matrix and ensure nonzero exit codes on CMake configuration failures.