### PR TITLE
switch FBO format to GL_RGB8 and remove swizzle

### DIFF
--- a/src/opengl/legacy/FBO.cpp
+++ b/src/opengl/legacy/FBO.cpp
@@ -30,7 +30,7 @@ void FBO::configure(const Viewport &physicalViewport, int requestedSamples)
     resolvedFormat.setAttachment(QOpenGLFramebufferObject::CombinedDepthStencil);
     resolvedFormat.setSamples(0);
     resolvedFormat.setTextureTarget(GL_TEXTURE_2D);
-    resolvedFormat.setInternalTextureFormat(GL_RGBA8);
+    resolvedFormat.setInternalTextureFormat(GL_RGB8);
 
     m_resolvedFbo = std::make_unique<QOpenGLFramebufferObject>(physicalSize, resolvedFormat);
     if (!m_resolvedFbo->isValid()) {
@@ -47,7 +47,7 @@ void FBO::configure(const Viewport &physicalViewport, int requestedSamples)
             msFormat.setAttachment(QOpenGLFramebufferObject::CombinedDepthStencil);
             msFormat.setSamples(actualSamples);
             msFormat.setTextureTarget(GL_TEXTURE_2D_MULTISAMPLE);
-            msFormat.setInternalTextureFormat(GL_RGBA8);
+            msFormat.setInternalTextureFormat(GL_RGB8);
 
             m_multisamplingFbo = std::make_unique<QOpenGLFramebufferObject>(physicalSize, msFormat);
             if (!m_multisamplingFbo->isValid()) {

--- a/src/opengl/legacy/Legacy.cpp
+++ b/src/opengl/legacy/Legacy.cpp
@@ -4,7 +4,6 @@
 #include "Legacy.h"
 
 #include "../../display/Textures.h"
-#include "../../global/ConfigConsts-Computed.h"
 #include "../../global/utils.h"
 #include "../OpenGLTypes.h"
 #include "../UboManager.h"
@@ -395,17 +394,6 @@ void Functions::checkError()
 void Functions::configureFbo(int samples)
 {
     getFBO().configure(getPhysicalViewport(), samples);
-
-    // WebGL2 lacks native support for texture swizzling
-    if constexpr (CURRENT_PLATFORM != PlatformEnum::Wasm) {
-        const GLuint textureId = getFBO().resolvedTextureId();
-        if (textureId != 0) {
-            // Fix Wayland ghosting by forcing the alpha channel of the blit target to 1.0.
-            Base::glBindTexture(GL_TEXTURE_2D, textureId);
-            Base::glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_A, GL_ONE);
-            Base::glBindTexture(GL_TEXTURE_2D, 0);
-        }
-    }
 }
 
 void Functions::bindFbo()


### PR DESCRIPTION
Change internal texture formats from GL_RGBA8 to GL_RGB8. Eliminating the alpha channel forces sampled textures to implicitly return an alpha of 1.0, ensuring fully opaque window composition under Wayland.

## Summary by Sourcery

Switch OpenGL framebuffer object color attachments to RGB8 and rely on implicit alpha of 1.0 for opaque composition under Wayland.

Enhancements:
- Change resolved and multisampled FBO internal texture formats from RGBA8 to RGB8 for color attachments.
- Remove texture alpha-channel swizzle configuration in legacy FBO setup now that alpha is implicitly 1.0.