### PR TITLE
rework website and move "demo" link to supported platforms

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -18,6 +18,7 @@
     <script src="{{ '/assets/js/download-highlight.js' | relative_url }}"></script>
 </head>
 <body>
+    <a href="#main-content" class="skip-link">Skip to content</a>
     <div class="content-wrapper">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <header style="display: flex; flex-direction: column; align-items: center;">
@@ -26,17 +27,16 @@
                     <h1><a href="{{ '/' | relative_url }}">{{ page.title | default: site.title }}</a></h1>
                 </div>
             </header>
-            <nav>
+            <nav aria-label="Main Navigation">
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="display: inline; margin-left: 10px;"><a href="{{ '/demo/' | relative_url }}">Demo</a></li>
-                    <li style="display: inline; margin-left: 10px;"><a href="{{ '/#download-mmapper' | relative_url }}">Download</a></li>
+                    <li style="display: inline; margin-left: 10px;"><a href="{{ '/#get-mmapper' | relative_url }}">Get</a></li>
                     <li style="display: inline; margin-left: 10px;"><a href="{{ '/changelog.html' | relative_url }}">Changelog</a></li>
                     <li style="display: inline; margin-left: 10px;"><a href="{{ '/about.html' | relative_url }}">About</a></li>
                 </ul>
             </nav>
         </div>
 
-        <main>
+        <main id="main-content">
             {{ content }}
         </main>
 

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -1,6 +1,22 @@
 /* Minimal MMapper Website Styles */
 
 /* Basic Reset & Body */
+.skip-link {
+    position: absolute;
+    top: -40px;
+    left: 0;
+    background: #cc9933;
+    color: #1a1a1a;
+    padding: 8px;
+    z-index: 100;
+    transition: top 0.3s;
+}
+
+.skip-link:focus,
+.skip-link:focus-visible {
+    top: 0;
+}
+
 body {
     margin: 0;
     padding: 0;

--- a/docs/assets/js/download-highlight.js
+++ b/docs/assets/js/download-highlight.js
@@ -1,7 +1,7 @@
 document.addEventListener('DOMContentLoaded', function() {
     let detectedArch = null;
     let isChromeOS = false;
-    const downloadLinks = document.querySelectorAll('.download-link');
+    const downloadLinks = document.querySelectorAll('.download-link, .platform-link');
 
     // --- Architecture Detection (Best Effort) ---
     if (navigator.userAgentData && navigator.userAgentData.architecture) {
@@ -23,17 +23,34 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     // --- Highlight Download Link ---
+    function addRecommendation(link) {
+        link.classList.add('recommended-download');
+        const recommendation = document.createElement('span');
+        recommendation.textContent = ' Recommended';
+        recommendation.classList.add('recommendation-text');
+
+        // Place recommendation outside the link as per user preference
+        if (link.classList.contains('platform-link')) {
+            recommendation.classList.add('platform-recommendation');
+        }
+        link.parentNode.insertBefore(recommendation, link.nextSibling);
+    }
+
     downloadLinks.forEach(link => {
         const href = link.href.toLowerCase();
+        const platform = link.getAttribute('data-platform');
 
         // Do not recommend Windows .exe installers
         if (href.includes('.exe')) {
             return;
         }
 
-        // Only recommend .deb for ChromeOS
-        if (isChromeOS && (href.includes('appimage') || href.includes('flatpak'))) {
-            return;
+        // For ChromeOS, only recommend the Web version
+        if (isChromeOS) {
+            if (platform === 'web') {
+                addRecommendation(link);
+            }
+            return; // Don't recommend anything else on ChromeOS
         }
 
         let linkArch = null;
@@ -44,11 +61,7 @@ document.addEventListener('DOMContentLoaded', function() {
         }
 
         if (detectedArch && linkArch === detectedArch) {
-            link.classList.add('recommended-download');
-            const recommendation = document.createElement('span');
-            recommendation.textContent = ' Recommended';
-            recommendation.classList.add('recommendation-text');
-            link.parentNode.insertBefore(recommendation, link.nextSibling);
+            addRecommendation(link);
         }
     });
 });

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,8 +8,6 @@ title: Play MUME with MMapper
     MMapper is a game client and graphical mapping tool that enhances the MUME (Multi-Users in Middle Earth) experience. It acts as a bridge between the MUME server and your mud client, analyzing real-time game data and visually displaying your character’s position on the map.
 </div>
 
-## Download MMapper
-
 ## Get MMapper
 {: #get-mmapper}
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,19 +10,26 @@ title: Play MUME with MMapper
 
 ## Download MMapper
 
-Choose your operating system to download the latest version {{ site.github.latest_release.tag_name }}:
+## Get MMapper
+{: #get-mmapper}
+
+Choose your preferred platform to start using MMapper {{ site.github.latest_release.tag_name }}:
 
 <div class="platform-links">
-    <a href="{{ '/windows.html' | relative_url }}" class="platform-link">
-        <i class="fab fa-windows"></i>
+    <a href="{{ '/demo/' | relative_url }}" class="platform-link" aria-label="Use MMapper in your Web Browser" data-platform="web">
+        <i class="fas fa-globe" aria-hidden="true"></i>
+        <span>Web</span>
+    </a>
+    <a href="{{ '/windows.html' | relative_url }}" class="platform-link" aria-label="Get MMapper for Windows">
+        <i class="fab fa-windows" aria-hidden="true"></i>
         <span>Windows</span>
     </a>
-    <a href="{{ '/macos.html' | relative_url }}" class="platform-link">
-        <i class="fab fa-apple"></i>
+    <a href="{{ '/macos.html' | relative_url }}" class="platform-link" aria-label="Get MMapper for macOS">
+        <i class="fab fa-apple" aria-hidden="true"></i>
         <span>macOS</span>
     </a>
-    <a href="{{ '/linux.html' | relative_url }}" class="platform-link">
-        <i class="fab fa-linux"></i>
+    <a href="{{ '/linux.html' | relative_url }}" class="platform-link" aria-label="Get MMapper for Linux">
+        <i class="fab fa-linux" aria-hidden="true"></i>
         <span>Linux</span>
     </a>
 </div>

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Download MMapper for Linux
+title: Get MMapper for Linux
 ---
 
 ## Download MMapper for Linux

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -3,7 +3,7 @@ layout: default
 title: Get MMapper for Linux
 ---
 
-## Download MMapper for Linux
+Choose your preferred distribution method below. We recommend using Flathub for a sandboxed environment and easy updates across most Linux distributions.
 
 <a href='https://flathub.org/apps/org.mume.MMapper'>
     <img width='200' alt='Get it on Flathub' src='https://flathub.org/api/badge?locale=en' style="vertical-align: middle;"/>

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Download MMapper for macOS
+title: Get MMapper for macOS
 ---
 
 ## Download MMapper for macOS

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -3,7 +3,8 @@ layout: default
 title: Get MMapper for macOS
 ---
 
-## Download MMapper for macOS
+To install MMapper on macOS, download the Disk Image (DMG) file provided below. MMapper is compatible with both Intel and Apple Silicon processors.
+
 {% for asset in site.github.latest_release.assets %}
 {% if asset.name contains 'sha256' %}
 {% elsif asset.name contains 'dmg' %}

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -3,7 +3,7 @@ layout: default
 title: Get MMapper for Windows
 ---
 
-## Download MMapper for Windows
+MMapper can be installed from the Microsoft Store for a seamless experience, including automatic updates. Alternatively, you can download the standalone installer below.
 
 <a href="https://apps.microsoft.com/detail/9p6f2b68rf7g?referrer=appbadge&mode=direct" style="display: inline-flex; align-items: center; text-decoration: none;">
      <img src="https://get.microsoft.com/images/en-us%20dark.svg" width="200" style="vertical-align: middle;"/>

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -1,13 +1,14 @@
 ---
 layout: default
-title: Download MMapper for Windows
+title: Get MMapper for Windows
 ---
 
 ## Download MMapper for Windows
 
-<a href="https://apps.microsoft.com/detail/9p6f2b68rf7g?referrer=appbadge&mode=direct">
+<a href="https://apps.microsoft.com/detail/9p6f2b68rf7g?referrer=appbadge&mode=direct" style="display: inline-flex; align-items: center; text-decoration: none;">
      <img src="https://get.microsoft.com/images/en-us%20dark.svg" width="200" style="vertical-align: middle;"/>
-</a><span class="recommendation-text"> Recommended</span>
+</a>
+<span class="recommendation-text"> Recommended</span>
 
 {% for asset in site.github.latest_release.assets %}
 {% if asset.name contains 'sha256' %}


### PR DESCRIPTION
## Summary by Sourcery

Revamp the website’s entry points to emphasize a platform-agnostic “Get MMapper” flow, including web access, while improving accessibility and automated download recommendations.

New Features:
- Add a Web platform entry point alongside desktop platforms for using MMapper in the browser.
- Introduce keyboard-accessible skip-to-content navigation and ARIA attributes for main navigation and platform links.

Enhancements:
- Generalize download recommendation highlighting to support both traditional downloads and platform links, with ChromeOS users guided specifically to the Web version.
- Retitle platform-specific pages and homepage section from “Download” to “Get MMapper” and add concise guidance text for each OS page.
- Improve styling and positioning of recommendation labels so they work consistently with platform links and existing buttons.

Documentation:
- Update homepage and platform-specific docs to describe platform choices, including a recommended Flathub install for Linux and clearer install instructions for Windows and macOS.