### PR TITLE
refactor OpenGL prober and remove support for GL3.3 compat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ if(Qt6OpenGL_FOUND)
                         OUTPUT_VARIABLE OUTPUT)
         file(WRITE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/CheckQtOpenGL33.cpp
             "#include <QOpenGLFunctions_3_3_Core>
-            #ifndef GL_QUADS
+            #ifndef GL_TRIANGLES
             # error
             #endif
             int main(int argc, char** argv) { return 0; }")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,7 @@
 #include "./opengl/OpenGLConfig.h"
 #include "./opengl/OpenGLProber.h"
 
+#include <cstring>
 #include <memory>
 #include <optional>
 
@@ -151,13 +152,20 @@ static bool setSurfaceFormat()
         return false;
     }
     OpenGLConfig::setBackendType(probeResult.backendType);
-    OpenGLConfig::setIsCompat(probeResult.isCompat);
     QSurfaceFormat::setDefaultFormat(probeResult.format);
     return true;
 }
 
 int main(int argc, char **argv)
 {
+#ifndef Q_OS_WASM
+    for (int i = 1; i < argc; ++i) {
+        if (std::strcmp(argv[i], "--probe") == 0) {
+            return OpenGLProber::runSurveyMode(argc, argv);
+        }
+    }
+#endif
+
     setHighDpiScaleFactorRoundingPolicy();
     setEnteredMain();
     if constexpr (IS_DEBUG_BUILD) {

--- a/src/opengl/OpenGL.cpp
+++ b/src/opengl/OpenGL.cpp
@@ -94,12 +94,12 @@ UniqueMesh OpenGL::createPointBatch(const View<ColorVert> batch)
 
 UniqueMesh OpenGL::createPlainLineBatch(const View<glm::vec3> batch)
 {
-    return getFunctions().createPlainBatch(DrawModeEnum::LINES, batch);
+    return getFunctions().createPlainLineBatch(batch);
 }
 
 UniqueMesh OpenGL::createColoredLineBatch(const View<ColorVert> batch)
 {
-    return getFunctions().createColoredBatch(DrawModeEnum::LINES, batch);
+    return getFunctions().createColoredLineBatch(batch);
 }
 
 UniqueMesh OpenGL::createPlainTriBatch(const View<glm::vec3> batch)
@@ -164,14 +164,22 @@ void OpenGL::renderPlain(const DrawModeEnum type,
                          const View<glm::vec3> verts,
                          const GLRenderState &state)
 {
-    getFunctions().renderPlain(type, verts, state);
+    if (type == DrawModeEnum::LINES) {
+        getFunctions().renderPlainLines(verts, state);
+    } else {
+        getFunctions().renderPlain(type, verts, state);
+    }
 }
 
 void OpenGL::renderColored(const DrawModeEnum type,
                            const View<ColorVert> verts,
                            const GLRenderState &state)
 {
-    getFunctions().renderColored(type, verts, state);
+    if (type == DrawModeEnum::LINES) {
+        getFunctions().renderColoredLines(verts, state);
+    } else {
+        getFunctions().renderColored(type, verts, state);
+    }
 }
 
 void OpenGL::renderPoints(const View<ColorVert> verts, const GLRenderState &state)

--- a/src/opengl/OpenGLConfig.cpp
+++ b/src/opengl/OpenGLConfig.cpp
@@ -6,7 +6,6 @@
 namespace OpenGLConfig {
 
 static OpenGLProber::BackendType g_backendType;
-static bool g_isCompat = false;
 static std::string g_glVersionString;
 static std::string g_esVersionString;
 static int g_maxSamples = 0;
@@ -19,16 +18,6 @@ NODISCARD OpenGLProber::BackendType getBackendType()
 void setBackendType(OpenGLProber::BackendType type)
 {
     g_backendType = type;
-}
-
-NODISCARD bool getIsCompat()
-{
-    return g_isCompat;
-}
-
-void setIsCompat(bool isCompat)
-{
-    g_isCompat = isCompat;
 }
 
 NODISCARD std::string getGLVersionString()

--- a/src/opengl/OpenGLConfig.h
+++ b/src/opengl/OpenGLConfig.h
@@ -11,9 +11,6 @@ namespace OpenGLConfig {
 NODISCARD extern OpenGLProber::BackendType getBackendType();
 extern void setBackendType(OpenGLProber::BackendType type);
 
-NODISCARD extern bool getIsCompat();
-extern void setIsCompat(bool isCompat);
-
 NODISCARD extern std::string getGLVersionString();
 extern void setGLVersionString(const std::string &versionString);
 

--- a/src/opengl/OpenGLProber.cpp
+++ b/src/opengl/OpenGLProber.cpp
@@ -49,7 +49,7 @@ OpenGLProber::ProbeResult OpenGLProber::probe()
 #ifdef Q_OS_WASM
     MMLOG_DEBUG() << "Probing for OpenGL support (Wasm/WebGL 2.0)...";
     ProbeResult result;
-    result.backendType = BackendType::ES;
+    result.backendType = BackendType::GLES;
     result.format.setRenderableType(QSurfaceFormat::OpenGLES);
     result.format.setVersion(3, 0);
     result.format.setDepthBufferSize(24);

--- a/src/opengl/OpenGLProber.cpp
+++ b/src/opengl/OpenGLProber.cpp
@@ -4,317 +4,219 @@
 #include "OpenGLProber.h"
 
 #include "../global/ConfigConsts.h"
+#include "../global/TextUtils.h"
 #include "../global/logging.h"
 #include "OpenGLConfig.h"
 
-#include <optional>
-#include <sstream>
-
+#include <QCoreApplication>
+#include <QDir>
+#include <QJsonDocument>
+#include <QJsonObject>
+#ifndef Q_OS_WASM
+#include <QGuiApplication>
 #include <QOpenGLContext>
+#include <QProcess>
+#include <QSurfaceFormat>
+#endif
+#include <QString>
 
 #ifdef WIN32
 #include <windows.h>
 
-extern "C" {
 // Prefer discrete nVidia and AMD GPUs by default on Windows
-__declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
-__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
-}
+extern "C" __declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+extern "C" __declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
 #endif
 
-namespace { // anonymous
+namespace {
 
-struct GLVersion
+OpenGLProber::ProbeResult getFallbackResult()
 {
-    int major = 0;
-    int minor = 0;
-
-    NODISCARD bool operator>(const GLVersion &other) const
-    {
-        return (major > other.major) || (major == other.major && minor > other.minor);
-    }
-
-    NODISCARD bool operator<(const GLVersion &other) const
-    {
-        return (major < other.major) || (major == other.major && minor < other.minor);
-    }
-};
-
-inline std::ostream &operator<<(std::ostream &os, const GLVersion &version)
-{
-    os << version.major << "." << version.minor;
-    return os;
-}
-
-struct GLContextCheckResult
-{
-    bool valid = false;
-    GLVersion version = {0, 0};
-    bool isCore = false;
-    bool isCompat = false;
-    bool isDeprecated = false;
-    bool isDebug = false;
-};
-
-NODISCARD GLContextCheckResult checkContext(QSurfaceFormat format,
-                                            GLVersion version,
-                                            QSurfaceFormat::OpenGLContextProfile profile)
-{
-    GLContextCheckResult result;
-    QOpenGLContext context;
-    context.setFormat(format);
-    if (!context.create()) {
-        MMLOG_DEBUG() << "[GL Check] context.create() failed for requested " << version
-                      << (profile == QSurfaceFormat::CoreProfile ? " Core" : " Compat");
-        return result;
-    }
-
-    QSurfaceFormat actualFormat = context.format();
-
-    result.isCore = (actualFormat.profile() & QSurfaceFormat::CoreProfile);
-    result.isCompat = (actualFormat.profile() & QSurfaceFormat::CompatibilityProfile);
-    result.isDeprecated = (actualFormat.options() & QSurfaceFormat::DeprecatedFunctions);
-    result.isDebug = (actualFormat.options() & QSurfaceFormat::DebugContext);
-    result.version = GLVersion{actualFormat.majorVersion(), actualFormat.minorVersion()};
-
-    context.doneCurrent();
-
-    // Check if the actual OpenGL context meets the minimum requirements
-    bool profileOk = false;
-
-    if (version < GLVersion{3, 2}) {
-        if (profile == QSurfaceFormat::CoreProfile) {
-            // Core profile did not exist before GL 3.2
-            profileOk = false;
-        } else {
-            // Must be compatibility-like
-            profileOk = result.isCompat || result.isDeprecated;
-        }
-    } else {
-        // For GL 3.2+
-        if (profile == QSurfaceFormat::CoreProfile) {
-            profileOk = result.isCore;
-        } else if (profile == QSurfaceFormat::CompatibilityProfile) {
-            profileOk = result.isCompat && result.isDeprecated;
-        }
-    }
-
-    // If the profile is ok, we consider the context valid even if the version is lower than requested.
-    if (profileOk) {
-        result.valid = true;
-        MMLOG_DEBUG() << "[GL Probe] GL " << result.version << (result.isCore ? " Core" : " Compat")
-                      << " is valid";
-    }
-    return result;
-}
-
-NODISCARD std::string formatGLVersionString(const GLContextCheckResult &result)
-{
-    std::ostringstream oss;
-    oss << "GL" << result.version;
-    if (!result.isDeprecated && result.version > GLVersion{3, 1}) {
-        oss << "core";
-    }
-    return oss.str();
-}
-
-NODISCARD std::optional<GLContextCheckResult> probeCore(QSurfaceFormat &testFormat,
-                                                        std::vector<GLVersion> &coreVersions,
-                                                        QSurfaceFormat::FormatOptions optionsCoreOnly)
-{
-    std::optional<GLContextCheckResult> coreResult = std::nullopt;
-    for (auto it = coreVersions.begin(); it != coreVersions.end();) {
-        const auto &version = *it;
-        testFormat.setVersion(version.major, version.minor);
-        testFormat.setProfile(QSurfaceFormat::CoreProfile);
-        testFormat.setOptions(optionsCoreOnly);
-
-        GLContextCheckResult contextCheckResult = checkContext(testFormat,
-                                                               version,
-                                                               QSurfaceFormat::CoreProfile);
-        if (contextCheckResult.valid) {
-            coreResult = contextCheckResult;
-            MMLOG_DEBUG() << "[GL Probe] Found highest supported Core version: "
-                          << contextCheckResult.version;
-            break;
-        } else {
-            it = coreVersions.erase(it);
-        }
-    }
-    return coreResult;
-}
-
-NODISCARD std::optional<GLContextCheckResult> probeCompat(
-    QSurfaceFormat &format,
-    std::vector<GLVersion> versions,
-    QSurfaceFormat::FormatOptions options,
-    std::optional<GLContextCheckResult> coreResult)
-{
-    std::optional<GLContextCheckResult> compatResult = std::nullopt;
-
-    std::vector<GLVersion> compatVersionsToTest = versions;
-    if (coreResult) {
-        // Filter compatVersions to only include versions <= coreResult
-        compatVersionsToTest.erase(std::remove_if(compatVersionsToTest.begin(),
-                                                  compatVersionsToTest.end(),
-                                                  [resultVer = coreResult->version](
-                                                      const GLVersion &ver) {
-                                                      return ver > resultVer;
-                                                  }),
-                                   compatVersionsToTest.end());
-    }
-
-    for (const auto &version : compatVersionsToTest) {
-        format.setVersion(version.major, version.minor);
-        format.setProfile(QSurfaceFormat::CompatibilityProfile);
-        format.setOptions(options);
-        GLContextCheckResult contextCheckResult = checkContext(format,
-                                                               version,
-                                                               QSurfaceFormat::CompatibilityProfile);
-        if (contextCheckResult.valid) {
-            compatResult = contextCheckResult;
-            MMLOG_DEBUG() << "[GL Probe] Found highest supported Compat version: "
-                          << compatResult->version;
-            break;
-        }
-    }
-    return compatResult;
-}
-
-NODISCARD std::string getHighestGLVersion(std::optional<GLContextCheckResult> coreResult,
-                                          std::optional<GLContextCheckResult> compatResult)
-{
-    std::string highestGLVersion;
-    if (coreResult && compatResult) {
-        if (coreResult->version > compatResult->version) {
-            highestGLVersion = formatGLVersionString(*coreResult);
-        } else {
-            highestGLVersion = formatGLVersionString(*compatResult);
-        }
-    } else if (coreResult) {
-        highestGLVersion = formatGLVersionString(*coreResult);
-    } else if (compatResult) {
-        highestGLVersion = formatGLVersionString(*compatResult);
-    } else {
-        highestGLVersion = "Fallback";
-    }
-    return highestGLVersion;
-}
-
-NODISCARD QSurfaceFormat getOptimalFormat(std::optional<GLContextCheckResult> result)
-{
-    QSurfaceFormat format;
-    format.setRenderableType(QSurfaceFormat::OpenGL);
-    format.setDepthBufferSize(24);
-    if (result) {
-        format.setVersion(result->version.major, result->version.minor);
-        format.setProfile(result->isCore ? QSurfaceFormat::CoreProfile
-                                         : QSurfaceFormat::CompatibilityProfile);
-        QSurfaceFormat::FormatOptions options;
-        if (result->isDebug) {
-            options |= QSurfaceFormat::DebugContext;
-        }
-        if (result->isCompat) {
-            options |= QSurfaceFormat::DeprecatedFunctions;
-        }
-        format.setOptions(options);
-        MMLOG_INFO() << "[GL Probe] Optimal running format determined: GL " << format.majorVersion()
-                     << "." << format.minorVersion()
-                     << " Profile: " << (result->isCore ? "Core" : "Compat")
-                     << (result->isDebug ? " (Debug)" : " (NO Debug)");
-    } else {
-        // Fallback for optimal running format if no context was found at all
-        format.setVersion(3, 3);
-        format.setProfile(QSurfaceFormat::CoreProfile);
-        format.setOptions(QSurfaceFormat::DebugContext);
-        MMLOG_ERROR() << "[GL Probe] No suitable GL context found for running format.";
-    }
-    return format;
-}
-
-OpenGLProber::ProbeResult probeOpenGL()
-{
-    if constexpr (NO_OPENGL) {
-        return {};
-    }
-
-    MMLOG_DEBUG() << "Probing for OpenGL support...";
-
-    QSurfaceFormat format;
-    format.setRenderableType(QSurfaceFormat::OpenGL);
-    format.setDepthBufferSize(24);
-
-    QSurfaceFormat::FormatOptions optionsCompat = QSurfaceFormat::DebugContext
-                                                  | QSurfaceFormat::DeprecatedFunctions;
-    QSurfaceFormat::FormatOptions optionsCore = QSurfaceFormat::DebugContext;
-
-    // Define lists of versions to try.
-    std::vector<GLVersion> versions
-        = {{4, 6}, {4, 5}, {4, 4}, {4, 3}, {4, 2}, {4, 1}, {4, 0}, {3, 3}, {3, 2}};
-
-    std::optional<GLContextCheckResult> coreResult = probeCore(format, versions, optionsCore);
-    std::optional<GLContextCheckResult> compatResult = probeCompat(format,
-                                                                   versions,
-                                                                   optionsCompat,
-                                                                   coreResult);
-
     OpenGLProber::ProbeResult result;
-    if (compatResult || coreResult) {
-        result.backendType = OpenGLProber::BackendType::GL;
-        result.highestVersionString = getHighestGLVersion(coreResult, compatResult);
-        OpenGLConfig::setGLVersionString(result.highestVersionString);
-        result.format = getOptimalFormat(compatResult ? compatResult : coreResult);
-        result.isCompat = (compatResult && compatResult->isCompat);
-    }
+    result.backendType = OpenGLProber::BackendType::GL;
+    result.format.setRenderableType(QSurfaceFormat::OpenGL);
+    result.format.setVersion(3, 3);
+    result.format.setProfile(QSurfaceFormat::CoreProfile);
+    result.format.setDepthBufferSize(24);
+    result.highestVersionString = "Fallback";
     return result;
-}
-
-OpenGLProber::ProbeResult probeOpenGLES()
-{
-    if constexpr (NO_GLES) {
-        return {};
-    }
-
-    MMLOG_DEBUG() << "Probing for OpenGL ES support...";
-
-    std::vector<GLVersion> glesVersions = {{3, 2}, {3, 1}, {3, 0}};
-
-    for (const auto &version : glesVersions) {
-        QSurfaceFormat format;
-        format.setRenderableType(QSurfaceFormat::OpenGLES);
-        format.setVersion(version.major, version.minor);
-
-        QOpenGLContext context;
-        context.setFormat(format);
-        if (context.create()) {
-            MMLOG_DEBUG() << "[GL Probe] Found highest supported GLES version: " << version;
-            OpenGLProber::ProbeResult result;
-            result.backendType = OpenGLProber::BackendType::GLES;
-            result.format = format;
-            std::ostringstream oss;
-            oss << "ES" << version;
-            result.highestVersionString = oss.str();
-            OpenGLConfig::setESVersionString(result.highestVersionString);
-            return result;
-        }
-    }
-
-    MMLOG_DEBUG() << "No suitable GLES context found.";
-    return {};
 }
 
 } // namespace
 
 OpenGLProber::ProbeResult OpenGLProber::probe()
 {
-    auto glResult = probeOpenGL();
-    auto glesResult = probeOpenGLES();
-    if (glResult.backendType != BackendType::None) {
-        return glResult;
+#ifdef Q_OS_WASM
+    MMLOG_DEBUG() << "Probing for OpenGL support (Wasm/WebGL 2.0)...";
+    ProbeResult result;
+    result.backendType = BackendType::ES;
+    result.format.setRenderableType(QSurfaceFormat::OpenGLES);
+    result.format.setVersion(3, 0);
+    result.format.setDepthBufferSize(24);
+    result.highestVersionString = "WebGL 2.0";
+    OpenGLConfig::setESVersionString(result.highestVersionString);
+    return result;
+#else
+    if constexpr (NO_OPENGL && NO_GLES) {
+        return {};
     }
-    if (glesResult.backendType != BackendType::None) {
-        return glesResult;
+
+    MMLOG_DEBUG() << "Probing for OpenGL support via --probe subprocess...";
+
+    const QString selfPath = QCoreApplication::applicationFilePath();
+    QProcess process;
+
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    env.insert("ASAN_OPTIONS", "detect_leaks=0");
+    process.setProcessEnvironment(env);
+
+    QStringList args = {"--probe"};
+    const QString platform = QGuiApplication::platformName();
+    if (!platform.isEmpty()) {
+        args << "-platform" << platform;
     }
-    MMLOG_DEBUG() << "No suitable backend found.";
-    return {};
+    process.start(selfPath, args);
+    if (!process.waitForFinished(5000)) {
+        MMLOG_ERROR() << "OpenGL probe subprocess timed out or failed to start. Using fallback.";
+        process.kill();
+        return getFallbackResult();
+    }
+
+    const QByteArray stdoutData = process.readAllStandardOutput();
+    const QByteArray stderrData = process.readAllStandardError();
+    return parseSurveyResult(stdoutData, stderrData);
+#endif
 }
+
+OpenGLProber::ProbeResult OpenGLProber::parseSurveyResult(const QByteArray &stdoutData,
+                                                          const QByteArray &stderrData)
+{
+    const qsizetype start = stdoutData.indexOf('{');
+    const qsizetype end = stdoutData.lastIndexOf('}');
+
+    QJsonDocument doc;
+    if (start != -1 && end != -1 && end > start) {
+        doc = QJsonDocument::fromJson(stdoutData.mid(start, end - start + 1));
+    }
+
+    if (doc.isNull() || !doc.isObject()) {
+        MMLOG_WARNING() << "OpenGL survey returned invalid JSON. Using fallback."
+                        << "\n  stdout:" << stdoutData.toStdString()
+                        << "\n  stderr:" << stderrData.toStdString();
+        return getFallbackResult();
+    }
+
+    QJsonObject obj = doc.object();
+    QString backend = obj["backend"].toString();
+    const bool debugSupported = obj["debug"].toBool();
+
+    ProbeResult result;
+    result.debugSupported = debugSupported;
+    if (debugSupported) {
+        result.format.setOption(QSurfaceFormat::DebugContext);
+    }
+
+    if (backend == "GL") {
+        result.backendType = BackendType::GL;
+        int major = obj["major"].toInt();
+        int minor = obj["minor"].toInt();
+        result.format.setRenderableType(QSurfaceFormat::OpenGL);
+        result.format.setVersion(major, minor);
+        result.format.setProfile(QSurfaceFormat::CoreProfile);
+        result.format.setDepthBufferSize(24);
+        result.highestVersionString = mmqt::toStdStringUtf8(
+            QString("GL%1.%2").arg(major).arg(minor));
+        OpenGLConfig::setGLVersionString(result.highestVersionString);
+    } else if (backend == "ES") {
+        result.backendType = BackendType::GLES;
+        int major = obj["major"].toInt();
+        int minor = obj["minor"].toInt();
+        result.format.setRenderableType(QSurfaceFormat::OpenGLES);
+        result.format.setVersion(major, minor);
+        result.format.setDepthBufferSize(24);
+        result.highestVersionString = mmqt::toStdStringUtf8(
+            QString("ES%1.%2").arg(major).arg(minor));
+        OpenGLConfig::setESVersionString(result.highestVersionString);
+    } else {
+        MMLOG_DEBUG() << "No suitable backend found by survey.";
+        return {};
+    }
+
+    MMLOG_INFO() << "[GL Probe] Survey determined: " << result.highestVersionString.c_str();
+    return result;
+}
+
+#ifndef Q_OS_WASM
+int OpenGLProber::runSurveyMode(int argc, char **argv)
+{
+    QGuiApplication app(argc, argv);
+
+    QJsonObject result;
+
+    struct GLVersion
+    {
+        int major;
+        int minor;
+    };
+
+    // Try OpenGL Core versions from highest to lowest
+    const std::vector<GLVersion> coreVersions
+        = {{4, 6}, {4, 5}, {4, 4}, {4, 3}, {4, 2}, {4, 1}, {4, 0}, {3, 3}};
+
+    bool foundBackend = false;
+    for (const auto &v : coreVersions) {
+        QSurfaceFormat format;
+        format.setRenderableType(QSurfaceFormat::OpenGL);
+        format.setVersion(v.major, v.minor);
+        format.setProfile(QSurfaceFormat::CoreProfile);
+        format.setOption(QSurfaceFormat::DebugContext);
+
+        QOpenGLContext context;
+        context.setFormat(format);
+        if (context.create()) {
+            const QSurfaceFormat actual = context.format();
+            if (actual.profile() == QSurfaceFormat::CoreProfile
+                && (actual.majorVersion() > v.major
+                    || (actual.majorVersion() == v.major && actual.minorVersion() >= v.minor))) {
+                result["backend"] = "GL";
+                result["major"] = actual.majorVersion();
+                result["minor"] = actual.minorVersion();
+                result["debug"] = actual.testOption(QSurfaceFormat::DebugContext);
+                foundBackend = true;
+                break;
+            }
+        }
+    }
+
+    if (!foundBackend) {
+        const std::vector<GLVersion> glesVersions = {{3, 2}, {3, 1}, {3, 0}};
+        for (const auto &v : glesVersions) {
+            QSurfaceFormat format;
+            format.setRenderableType(QSurfaceFormat::OpenGLES);
+            format.setVersion(v.major, v.minor);
+            format.setOption(QSurfaceFormat::DebugContext);
+
+            QOpenGLContext context;
+            context.setFormat(format);
+            if (context.create()) {
+                const QSurfaceFormat actual = context.format();
+                result["backend"] = "ES";
+                result["major"] = actual.majorVersion();
+                result["minor"] = actual.minorVersion();
+                result["debug"] = actual.testOption(QSurfaceFormat::DebugContext);
+                foundBackend = true;
+                break;
+            }
+        }
+    }
+
+    if (result.isEmpty()) {
+        result["backend"] = "None";
+    }
+
+    const QByteArray output = QJsonDocument(result).toJson(QJsonDocument::Compact);
+    fprintf(stdout, "\n%s\n", output.constData());
+    fflush(stdout);
+    return 0;
+}
+#endif

--- a/src/opengl/OpenGLProber.h
+++ b/src/opengl/OpenGLProber.h
@@ -7,6 +7,7 @@
 
 #include <string>
 
+#include <QByteArray>
 #include <QSurfaceFormat>
 
 class NODISCARD OpenGLProber final
@@ -19,7 +20,7 @@ public:
         BackendType backendType = BackendType::None;
         QSurfaceFormat format;
         std::string highestVersionString = "Unknown";
-        bool isCompat = false;
+        bool debugSupported = false;
     };
 
 public:
@@ -28,4 +29,11 @@ public:
     DTOR(OpenGLProber) = default;
 
     NODISCARD ProbeResult probe();
+
+    NODISCARD ProbeResult parseSurveyResult(const QByteArray &stdoutData,
+                                            const QByteArray &stderrData = {});
+
+#ifndef Q_OS_WASM
+    NODISCARD static int runSurveyMode(int argc, char **argv);
+#endif
 };

--- a/src/opengl/OpenGLTypes.h
+++ b/src/opengl/OpenGLTypes.h
@@ -139,9 +139,9 @@ enum class NODISCARD DrawModeEnum {
 
 struct NODISCARD LineParams final
 {
-    float width = 1.f;
-    LineParams() = default;
+    float width = 1.0f;
 
+    LineParams() = default;
     explicit LineParams(const float width_)
         : width{width_}
     {}

--- a/src/opengl/legacy/AbstractShaderProgram.cpp
+++ b/src/opengl/legacy/AbstractShaderProgram.cpp
@@ -171,4 +171,10 @@ void AbstractShaderProgram::setViewport(const char *const name, const Viewport &
     setUniform4iv(location, 1, glm::value_ptr(viewport));
 }
 
+void AbstractShaderProgram::setFloat(const char *const name, const float value)
+{
+    const GLint location = getUniformLocation(name);
+    setUniform1fv(location, 1, &value);
+}
+
 } // namespace Legacy

--- a/src/opengl/legacy/AbstractShaderProgram.h
+++ b/src/opengl/legacy/AbstractShaderProgram.h
@@ -92,6 +92,7 @@ public:
     void setMatrix(const char *name, const glm::mat4 &m);
     void setTexture(const char *name, int textureUnit);
     void setViewport(const char *name, const Viewport &input_viewport);
+    void setFloat(const char *name, float value);
 };
 
 } // namespace Legacy

--- a/src/opengl/legacy/Binders.cpp
+++ b/src/opengl/legacy/Binders.cpp
@@ -106,22 +106,9 @@ DepthBinder::~DepthBinder()
     }
 }
 
-LineParamsBinder::LineParamsBinder(Functions &functions, const LineParams &lineParams)
-    : m_functions{functions}
-    , m_lineParams{lineParams}
-{
-    m_functions.glLineWidth(m_lineParams.width);
-}
+LineParamsBinder::LineParamsBinder(Functions & /*functions*/, const LineParams & /*lineParams*/) {}
 
-LineParamsBinder::~LineParamsBinder()
-{
-    const auto &width = m_lineParams.width;
-    const float ONE = 1.f;
-    static_assert(sizeof(ONE) == sizeof(width));
-    if (!utils::equals(&width, &ONE)) {
-        m_functions.glLineWidth(ONE);
-    }
-}
+LineParamsBinder::~LineParamsBinder() {}
 
 PointSizeBinder::PointSizeBinder(Functions &functions, const std::optional<GLfloat> &pointSize)
     : m_functions{functions}

--- a/src/opengl/legacy/Binders.h
+++ b/src/opengl/legacy/Binders.h
@@ -56,10 +56,6 @@ public:
 
 struct NODISCARD LineParamsBinder
 {
-private:
-    Functions &m_functions;
-    const LineParams &m_lineParams;
-
 public:
     explicit LineParamsBinder(Functions &functions, const LineParams &lineParams);
     ~LineParamsBinder();

--- a/src/opengl/legacy/FunctionsES30.cpp
+++ b/src/opengl/legacy/FunctionsES30.cpp
@@ -4,14 +4,7 @@ namespace Legacy {
 
 FunctionsES30::FunctionsES30(Badge<Functions> badge, UboManager &uboManager)
     : Functions(badge, uboManager)
-{
-    assert(!OpenGLConfig::getIsCompat());
-}
-
-bool FunctionsES30::virt_canRenderQuads()
-{
-    return false;
-}
+{}
 
 std::optional<GLenum> FunctionsES30::virt_toGLenum(const DrawModeEnum mode)
 {

--- a/src/opengl/legacy/FunctionsES30.h
+++ b/src/opengl/legacy/FunctionsES30.h
@@ -17,7 +17,6 @@ public:
 private:
     void virt_enableProgramPointSize(bool enable) override;
     NODISCARD const char *virt_getShaderVersion() const override;
-    NODISCARD bool virt_canRenderQuads() override;
     NODISCARD std::optional<GLenum> virt_toGLenum(DrawModeEnum mode) override;
 };
 

--- a/src/opengl/legacy/FunctionsGL33.cpp
+++ b/src/opengl/legacy/FunctionsGL33.cpp
@@ -1,7 +1,6 @@
 #include "FunctionsGL33.h"
 
 #include "../../global/ConfigConsts.h"
-#include "../OpenGLConfig.h"
 
 #include <optional>
 
@@ -10,11 +9,6 @@ namespace Legacy {
 FunctionsGL33::FunctionsGL33(Badge<Functions> badge, UboManager &uboManager)
     : Functions(badge, uboManager)
 {}
-
-bool FunctionsGL33::virt_canRenderQuads()
-{
-    return OpenGLConfig::getIsCompat();
-}
 
 std::optional<GLenum> FunctionsGL33::virt_toGLenum(const DrawModeEnum mode)
 {
@@ -26,11 +20,6 @@ std::optional<GLenum> FunctionsGL33::virt_toGLenum(const DrawModeEnum mode)
     case DrawModeEnum::TRIANGLES:
         return GL_TRIANGLES;
     case DrawModeEnum::QUADS:
-#ifndef MMAPPER_NO_OPENGL
-        return canRenderQuads() ? std::make_optional(GL_QUADS) : std::nullopt;
-#else
-        FALLTHROUGH;
-#endif
     case DrawModeEnum::INSTANCED_QUADS:
     case DrawModeEnum::INVALID:
         break;
@@ -49,14 +38,8 @@ void FunctionsGL33::virt_enableProgramPointSize(const bool enable)
 #ifndef MMAPPER_NO_OPENGL
     if (enable) {
         Base::glEnable(GL_PROGRAM_POINT_SIZE);
-        if (OpenGLConfig::getIsCompat()) {
-            Base::glEnable(GL_POINT_SPRITE);
-        }
     } else {
         Base::glDisable(GL_PROGRAM_POINT_SIZE);
-        if (OpenGLConfig::getIsCompat()) {
-            Base::glDisable(GL_POINT_SPRITE);
-        }
     }
 #endif
 }

--- a/src/opengl/legacy/FunctionsGL33.h
+++ b/src/opengl/legacy/FunctionsGL33.h
@@ -17,7 +17,6 @@ public:
 private:
     void virt_enableProgramPointSize(bool enable) override;
     NODISCARD const char *virt_getShaderVersion() const override;
-    NODISCARD bool virt_canRenderQuads() override;
     NODISCARD std::optional<GLenum> virt_toGLenum(DrawModeEnum mode) override;
 };
 

--- a/src/opengl/legacy/Legacy.cpp
+++ b/src/opengl/legacy/Legacy.cpp
@@ -111,16 +111,28 @@ UniqueMesh Functions::createPointBatch(const View<ColorVert> batch)
     return createUniqueMesh<PointMesh>(shared_from_this(), DrawModeEnum::POINTS, batch, prog);
 }
 
+UniqueMesh Functions::createPlainLineBatch(View<glm::vec3> batch)
+{
+    const auto &prog = getShaderPrograms().getLineUColorShader();
+    return createUniqueMesh<LineMesh>(shared_from_this(), DrawModeEnum::LINES, batch, prog);
+}
+
+UniqueMesh Functions::createColoredLineBatch(View<ColorVert> batch)
+{
+    const auto &prog = getShaderPrograms().getLineAColorShader();
+    return createUniqueMesh<ColoredLineMesh>(shared_from_this(), DrawModeEnum::LINES, batch, prog);
+}
+
 UniqueMesh Functions::createPlainBatch(const DrawModeEnum mode, const View<glm::vec3> batch)
 {
-    assert(static_cast<size_t>(mode) >= VERTS_PER_LINE);
+    assert(static_cast<size_t>(mode) >= VERTS_PER_TRI);
     const auto &prog = getShaderPrograms().getPlainUColorShader();
     return createUniqueMesh<PlainMesh>(shared_from_this(), mode, batch, prog);
 }
 
 UniqueMesh Functions::createColoredBatch(const DrawModeEnum mode, const View<ColorVert> batch)
 {
-    assert(static_cast<size_t>(mode) >= VERTS_PER_LINE);
+    assert(static_cast<size_t>(mode) >= VERTS_PER_TRI);
     const auto &prog = getShaderPrograms().getPlainAColorShader();
     return createUniqueMesh<ColoredMesh>(shared_from_this(), mode, batch, prog);
 }
@@ -199,11 +211,29 @@ static void renderImmediate(const SharedFunctions &sharedFunctions,
     sharedFunctions->clearVbo(vbo.get());
 }
 
+void Functions::renderPlainLines(const View<glm::vec3> verts, const GLRenderState &state)
+{
+    const auto &shared = shared_from_this();
+    const auto &prog = getShaderPrograms().getLineUColorShader();
+    renderImmediate<glm::vec3, Legacy::LineMesh>(shared, DrawModeEnum::LINES, verts, prog, state);
+}
+
+void Functions::renderColoredLines(const View<ColorVert> verts, const GLRenderState &state)
+{
+    const auto &shared = shared_from_this();
+    const auto &prog = getShaderPrograms().getLineAColorShader();
+    renderImmediate<ColorVert, Legacy::ColoredLineMesh>(shared,
+                                                        DrawModeEnum::LINES,
+                                                        verts,
+                                                        prog,
+                                                        state);
+}
+
 void Functions::renderPlain(const DrawModeEnum mode,
                             const View<glm::vec3> verts,
                             const GLRenderState &state)
 {
-    assert(static_cast<size_t>(mode) >= VERTS_PER_LINE);
+    assert(static_cast<size_t>(mode) >= VERTS_PER_TRI);
     const auto &shared = shared_from_this();
     const auto &prog = getShaderPrograms().getPlainUColorShader();
     renderImmediate<glm::vec3, Legacy::PlainMesh>(shared, mode, verts, prog, state);
@@ -213,7 +243,7 @@ void Functions::renderColored(const DrawModeEnum mode,
                               const View<ColorVert> verts,
                               const GLRenderState &state)
 {
-    assert(static_cast<size_t>(mode) >= VERTS_PER_LINE);
+    assert(static_cast<size_t>(mode) >= VERTS_PER_TRI);
     const auto &prog = getShaderPrograms().getPlainAColorShader();
     renderImmediate<ColorVert, Legacy::ColoredMesh>(shared_from_this(), mode, verts, prog, state);
 }

--- a/src/opengl/legacy/Legacy.h
+++ b/src/opengl/legacy/Legacy.h
@@ -260,15 +260,6 @@ public:
     using Base::glVertexAttribPointer;
 
 public:
-    void glLineWidth(const GLfloat lineWidth)
-    {
-        // REVISIT: Only width 1 is guaranteed to be supported for core profiles
-        if (OpenGLConfig::getIsCompat()) {
-            Base::glLineWidth(lineWidth);
-        }
-    }
-
-public:
     void glViewport(const GLint x, const GLint y, const GLsizei width, const GLsizei height)
     {
         m_viewport = Viewport{{x, y}, {width, height}};
@@ -331,7 +322,6 @@ public:
     NODISCARD const char *getShaderVersion() const { return virt_getShaderVersion(); }
 
 protected:
-    NODISCARD virtual bool virt_canRenderQuads() = 0;
     NODISCARD virtual std::optional<GLenum> virt_toGLenum(DrawModeEnum mode) = 0;
     virtual void virt_enableProgramPointSize(bool enable) = 0;
     NODISCARD virtual const char *virt_getShaderVersion() const = 0;
@@ -339,9 +329,6 @@ protected:
 
 public:
     NODISCARD static const char *getUniformBlockName(SharedVboEnum block);
-
-    /// platform-specific (ES vs GL)
-    NODISCARD bool canRenderQuads() { return virt_canRenderQuads(); }
 
     /// platform-specific (ES vs GL)
     NODISCARD std::optional<GLenum> toGLenum(DrawModeEnum mode) { return virt_toGLenum(mode); }
@@ -412,9 +399,9 @@ public:
                           const BufferUsageEnum usage = BufferUsageEnum::DYNAMIC_DRAW)
     {
         using Pair = std::pair<DrawModeEnum, GLsizei>;
-        if (mode == DrawModeEnum::QUADS && !canRenderQuads()) {
+        if (mode == DrawModeEnum::QUADS) {
             const auto tris = convertQuadsToTris(batch);
-            return Pair{DrawModeEnum::TRIANGLES, setVbo(GL_ARRAY_BUFFER, vbo, View<T>{tris}, usage)};
+            return Pair{DrawModeEnum::TRIANGLES, setVbo(GL_ARRAY_BUFFER, vbo, View{tris}, usage)};
         }
         return Pair{mode, setVbo(GL_ARRAY_BUFFER, vbo, batch, usage)};
     }
@@ -428,6 +415,8 @@ public:
 
 public:
     NODISCARD UniqueMesh createPointBatch(View<ColorVert> batch);
+    NODISCARD UniqueMesh createPlainLineBatch(View<glm::vec3> batch);
+    NODISCARD UniqueMesh createColoredLineBatch(View<ColorVert> batch);
 
 public:
     NODISCARD UniqueMesh createPlainBatch(DrawModeEnum mode, View<glm::vec3> batch);
@@ -449,6 +438,8 @@ public:
 
 public:
     void renderPoints(View<ColorVert> verts, const GLRenderState &state);
+    void renderPlainLines(View<glm::vec3> verts, const GLRenderState &state);
+    void renderColoredLines(View<ColorVert> verts, const GLRenderState &state);
 
     void renderPlain(DrawModeEnum mode, View<glm::vec3> verts, const GLRenderState &state);
     void renderColored(DrawModeEnum mode, View<ColorVert> verts, const GLRenderState &state);

--- a/src/opengl/legacy/Meshes.h
+++ b/src/opengl/legacy/Meshes.h
@@ -63,6 +63,99 @@ private:
     }
 };
 
+template<typename VertexType_>
+class NODISCARD LineMesh final : public SimpleMesh<VertexType_, UColorLineShader>
+{
+public:
+    using Base = SimpleMesh<VertexType_, UColorLineShader>;
+    using Base::Base;
+
+private:
+    struct NODISCARD Attribs final
+    {
+        GLuint vert1Pos = INVALID_ATTRIB_LOCATION;
+        GLuint vert2Pos = INVALID_ATTRIB_LOCATION;
+
+        NODISCARD static Attribs getLocations(AbstractShaderProgram &shader)
+        {
+            Attribs result;
+            result.vert1Pos = shader.getAttribLocation("aVert1");
+            result.vert2Pos = shader.getAttribLocation("aVert2");
+            return result;
+        }
+    };
+
+    std::optional<Attribs> m_boundAttribs;
+
+    void virt_bind() override
+    {
+        const auto vertSize = static_cast<GLsizei>(sizeof(VertexType_));
+        Functions &gl = Base::m_functions;
+        const auto attribs = Attribs::getLocations(Base::m_program);
+        gl.glBindBuffer(GL_ARRAY_BUFFER, Base::m_vbo.get());
+        // aVert1
+        gl.enableAttrib(attribs.vert1Pos, 3, GL_FLOAT, GL_FALSE, 2 * vertSize, nullptr);
+        // aVert2
+        gl.enableAttrib(attribs.vert2Pos, 3, GL_FLOAT, GL_FALSE, 2 * vertSize, VPO_PTR(vertSize));
+
+        // instancing: one line per 4 vertices (quad)
+        gl.glVertexAttribDivisor(attribs.vert1Pos, 1);
+        gl.glVertexAttribDivisor(attribs.vert2Pos, 1);
+
+        m_boundAttribs = attribs;
+    }
+
+    void virt_render(const GLRenderState &renderState) override
+    {
+        if (Base::isEmpty()) {
+            return;
+        }
+
+        Functions &gl = Base::m_functions;
+        gl.checkError();
+
+        const glm::mat4 mvp = renderState.mvp.value_or(gl.getProjectionMatrix());
+        auto programUnbinder = Base::m_program.bind();
+        Base::m_program.setUniforms(mvp, renderState.uniforms);
+        Base::m_program.setViewport("uViewport", gl.getPhysicalViewport());
+        Base::m_program.setFloat("uLineWidth",
+                                 renderState.lineParams.width * gl.getDevicePixelRatio());
+
+        RenderStateBinder renderStateBinder(gl, gl.getTexLookup(), renderState);
+
+        gl.glBindVertexArray(Base::m_vao.get());
+        RAIICallback vaoUnbinder([&gl]() {
+            gl.glBindVertexArray(0);
+            gl.checkError();
+        });
+
+        auto attribUnbinder = Base::bindAttribs();
+
+        const GLsizei numInstances = Base::m_numVerts / 2;
+        gl.glDrawArraysInstanced(GL_TRIANGLE_FAN, 0, 4, numInstances);
+    }
+
+    void virt_unbind() override
+    {
+        if (!m_boundAttribs) {
+            return;
+        }
+        auto &attribs = m_boundAttribs.value();
+        Functions &gl = Base::m_functions;
+        gl.glDisableVertexAttribArray(attribs.vert1Pos);
+        gl.glDisableVertexAttribArray(attribs.vert2Pos);
+        gl.glVertexAttribDivisor(attribs.vert1Pos, 0);
+        gl.glVertexAttribDivisor(attribs.vert2Pos, 0);
+        gl.glBindBuffer(GL_ARRAY_BUFFER, 0);
+        m_boundAttribs.reset();
+    }
+
+    NODISCARD static const void *VPO_PTR(size_t offset)
+    {
+        return reinterpret_cast<const void *>(offset);
+    }
+};
+
 // Per-vertex color
 // flat-shaded in MMapper, due to glShadeModel(GL_FLAT)
 template<typename VertexType_>
@@ -117,7 +210,114 @@ private:
         gl.glBindBuffer(GL_ARRAY_BUFFER, 0);
         m_boundAttribs.reset();
     }
-}; // namespace Legacy
+};
+
+template<typename VertexType_>
+class NODISCARD ColoredLineMesh final : public SimpleMesh<VertexType_, AColorLineShader>
+{
+public:
+    using Base = SimpleMesh<VertexType_, AColorLineShader>;
+    using Base::Base;
+
+private:
+    struct NODISCARD Attribs final
+    {
+        GLuint colorPos = INVALID_ATTRIB_LOCATION;
+        GLuint vert1Pos = INVALID_ATTRIB_LOCATION;
+        GLuint vert2Pos = INVALID_ATTRIB_LOCATION;
+
+        NODISCARD static Attribs getLocations(AbstractShaderProgram &shader)
+        {
+            Attribs result;
+            result.colorPos = shader.getAttribLocation("aColor");
+            result.vert1Pos = shader.getAttribLocation("aVert1");
+            result.vert2Pos = shader.getAttribLocation("aVert2");
+            return result;
+        }
+    };
+
+    std::optional<Attribs> m_boundAttribs;
+
+    void virt_bind() override
+    {
+        const auto vertSize = static_cast<GLsizei>(sizeof(VertexType_));
+        Functions &gl = Base::m_functions;
+        const auto attribs = Attribs::getLocations(Base::m_program);
+        gl.glBindBuffer(GL_ARRAY_BUFFER, Base::m_vbo.get());
+
+        // We assume the color comes from the first vertex of the segment
+        // aColor
+        gl.enableAttrib(attribs.colorPos, 4, GL_UNSIGNED_BYTE, GL_TRUE, 2 * vertSize, VPO(color));
+        // aVert1
+        gl.enableAttrib(attribs.vert1Pos, 3, GL_FLOAT, GL_FALSE, 2 * vertSize, VPO(vert));
+        // aVert2
+        gl.enableAttrib(attribs.vert2Pos,
+                        3,
+                        GL_FLOAT,
+                        GL_FALSE,
+                        2 * vertSize,
+                        VPO_PTR(VPO(vert), vertSize));
+
+        // instancing
+        gl.glVertexAttribDivisor(attribs.colorPos, 1);
+        gl.glVertexAttribDivisor(attribs.vert1Pos, 1);
+        gl.glVertexAttribDivisor(attribs.vert2Pos, 1);
+
+        m_boundAttribs = attribs;
+    }
+
+    void virt_render(const GLRenderState &renderState) override
+    {
+        if (Base::isEmpty()) {
+            return;
+        }
+
+        Functions &gl = Base::m_functions;
+        gl.checkError();
+
+        const glm::mat4 mvp = renderState.mvp.value_or(gl.getProjectionMatrix());
+        auto programUnbinder = Base::m_program.bind();
+        Base::m_program.setUniforms(mvp, renderState.uniforms);
+        Base::m_program.setViewport("uViewport", gl.getPhysicalViewport());
+        Base::m_program.setFloat("uLineWidth",
+                                 renderState.lineParams.width * gl.getDevicePixelRatio());
+
+        RenderStateBinder renderStateBinder(gl, gl.getTexLookup(), renderState);
+
+        gl.glBindVertexArray(Base::m_vao.get());
+        RAIICallback vaoUnbinder([&gl]() {
+            gl.glBindVertexArray(0);
+            gl.checkError();
+        });
+
+        auto attribUnbinder = Base::bindAttribs();
+
+        const GLsizei numInstances = Base::m_numVerts / 2;
+        gl.glDrawArraysInstanced(GL_TRIANGLE_FAN, 0, 4, numInstances);
+    }
+
+    void virt_unbind() override
+    {
+        if (!m_boundAttribs) {
+            return;
+        }
+        auto &attribs = m_boundAttribs.value();
+        Functions &gl = Base::m_functions;
+        gl.glDisableVertexAttribArray(attribs.colorPos);
+        gl.glDisableVertexAttribArray(attribs.vert1Pos);
+        gl.glDisableVertexAttribArray(attribs.vert2Pos);
+        gl.glVertexAttribDivisor(attribs.colorPos, 0);
+        gl.glVertexAttribDivisor(attribs.vert1Pos, 0);
+        gl.glVertexAttribDivisor(attribs.vert2Pos, 0);
+        gl.glBindBuffer(GL_ARRAY_BUFFER, 0);
+        m_boundAttribs.reset();
+    }
+
+    NODISCARD static const void *VPO_PTR(const void *base, size_t offset)
+    {
+        return static_cast<const char *>(base) + offset;
+    }
+};
 
 // Textured mesh with color modulated by uniform
 template<typename VertexType_>

--- a/src/opengl/legacy/Shaders.cpp
+++ b/src/opengl/legacy/Shaders.cpp
@@ -30,6 +30,8 @@ namespace Legacy {
 
 AColorPlainShader::~AColorPlainShader() = default;
 UColorPlainShader::~UColorPlainShader() = default;
+AColorLineShader::~AColorLineShader() = default;
+UColorLineShader::~UColorLineShader() = default;
 AColorTexturedShader::~AColorTexturedShader() = default;
 UColorTexturedShader::~UColorTexturedShader() = default;
 
@@ -48,6 +50,8 @@ void ShaderPrograms::early_init()
 {
     std::ignore = getPlainAColorShader();
     std::ignore = getPlainUColorShader();
+    std::ignore = getLineAColorShader();
+    std::ignore = getLineUColorShader();
     std::ignore = getTexturedAColorShader();
     std::ignore = getTexturedUColorShader();
 
@@ -67,6 +71,8 @@ void ShaderPrograms::resetAll()
 {
     m_aColorShader.reset();
     m_uColorShader.reset();
+    m_aLineShader.reset();
+    m_uLineShader.reset();
     m_aTexturedShader.reset();
     m_uTexturedShader.reset();
 
@@ -119,6 +125,16 @@ const std::shared_ptr<AColorPlainShader> &ShaderPrograms::getPlainAColorShader()
 const std::shared_ptr<UColorPlainShader> &ShaderPrograms::getPlainUColorShader()
 {
     return getInitialized<UColorPlainShader>(m_uColorShader, getFunctions(), "plain/ucolor");
+}
+
+const std::shared_ptr<AColorLineShader> &ShaderPrograms::getLineAColorShader()
+{
+    return getInitialized<AColorLineShader>(m_aLineShader, getFunctions(), "line/acolor");
+}
+
+const std::shared_ptr<UColorLineShader> &ShaderPrograms::getLineUColorShader()
+{
+    return getInitialized<UColorLineShader>(m_uLineShader, getFunctions(), "line/ucolor");
 }
 
 const std::shared_ptr<AColorTexturedShader> &ShaderPrograms::getTexturedAColorShader()

--- a/src/opengl/legacy/Shaders.h
+++ b/src/opengl/legacy/Shaders.h
@@ -23,6 +23,36 @@ private:
     }
 };
 
+struct NODISCARD AColorLineShader final : public AbstractShaderProgram
+{
+public:
+    using AbstractShaderProgram::AbstractShaderProgram;
+
+    ~AColorLineShader() final;
+
+private:
+    void virt_setUniforms(const glm::mat4 &mvp, const GLRenderState::Uniforms &uniforms) final
+    {
+        setColor("uColor", uniforms.color);
+        setMatrix("uMVP", mvp);
+    }
+};
+
+struct NODISCARD UColorLineShader final : public AbstractShaderProgram
+{
+public:
+    using AbstractShaderProgram::AbstractShaderProgram;
+
+    ~UColorLineShader() final;
+
+private:
+    void virt_setUniforms(const glm::mat4 &mvp, const GLRenderState::Uniforms &uniforms) final
+    {
+        setColor("uColor", uniforms.color);
+        setMatrix("uMVP", mvp);
+    }
+};
+
 struct NODISCARD UColorPlainShader final : public AbstractShaderProgram
 {
 public:
@@ -219,6 +249,8 @@ private:
 private:
     std::shared_ptr<AColorPlainShader> m_aColorShader;
     std::shared_ptr<UColorPlainShader> m_uColorShader;
+    std::shared_ptr<AColorLineShader> m_aLineShader;
+    std::shared_ptr<UColorLineShader> m_uLineShader;
     std::shared_ptr<AColorTexturedShader> m_aTexturedShader;
     std::shared_ptr<UColorTexturedShader> m_uTexturedShader;
 
@@ -253,6 +285,8 @@ public:
     NODISCARD const std::shared_ptr<AColorPlainShader> &getPlainAColorShader();
     // uniform color (aka "Plain")
     NODISCARD const std::shared_ptr<UColorPlainShader> &getPlainUColorShader();
+    NODISCARD const std::shared_ptr<AColorLineShader> &getLineAColorShader();
+    NODISCARD const std::shared_ptr<UColorLineShader> &getLineUColorShader();
     // attribute color + textured (aka "ColoredTextured")
     NODISCARD const std::shared_ptr<AColorTexturedShader> &getTexturedAColorShader();
     // uniform color + textured (aka "Textured")

--- a/src/opengl/legacy/SimpleMesh.h
+++ b/src/opengl/legacy/SimpleMesh.h
@@ -166,7 +166,7 @@ private:
     }
 
 private:
-    void virt_render(const GLRenderState &renderState) final
+    void virt_render(const GLRenderState &renderState) override
     {
         if (isEmpty()) {
             return;

--- a/src/resources/mmapper2.qrc
+++ b/src/resources/mmapper2.qrc
@@ -213,6 +213,10 @@
         <file>pixmaps/wall-west.png</file>
         <file>shaders/legacy/font/frag.glsl</file>
         <file>shaders/legacy/font/vert.glsl</file>
+        <file>shaders/legacy/line/acolor/frag.glsl</file>
+        <file>shaders/legacy/line/acolor/vert.glsl</file>
+        <file>shaders/legacy/line/ucolor/frag.glsl</file>
+        <file>shaders/legacy/line/ucolor/vert.glsl</file>
         <file>shaders/legacy/room/tex/acolor/frag.glsl</file>
         <file>shaders/legacy/room/tex/acolor/vert.glsl</file>
         <file>shaders/legacy/plain/acolor/frag.glsl</file>

--- a/src/resources/shaders/legacy/line/acolor/frag.glsl
+++ b/src/resources/shaders/legacy/line/acolor/frag.glsl
@@ -1,0 +1,10 @@
+uniform vec4 uColor;
+
+in vec4 vColor;
+
+out vec4 vFragmentColor;
+
+void main()
+{
+    vFragmentColor = vColor * uColor;
+}

--- a/src/resources/shaders/legacy/line/acolor/vert.glsl
+++ b/src/resources/shaders/legacy/line/acolor/vert.glsl
@@ -1,0 +1,44 @@
+uniform mat4 uMVP;
+uniform float uLineWidth;
+uniform ivec4 uViewport; // x, y, width, height
+
+layout(location = 0) in vec4 aColor;
+layout(location = 1) in vec3 aVert1;
+layout(location = 2) in vec3 aVert2;
+
+out vec4 vColor;
+
+void main()
+{
+    vColor = aColor;
+
+    vec4 clip1 = uMVP * vec4(aVert1, 1.0);
+    vec4 clip2 = uMVP * vec4(aVert2, 1.0);
+
+    vec2 ndc1 = clip1.xy / clip1.w;
+    vec2 ndc2 = clip2.xy / clip2.w;
+
+    vec2 screen1 = (ndc1 + 1.0) * 0.5 * vec2(uViewport.zw);
+    vec2 screen2 = (ndc2 + 1.0) * 0.5 * vec2(uViewport.zw);
+
+    vec2 dir = screen2 - screen1;
+    float len = length(dir);
+    if (len < 0.0001) {
+        dir = vec2(1.0, 0.0);
+    } else {
+        dir /= len;
+    }
+    vec2 normal = vec2(-dir.y, dir.x);
+
+    vec2 offset = normal * uLineWidth * 0.5;
+
+    vec2 pos;
+    float z;
+    if (gl_VertexID == 0) { pos = screen1 + offset; z = clip1.z / clip1.w; }
+    else if (gl_VertexID == 1) { pos = screen1 - offset; z = clip1.z / clip1.w; }
+    else if (gl_VertexID == 2) { pos = screen2 - offset; z = clip2.z / clip2.w; }
+    else { pos = screen2 + offset; z = clip2.z / clip2.w; }
+
+    vec2 final_ndc = (pos / vec2(uViewport.zw)) * 2.0 - 1.0;
+    gl_Position = vec4(final_ndc, z, 1.0);
+}

--- a/src/resources/shaders/legacy/line/ucolor/frag.glsl
+++ b/src/resources/shaders/legacy/line/ucolor/frag.glsl
@@ -1,0 +1,8 @@
+uniform vec4 uColor;
+
+out vec4 vFragmentColor;
+
+void main()
+{
+    vFragmentColor = uColor;
+}

--- a/src/resources/shaders/legacy/line/ucolor/vert.glsl
+++ b/src/resources/shaders/legacy/line/ucolor/vert.glsl
@@ -1,0 +1,39 @@
+uniform mat4 uMVP;
+uniform float uLineWidth;
+uniform ivec4 uViewport; // x, y, width, height
+
+layout(location = 0) in vec3 aVert1;
+layout(location = 1) in vec3 aVert2;
+
+void main()
+{
+    vec4 clip1 = uMVP * vec4(aVert1, 1.0);
+    vec4 clip2 = uMVP * vec4(aVert2, 1.0);
+
+    vec2 ndc1 = clip1.xy / clip1.w;
+    vec2 ndc2 = clip2.xy / clip2.w;
+
+    vec2 screen1 = (ndc1 + 1.0) * 0.5 * vec2(uViewport.zw);
+    vec2 screen2 = (ndc2 + 1.0) * 0.5 * vec2(uViewport.zw);
+
+    vec2 dir = screen2 - screen1;
+    float len = length(dir);
+    if (len < 0.0001) {
+        dir = vec2(1.0, 0.0);
+    } else {
+        dir /= len;
+    }
+    vec2 normal = vec2(-dir.y, dir.x);
+
+    vec2 offset = normal * uLineWidth * 0.5;
+
+    vec2 pos;
+    float z;
+    if (gl_VertexID == 0) { pos = screen1 + offset; z = clip1.z / clip1.w; }
+    else if (gl_VertexID == 1) { pos = screen1 - offset; z = clip1.z / clip1.w; }
+    else if (gl_VertexID == 2) { pos = screen2 - offset; z = clip2.z / clip2.w; }
+    else { pos = screen2 + offset; z = clip2.z / clip2.w; }
+
+    vec2 final_ndc = (pos / vec2(uViewport.zw)) * 2.0 - 1.0;
+    gl_Position = vec4(final_ndc, z, 1.0);
+}


### PR DESCRIPTION
- OpenGL prober runs as a separate process
- add thick screen line shader

## Summary by Sourcery

Probe OpenGL capabilities via a dedicated subprocess and JSON survey, and switch legacy line rendering to shader-based thick lines while removing reliance on GL 3.3 compatibility features.

New Features:
- Introduce a subprocess-based OpenGL prober with a survey mode and JSON output, including support for WebGL 2.0 probing on WASM.
- Add new legacy line rendering shaders and mesh types to draw thick screen-space lines for both uniform and per-vertex colored lines.

Bug Fixes:
- Ensure OpenGL probing falls back to a safe default format when the survey subprocess fails or returns invalid data.

Enhancements:
- Simplify OpenGL configuration by dropping the global compatibility flag and relying on the probed backend and debug-context capabilities.
- Standardize quad rendering by always converting quads to triangles, removing backend-specific quad support checks.
- Refine legacy rendering APIs to route line draw calls through the new line-specific meshes and shaders, and make line width controlled via shader uniforms instead of glLineWidth.