### PR TITLE
fix parser commands to persist configuration

### DIFF
--- a/src/client/HotkeyManager.cpp
+++ b/src/client/HotkeyManager.cpp
@@ -95,6 +95,7 @@ bool HotkeyManager::setHotkey(const Hotkey &hk, const std::string_view command)
     QVariantMap data = getConfig().hotkeys.data();
     data[mmqt::toQStringUtf8(hk.to_string())] = mmqt::toQStringUtf8(command);
     setConfig().hotkeys.setData(std::move(data));
+    getConfig().write();
     return true;
 }
 
@@ -110,6 +111,7 @@ bool HotkeyManager::removeHotkey(const Hotkey &hk)
     }
     data.remove(key);
     setConfig().hotkeys.setData(std::move(data));
+    getConfig().write();
     return true;
 }
 
@@ -143,9 +145,11 @@ void HotkeyManager::resetToDefaults()
     XFOREACH_DEFAULT_HOTKEYS(X_DEFAULT)
 #undef X_DEFAULT
     setConfig().hotkeys.setData(std::move(data));
+    getConfig().write();
 }
 
 void HotkeyManager::clear()
 {
     setConfig().hotkeys.setData(QVariantMap());
+    getConfig().write();
 }

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -1046,6 +1046,7 @@ void MainWindow::createActions()
 static void setConfigMapMode(const MapModeEnum mode)
 {
     setConfig().general.mapMode = mode;
+    getConfig().write();
 }
 
 void MainWindow::slot_onPlayMode()

--- a/src/parser/AbstractParser-Config.cpp
+++ b/src/parser/AbstractParser-Config.cpp
@@ -198,6 +198,7 @@ void AbstractParser::doConfig(const StringView cmd)
 
                 clone.set(oldValue);
                 fp.setFloat(value);
+                getConfig().write();
                 os << "Changed " << help << " from " << clone.getFloat() << " to " << fp.getFloat()
                    << AnsiOstream::endl;
                 this->graphicsSettingsChanged();
@@ -294,6 +295,7 @@ void AbstractParser::doConfig(const StringView cmd)
                            }
 
                            conf.set(value);
+                           getConfig().write();
                            os << "Set " << conf.getName() << " = " << BoolAlpha(value)
                               << AnsiOstream::endl;
                            graphicsSettingsChanged();

--- a/src/parser/AbstractParser-Group.cpp
+++ b/src/parser/AbstractParser-Group.cpp
@@ -129,6 +129,7 @@ void AbstractParser::parseGroup(StringView input)
             member->setColor(newColor.getQColor());
             if (member->isYou()) {
                 setConfig().groupManager.color = member->getColor();
+                getConfig().write();
             }
             os << "Member " << name << " (" << id << ") has been changed from " << oldColor
                << " to " << newColor << ".\n";

--- a/src/parser/abstractparser.cpp
+++ b/src/parser/abstractparser.cpp
@@ -480,6 +480,7 @@ bool AbstractParser::setCommandPrefix(const char prefix)
         return false;
     }
     setConfig().parser.prefixChar = prefix;
+    getConfig().write();
     showCommandPrefix();
     return true;
 }


### PR DESCRIPTION
This ensures that changes made by the CLI are persisted immediately since they could be undone if the user canceled the Preferences dialog.

## Summary by Sourcery

Ensure configuration changes made via hotkeys, parser commands, and UI actions are written to disk immediately.

Bug Fixes:
- Persist hotkey add/remove/reset/clear operations immediately to avoid losing changes.
- Persist numeric and boolean configuration updates issued via parser commands as soon as they are applied.
- Persist map mode selection changes directly when updated from the main window.
- Persist group color updates for the current user when changed through group parser commands.
- Persist parser command prefix changes immediately after they are set.