### PR TITLE
fix typo and change Freya to Freyja/Fayth

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,7 +1,7 @@
 Dmitrijs Barbarins <lachupe@gmail.com> (Azazello)
 Kevin Wilson <kpwilson@pm.me> (Cuantar)
 'Elval' <ethorondil@gmail.com> (Elval)
-'Freya' <spetsk@gmail.com> (Freya)
+'Freyja/Fayth' <spetsk@gmail.com> (Freyja)
 Kaspar Metsa <kasparmetsa@gmail.com> (Gamor)
 Jan 'Kovis' Struhar <kovis@sourceforge.net> (Kovis)
 Jean-Yves Perrier <jypenator@gmail.com> (Teoli)


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Update AUTHORS file to correct a typo in contributor names and reflect the preferred Freyja/Fayth naming.