### PR TITLE
switch from GL_TRIANGLE_FAN to GL_TRIANGLE_STRIP

### DIFF
--- a/src/opengl/legacy/SimpleMesh.cpp
+++ b/src/opengl/legacy/SimpleMesh.cpp
@@ -8,5 +8,5 @@
 void Legacy::drawRoomQuad(Functions &gl, const GLsizei numInstances)
 {
     // The shader uses gl_VertexID to generate quad vertices [0..3]
-    gl.glDrawArraysInstanced(GL_TRIANGLE_FAN, 0, 4, numInstances);
+    gl.glDrawArraysInstanced(GL_TRIANGLE_STRIP, 0, 4, numInstances);
 }

--- a/src/resources/shaders/legacy/room/tex/acolor/vert.glsl
+++ b/src/resources/shaders/legacy/room/tex/acolor/vert.glsl
@@ -14,9 +14,22 @@ out vec3 vTexCoord;
 
 void main()
 {
-    // ccw-order assumes it's a triangle fan (as opposed to a triangle strip)
-    const ivec3[4] ioffsets_ccw = ivec3[4](ivec3(0, 0, 0), ivec3(1, 0, 0), ivec3(1, 1, 0), ivec3(0, 1, 0));
-    ivec3 ioffset = ioffsets_ccw[gl_VertexID];
+#if 0
+    // GL_TRIANGLE_FAN
+    //  3--2
+    //  | /|  Triangles 012 and 023 both use CCW order.
+    //  |/ |  Notice that the four vertices are in CCW order.
+    //  0--1
+    const ivec3[4] ioffsets = ivec3[4](ivec3(0, 0, 0), ivec3(1, 0, 0), ivec3(1, 1, 0), ivec3(0, 1, 0)); // fan
+#else
+    // GL_TRIANGLE_STRIP
+    //  2--3  Note: Triangle strips alternate CCW/CW winding on every other triangle. This means...
+    //  |\ |    triangle 012 is CCW order, but triangle 123 is CW order (backwards).
+    //  | \|  Keep in mind that OpenGL does not actually draw the triangle backwards,
+    //  0--1    so it does not affect glFrontFace() or the gl_FrontFacing variable.
+    const ivec3[4] ioffsets = ivec3[4](ivec3(0, 0, 0), ivec3(1, 0, 0), ivec3(0, 1, 0), ivec3(1, 1, 0)); // strip
+#endif
+    ivec3 ioffset = ioffsets[gl_VertexID];
 
     int texZ = aVertTexCol.w & 0xFF;
     int colorId = (aVertTexCol.w >> 8) % MAX_NAMED_COLORS;


### PR DESCRIPTION
This is a work-around for a bug in VmWare SVGA3D,
which renders GL_TRIANGLE_FAN incorrectly.

Triangle strips are used more often than triangle fans, so bugs with triangle fans are less likely to be tested and reported to driver vendors.

## Summary by Sourcery

Switch room quad rendering from GL_TRIANGLE_FAN to GL_TRIANGLE_STRIP to work around a VMware SVGA3D bug and adjust the vertex shader accordingly.

Enhancements:
- Update the legacy room textured vertex shader to generate vertices suitable for GL_TRIANGLE_STRIP instead of GL_TRIANGLE_FAN, with improved documentation comments.
- Change Legacy::drawRoomQuad to render quads using GL_TRIANGLE_STRIP to avoid driver issues with triangle fans.