### PR TITLE
show mana column for solo players with mana

### DIFF
--- a/src/group/groupwidget.cpp
+++ b/src/group/groupwidget.cpp
@@ -1027,6 +1027,13 @@ void GroupWidget::slot_onCharacterUpdated(SharedGroupChar character)
 {
     assert(character);
     deref(m_model).updateCharacter(character);
+
+    const int manaCol = static_cast<int>(ColumnTypeEnum::MANA);
+    const bool hasMana = character->getMana() > 0 || character->getMaxMana() > 0;
+    if (m_table->isColumnHidden(manaCol) == hasMana) {
+        updateColumnVisibility();
+    }
+
     updatePulseTimer();
 }
 


### PR DESCRIPTION
The GroupWidget was hiding the Mana column until the player joined a group, even if the player themselves had mana. This happened because column visibility was only updated when characters were added or removed, but not when they were updated.

This commit modifies GroupWidget::slot_onCharacterUpdated to conditionally trigger updateColumnVisibility() if the updated character's mana status is inconsistent with the current column visibility. This ensures the Mana column appears as soon as the player's vitals (including mana) are first received, while avoiding redundant visibility updates when the state hasn't changed.

## Summary by Sourcery

Bug Fixes:
- Fix mana column remaining hidden for solo players whose characters have mana by updating column visibility when character mana status changes.