### PR TITLE
migrate to c++20 compiler

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -21,14 +21,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, macos-latest, ubuntu-latest]
+        os: [windows-2022, macos-15, ubuntu-latest]
         compiler: ['clang', 'gcc', 'msvc']
         exclude:
         - os: ubuntu-latest
           compiler: 'msvc'
-        - os: macos-latest
+        - os: macos-15
           compiler: 'gcc'
-        - os: macos-latest
+        - os: macos-15
           compiler: 'msvc'
     steps:
     - uses: actions/checkout@v7

--- a/BUILD.md
+++ b/BUILD.md
@@ -8,7 +8,7 @@ This guide describes how to build **MMapper** from source on Linux, macOS, and W
 
 Ensure the following tools are installed:
 
-- A C++17-compatible compiler (e.g., GCC, Clang, MSVC)
+- A C++20-compatible compiler (e.g., GCC 11+, Clang 16+, MSVC 19.29+)
 - [CMake 3.20+](https://cmake.org/)
 - [Ninja](https://ninja-build.org/)
 - [Qt 6.4+](https://www.qt.io/) (6.8.3 recommended) with `QtWebSockets` and `QtMultimedia`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(mmapper CXX)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -148,7 +148,7 @@ endif()
 
 if(APPLE)
     set(CMAKE_MACOSX_RPATH TRUE)
-    set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0" CACHE STRING "Minimum OS X deployment version" FORCE)
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "13.3" CACHE STRING "Minimum OS X deployment version" FORCE)
 endif()
 
 if(WIN32)
@@ -414,6 +414,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         endif()
 
         add_compile_options(-Weverything)
+        add_compile_options(-Wno-c++20-compat)
         add_compile_options(-Wno-c++98-c++11-compat-binary-literal) # never useful.
         add_compile_options(-Wno-c++98-compat) # never useful.
         add_compile_options(-Wno-c++98-compat-pedantic) # sometimes useful.
@@ -456,7 +457,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         add_compile_options(-Werror=shorten-64-to-32)
         add_compile_options(-Werror=sign-conversion) # can warn about hard-to-spot bugs.
         add_compile_options(-Werror=switch)
-        add_compile_options(-Werror=unused-result) # required for c++17 [[nodiscard]]
+        add_compile_options(-Werror=unused-result) # required for [[nodiscard]]
         add_compile_options(-Werror=weak-vtables) # can result in crashes for ODR violations.
 
         # remove noise (most of these cannot be fixed)
@@ -467,6 +468,7 @@ if(MSVC)
     add_definitions(-DNOMINMAX)
     # modernize the __cplusplus value
     add_compile_options(/Zc:__cplusplus)
+    add_compile_options(/Zc:preprocessor)
     add_compile_options(/utf-8)
     add_compile_options(/permissive-)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -125,6 +125,7 @@ set(mmapper_SRCS
     global/ConversionResult.h
     global/Diff.cpp
     global/Diff.h
+    global/EnumIndexedArray.cpp
     global/EnumIndexedArray.h
     global/Flags.cpp
     global/Flags.h
@@ -182,6 +183,7 @@ set(mmapper_SRCS
     global/Timer.cpp
     global/Timer.h
     global/Version.h
+    global/View.cpp
     global/View.h
     global/WeakHandle.cpp
     global/WeakHandle.h
@@ -190,6 +192,8 @@ set(mmapper_SRCS
     global/bits.h
     global/cast_error.cpp
     global/cast_error.h
+    global/concepts.cpp
+    global/concepts.h
     global/emojis.cpp
     global/emojis.h
     global/entities-xforeach.txt
@@ -783,7 +787,7 @@ endif()
 
 set_target_properties(
   mmapper PROPERTIES
-  CXX_STANDARD 17
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -793,7 +797,7 @@ set_target_properties(
 
 set_target_properties(
   mm_global PROPERTIES
-  CXX_STANDARD 17
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -801,7 +805,7 @@ set_target_properties(
 
 set_target_properties(
   mm_map PROPERTIES
-  CXX_STANDARD 17
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   COMPILE_FLAGS "${WARNING_FLAGS}"

--- a/src/client/Hotkey.cpp
+++ b/src/client/Hotkey.cpp
@@ -11,14 +11,12 @@
 #include <sstream>
 
 namespace {
-NODISCARD constexpr bool isUppercase(const char *s)
+// actually "isNotLowercase()"
+NODISCARD constexpr bool isUppercase(const std::string_view sv)
 {
-    while (*s) {
-        if (*s >= 'a' && *s <= 'z')
-            return false;
-        s++;
-    }
-    return true;
+    return !std::any_of(sv.begin(), sv.end(), [](const char c) -> bool {
+        return c >= 'a' && c <= 'z';
+    });
 }
 #define X_CHECK_UPPER(id, name, qkey, policy) \
     static_assert(isUppercase(name), "Hotkey name must be uppercase: " name);

--- a/src/clock/mumeclock.cpp
+++ b/src/clock/mumeclock.cpp
@@ -7,6 +7,7 @@
 #include "../configuration/configuration.h"
 #include "../global/Array.h"
 #include "../global/JsonObj.h"
+#include "../global/enums.h"
 #include "../proxy/GmcpMessage.h"
 #include "../proxy/MudTelnet.h" // FIXME: move MsspTime somewhere more appropriate, or just use MumeMoment.
 #include "mumemoment.h"
@@ -66,14 +67,11 @@ NODISCARD const char *getOrdinalSuffix(const int day)
 } // namespace
 
 namespace mmqt {
-template<typename T>
+template<concepts::IsSignedEnum T>
+    requires(enums::to_underlying(T::Invalid) == -1)
 class NODISCARD QME final
 {
 private:
-    static_assert(std::is_enum_v<T>);
-    using U = std::underlying_type_t<T>;
-    static_assert(std::is_signed_v<U>);
-    static_assert(static_cast<U>(T::Invalid) == -1);
     static inline const QMetaEnum g_qme = QMetaEnum::fromType<T>();
 
 public:

--- a/src/configuration/NamedConfig.h
+++ b/src/configuration/NamedConfig.h
@@ -3,12 +3,11 @@
 // Copyright (C) 2019 The MMapper Authors
 
 #include "../global/ChangeMonitor.h"
+#include "../global/concepts.h"
 
 #include <cmath>
 #include <string>
 #include <string_view>
-#include <type_traits>
-#include <vector>
 
 template<typename T>
 class NODISCARD NamedConfig final
@@ -66,10 +65,9 @@ public:
     }
 
     void clamp(const T lo, const T hi)
+        requires(concepts::IsNumeric<T>)
     {
-        // don't try to call this for boolean or string.
-        static_assert(std::is_integral_v<T> || std::is_floating_point_v<T>);
-        if constexpr (std::is_floating_point_v<T>) {
+        if constexpr (concepts::IsFloatingPoint<T>) {
             assert(std::isfinite(lo));
             assert(std::isfinite(hi));
         }

--- a/src/display/Characters.cpp
+++ b/src/display/Characters.cpp
@@ -152,6 +152,12 @@ void CharacterBatch::CharFakeGL::drawQuadCommon(const glm::vec2 in_a,
                                                 const glm::vec2 in_d,
                                                 const QuadOptsEnum options)
 {
+    {
+        using enum QuadOptsEnum;
+        constexpr auto ALL = OUTLINE | FILL | BEACON;
+        static_assert(~ALL == NONE);
+        static_assert(~NONE == ALL);
+    }
     const auto &m = m_stack.top().modelView;
     const auto transform = [&m](const glm::vec2 vin) -> glm::vec3 {
         const auto vtmp = m * glm::vec4(vin, 0.f, 1.f);

--- a/src/display/Characters.h
+++ b/src/display/Characters.h
@@ -164,22 +164,8 @@ private:
         }
 
     private:
-        enum class NODISCARD QuadOptsEnum : uint32_t {
-            NONE = 0,
-            OUTLINE = 1,
-            FILL = 2,
-            BEACON = 4
-        };
-        NODISCARD friend QuadOptsEnum operator|(const QuadOptsEnum lhs, const QuadOptsEnum rhs)
-        {
-            return static_cast<QuadOptsEnum>(static_cast<uint32_t>(lhs)
-                                             | static_cast<uint32_t>(rhs));
-        }
-        NODISCARD friend QuadOptsEnum operator&(const QuadOptsEnum lhs, const QuadOptsEnum rhs)
-        {
-            return static_cast<QuadOptsEnum>(static_cast<uint32_t>(lhs)
-                                             & static_cast<uint32_t>(rhs));
-        }
+        enum class NODISCARD QuadOptsEnum : uint8_t { NONE = 0, OUTLINE = 1, FILL = 2, BEACON = 4 };
+        FRIEND_ENUM_ALLOWS_BIT_OPS_WITH_WIDTH(QuadOptsEnum, 3)
 
         void drawQuadCommon(glm::vec2 a, glm::vec2 b, glm::vec2 c, glm::vec2 d, QuadOptsEnum options);
     };

--- a/src/display/MapCanvasData.h
+++ b/src/display/MapCanvasData.h
@@ -36,7 +36,7 @@ class MapData;
 class PrespammedPath;
 class InfomarkSelection;
 
-enum class NODISCARD RoomTintEnum { DARK, NO_SUNDEATH };
+enum class NODISCARD RoomTintEnum : uint8_t { DARK, NO_SUNDEATH };
 static const size_t NUM_ROOM_TINTS = 2;
 NODISCARD extern const MMapper::Array<RoomTintEnum, NUM_ROOM_TINTS> &getAllRoomTints();
 #define ALL_ROOM_TINTS getAllRoomTints()
@@ -367,7 +367,7 @@ public:
     }
     void endPinch() { m_pinchState.reset(); }
 
-    void beginMagnification() { m_magnificationState.emplace(MagnificationState{1.f}); }
+    void beginMagnification() { m_magnificationState.emplace(1.f); }
     void updateMagnification(const float lastValue)
     {
         if (!m_magnificationState) {

--- a/src/display/RoadIndex.cpp
+++ b/src/display/RoadIndex.cpp
@@ -10,6 +10,9 @@
 
 #include <stdexcept>
 
+static_assert(~RoadIndexMaskEnum::ALL == RoadIndexMaskEnum::NONE);
+static_assert(~RoadIndexMaskEnum::NONE == RoadIndexMaskEnum::ALL);
+
 RoadIndexMaskEnum getRoadIndex(const ExitDirEnum dir)
 {
     if (!isNESW(dir)) {

--- a/src/display/RoadIndex.h
+++ b/src/display/RoadIndex.h
@@ -25,28 +25,7 @@ enum class NODISCARD RoadIndexMaskEnum : uint32_t {
 static_assert(static_cast<int>(RoadIndexMaskEnum::ALL) == 15);
 DEFINE_ENUM_COUNT(RoadIndexMaskEnum, NUM_ROAD_INDICES)
 
-NODISCARD inline constexpr RoadIndexMaskEnum operator|(const RoadIndexMaskEnum lhs,
-                                                       const RoadIndexMaskEnum rhs) noexcept
-{
-    return static_cast<RoadIndexMaskEnum>(static_cast<uint32_t>(lhs) | static_cast<uint32_t>(rhs));
-}
-inline constexpr RoadIndexMaskEnum &operator|=(RoadIndexMaskEnum &lhs,
-                                               const RoadIndexMaskEnum rhs) noexcept
-{
-    return lhs = (lhs | rhs);
-}
-NODISCARD inline constexpr RoadIndexMaskEnum operator&(const RoadIndexMaskEnum lhs,
-                                                       const RoadIndexMaskEnum rhs)
-{
-    return static_cast<RoadIndexMaskEnum>(static_cast<uint32_t>(lhs) & static_cast<uint32_t>(rhs));
-}
-NODISCARD inline constexpr RoadIndexMaskEnum operator~(const RoadIndexMaskEnum x)
-{
-    return static_cast<RoadIndexMaskEnum>(static_cast<uint32_t>(x)
-                                          ^ static_cast<uint32_t>(RoadIndexMaskEnum::ALL));
-}
-static_assert(~RoadIndexMaskEnum::ALL == RoadIndexMaskEnum::NONE);
-static_assert(~RoadIndexMaskEnum::NONE == RoadIndexMaskEnum::ALL);
+ENUM_ALLOWS_BIT_OPS_WITH_WIDTH(RoadIndexMaskEnum, 4)
 
 NODISCARD RoadIndexMaskEnum getRoadIndex(ExitDirEnum dir);
 NODISCARD RoadIndexMaskEnum getRoadIndex(const RawRoom &room);

--- a/src/display/RoomSelections.cpp
+++ b/src/display/RoomSelections.cpp
@@ -24,7 +24,7 @@
 class NODISCARD RoomSelFakeGL final
 {
 public:
-    enum class NODISCARD SelTypeEnum { Near, Distant, MoveBad, MoveGood };
+    enum class NODISCARD SelTypeEnum : uint8_t { Near, Distant, MoveBad, MoveGood };
     static constexpr size_t NUM_SEL_TYPES = 4;
 
 private:

--- a/src/display/Textures.cpp
+++ b/src/display/Textures.cpp
@@ -605,10 +605,11 @@ void MapCanvas::initTextures()
             }
         };
 
-        auto initGroup = [&maybeCreateArray2](const std::string_view groupName,
-                                              auto &&...sources) -> SharedMMTexture {
+        auto initGroup = [&maybeCreateArray2]<typename... Sources>
+            requires(sizeof...(Sources) > 0)
+        (const std::string_view groupName, Sources &&...sources) -> SharedMMTexture {
             SharedMMTexture pArrayTex;
-            auto thing = combine(std::forward<decltype(sources)>(sources)...);
+            auto thing = combine(std::forward<Sources>(sources)...);
             maybeCreateArray2(groupName, thing, pArrayTex);
             return pArrayTex;
         };

--- a/src/display/Textures.h
+++ b/src/display/Textures.h
@@ -235,9 +235,8 @@ namespace mctp {
 namespace detail {
 // converts from EnumIndexedArray<SharedMMTexture, ...> to EnumIndexedArray<MMTexArrayPosition, ...>
 template<typename T>
-auto typeHack(const T &)
-    -> std::enable_if_t<std::is_same_v<typename T::value_type, SharedMMTexture>,
-                        EnumIndexedArray<MMTexArrayPosition, typename T::index_type, T::SIZE>>;
+    requires(std::is_same_v<typename T::value_type, SharedMMTexture>)
+auto typeHack(const T &) -> EnumIndexedArray<MMTexArrayPosition, typename T::index_type, T::SIZE>;
 
 template<typename T>
 struct NODISCARD Proxy

--- a/src/global/AnsiOstream.h
+++ b/src/global/AnsiOstream.h
@@ -135,13 +135,14 @@ public:
     void write(char16_t codepoint);
     void write(char32_t codepoint);
     void write(std::string_view sv);
+    void write(std::u8string_view sv) = delete;
 
     template<typename T>
-    auto write(const T n)
-        -> std::enable_if_t<(std::is_integral_v<T> && !std::is_same_v<char32_t, std::decay_t<T>>
-                             && sizeof(char) < sizeof(T))
-                                || std::is_floating_point_v<T>,
-                            void>
+        requires((std::is_integral_v<T> and sizeof(T) > sizeof(char)
+                  and not(std::is_same_v<char16_t, std::decay_t<T>>
+                          or std::is_same_v<char32_t, std::decay_t<T>>))
+                 or std::is_floating_point_v<T>)
+    void write(const T n)
     {
         auto s = std::to_string(n);
         write(std::string_view{s});

--- a/src/global/AnsiTextUtils.cpp
+++ b/src/global/AnsiTextUtils.cpp
@@ -1255,7 +1255,7 @@ NODISCARD static AnsiColor16Enum getClosestMatchInColorSpace(const AnsiColorRGB 
         Arr arr;
 
     public:
-        Table() { init(); }
+        explicit Table() { init(); }
 
     private:
         void init()

--- a/src/global/AnsiTextUtils.h
+++ b/src/global/AnsiTextUtils.h
@@ -74,7 +74,7 @@ struct NODISCARD AnsiStyleFlags final : enums::Flags<AnsiStyleFlags, AnsiStyleFl
 
 #define X_DECL_LO(n, lower, UPPER) lower,
 #define X_DECL_HI(n, lower, UPPER) UPPER,
-enum class NODISCARD AnsiColor16Enum {
+enum class NODISCARD AnsiColor16Enum : uint8_t {
     XFOREACH_ANSI_COLOR_0_7(X_DECL_LO) //
     XFOREACH_ANSI_COLOR_0_7(X_DECL_HI) //
 };
@@ -813,6 +813,9 @@ NODISCARD bool isAnsiColor(std::string_view input);
 NODISCARD std::optional<RawAnsi> ansi_parse(RawAnsi ansi, std::string_view input);
 
 template<typename ValidAnsiColorCallback, typename InvalidEscapeCallback, typename NonAnsiCallback>
+    requires(std::is_invocable_r_v<void, ValidAnsiColorCallback, std::string_view>
+             and std::is_invocable_r_v<void, InvalidEscapeCallback, std::string_view>
+             and std::is_invocable_r_v<void, NonAnsiCallback, std::string_view>)
 void foreachAnsi(const std::string_view input,
                  ValidAnsiColorCallback &&validAnsiColor,
                  InvalidEscapeCallback &&invalidEscape,

--- a/src/global/Array.h
+++ b/src/global/Array.h
@@ -21,11 +21,11 @@ class NODISCARD Array : public std::array<T, N>
 public:
     /// Uses std::array's implicitly-defined default constructor
     /// that uses the rules of aggregate initialization.
-    explicit Array(Uninitialized) {}
+    explicit constexpr Array(Uninitialized) {}
 
 public:
     /// calls std::array's initializing default constructor
-    Array()
+    constexpr Array()
         : std::array<T, N>{}
     {}
 
@@ -35,6 +35,7 @@ public:
 
 public:
     template<typename First, typename... Types>
+        requires(std::is_same_v<First, Types> && ...)
     explicit constexpr Array(First &&first, Types &&...args)
         : std::array<T, N>{std::forward<First>(first), std::forward<Types>(args)...}
     {
@@ -42,9 +43,28 @@ public:
     }
 };
 
-#if __cpp_deduction_guides >= 201606
-// deducation guide copied from std::array
 template<typename T, typename... U>
-Array(T, U...) -> Array<std::enable_if_t<(std::is_same_v<T, U> && ...), T>, 1 + sizeof...(U)>;
-#endif
+    requires(std::is_same_v<T, U> && ...)
+Array(T, U...) -> Array<T, 1 + sizeof...(U)>;
 } // namespace MMapper
+
+namespace concepts {
+namespace detail {
+namespace cpp11 {
+template<typename T>
+struct IsMmapperArray : std::false_type
+{};
+
+template<typename T, size_t N>
+struct IsMmapperArray<MMapper::Array<T, N>> : std::true_type
+{};
+
+} // namespace cpp11
+namespace cpp17 {
+template<typename T>
+inline constexpr bool IsMmapperArray_v = cpp11::IsMmapperArray<T>::value;
+}
+} // namespace detail
+template<typename T>
+concept IsMmapperArray = detail::cpp17::IsMmapperArray_v<T>;
+} // namespace concepts

--- a/src/global/Charset-Utf8.cpp
+++ b/src/global/Charset-Utf8.cpp
@@ -94,10 +94,9 @@ namespace conversion {
 namespace conversion_detail {
 static constexpr size_t UTF8_BITS_PER_BYTE = 6;
 
-template<typename T>
+template<concepts::IsUnsignedIntegralNumeric T>
 struct NODISCARD wrapped final
 {
-    static_assert(std::is_integral_v<T> && std::is_unsigned_v<T>);
     T value{};
     NODISCARD explicit constexpr wrapped(const T x)
         : value{x}
@@ -552,13 +551,7 @@ NODISCARD static constexpr bool is7bit(const char c) noexcept
 }
 NODISCARD static constexpr bool is7bit(const std::string_view sv) noexcept
 {
-    // NOLINTNEXTLINE (can't use std::all_of() in constexpr in c++17)
-    for (const char c : sv) {
-        if (!is7bit(c)) {
-            return false;
-        }
-    }
-    return true;
+    return std::all_of(sv.begin(), sv.end(), [](char c) { return is7bit(c); });
 }
 
 NODISCARD static constexpr Utf8ValidationEnum validateUtf8(std::string_view sv) noexcept

--- a/src/global/Charset.cpp
+++ b/src/global/Charset.cpp
@@ -348,7 +348,6 @@ ALLOW_DISCARD QString &toAsciiInPlace(QString &str)
 
     // NOTE: 128 (0x80) was not converted to 'z' before.
     for (QChar &qc : str) {
-        // c++17 if statement with initializer
         if (const char ch = mmqt::toLatin1(qc); !isAscii(ch)) {
             qc = QLatin1Char{charset::conversion::latin1ToAscii(ch)};
         }

--- a/src/global/Charset.h
+++ b/src/global/Charset.h
@@ -14,6 +14,20 @@
 
 #include <QString>
 
+namespace concepts {
+template<typename T>
+concept IsChar8Callback = std::is_invocable_r_v<void, T, uint8_t>;
+template<typename T>
+concept IsChar16Callback = std::is_invocable_r_v<void, T, char16_t>;
+template<typename T>
+concept IsChar32Callback = std::is_invocable_r_v<void, T, char32_t>;
+
+// both 8 and 32
+template<typename T>
+concept IsChar832Callback = IsChar8Callback<T> and IsChar32Callback<T>;
+
+} // namespace concepts
+
 namespace charset::ascii {
 
 // ASCII 00 to 1F, and 7F only; Latin1 control codes 80 to 9F don't count.
@@ -437,7 +451,7 @@ struct NODISCARD Utf16Iterable final
 
 } // namespace conversion
 
-template<typename Callback>
+template<concepts::IsChar8Callback Callback>
 void foreach_codepoint_ascii(const std::string_view sv, Callback &&callback)
 {
     assert(isAscii(sv));
@@ -446,7 +460,7 @@ void foreach_codepoint_ascii(const std::string_view sv, Callback &&callback)
     }
 }
 
-template<typename Callback>
+template<concepts::IsChar8Callback Callback>
 void foreach_codepoint_latin1(std::string_view sv, Callback &&callback)
 {
     for (const char c : sv) {
@@ -454,7 +468,7 @@ void foreach_codepoint_latin1(std::string_view sv, Callback &&callback)
     }
 }
 
-template<typename Callback>
+template<concepts::IsChar832Callback Callback>
 void foreach_codepoint_utf8(std::string_view sv,
                             Callback &&callback,
                             const char32_t invalid = charset_detail::DEFAULT_UNMAPPED_CHARACTER)
@@ -469,7 +483,7 @@ void foreach_codepoint_utf8(std::string_view sv,
     }
 }
 
-template<typename Callback>
+template<concepts::IsChar832Callback Callback>
 void foreach_codepoint_utf8_unfriendly(
     std::string_view sv,
     Callback &&callback,

--- a/src/global/ConfigConsts-Computed.h
+++ b/src/global/ConfigConsts-Computed.h
@@ -4,6 +4,7 @@
 
 #include "ConfigEnums.h"
 
+#include <functional>
 #include <stdexcept>
 #include <string_view>
 
@@ -44,7 +45,7 @@ static inline constexpr PackageEnum CURRENT_PACKAGE = [] {
     throw std::runtime_error("unsupported package type");
 }();
 
-static inline constexpr const PlatformEnum CURRENT_PLATFORM = [] {
+static inline constexpr PlatformEnum CURRENT_PLATFORM = std::invoke([]() constexpr -> PlatformEnum {
 #if defined(Q_OS_WIN)
     return PlatformEnum::Windows;
 #elif defined(Q_OS_MAC)
@@ -56,14 +57,15 @@ static inline constexpr const PlatformEnum CURRENT_PLATFORM = [] {
 #else
     throw std::runtime_error("unsupported platform");
 #endif
-}();
+});
 
-static inline constexpr const EnvironmentEnum CURRENT_ENVIRONMENT = [] {
+static inline constexpr EnvironmentEnum CURRENT_ENVIRONMENT = std::invoke(
+    []() constexpr -> EnvironmentEnum {
 #if Q_PROCESSOR_WORDSIZE == 4
-    return EnvironmentEnum::Env32Bit;
+        return EnvironmentEnum::Env32Bit;
 #elif Q_PROCESSOR_WORDSIZE == 8
-    return EnvironmentEnum::Env64Bit;
+        return EnvironmentEnum::Env64Bit;
 #else
-    throw std::runtime_error("unsupported environment");
+        throw std::runtime_error("unsupported environment");
 #endif
-}();
+    });

--- a/src/global/EnumIndexedArray.cpp
+++ b/src/global/EnumIndexedArray.cpp
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+#include "EnumIndexedArray.h"
+
+#include "enums.h"
+#include "logging.h"
+
+#include <array>
+#include <cstdint>
+#include <format>
+#include <string>
+
+namespace {
+enum class NODISCARD AbcEnum : uint8_t { A, B, C };
+} // namespace
+
+DEFINE_ENUM_COUNT(AbcEnum, 3)
+
+namespace {
+
+template<typename T>
+using AbcArrayView = EnumIndexedArray<T, AbcEnum>;
+
+using Names = EnumIndexedArray<std::string, AbcEnum>;
+static_assert(concepts::IsEnumIndexedArray<Names>);
+
+using concepts::IsEnumIndexedArrayOfStrings;
+static_assert(!IsEnumIndexedArrayOfStrings<AbcArrayView<int>>);
+static_assert(IsEnumIndexedArrayOfStrings<AbcArrayView<std::string>>);
+static_assert(IsEnumIndexedArrayOfStrings<AbcArrayView<std::string_view>>);
+static_assert(IsEnumIndexedArrayOfStrings<AbcArrayView<const char *>>);
+
+} // namespace

--- a/src/global/EnumIndexedArray.cpp
+++ b/src/global/EnumIndexedArray.cpp
@@ -8,7 +8,6 @@
 
 #include <array>
 #include <cstdint>
-#include <format>
 #include <string>
 
 namespace {

--- a/src/global/EnumIndexedArray.h
+++ b/src/global/EnumIndexedArray.h
@@ -5,6 +5,8 @@
 
 #include "Array.h"
 #include "Flags.h"
+#include "View.h"
+#include "enums.h"
 #include "macros.h"
 
 #include <algorithm>
@@ -12,13 +14,24 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <span>
+#include <type_traits>
 
-template<typename T, typename E, size_t SIZE_ = enums::CountOf<E>::value>
+template<typename T, concepts::IsUnsignedEnum E, size_t SIZE_ = enums::CountOf<E>::value>
+    requires(SIZE_ > 0)
 class NODISCARD EnumIndexedArray : private MMapper::Array<T, SIZE_>
 {
 public:
     using base = MMapper::Array<T, SIZE_>;
-    using value_type = typename base::value_type;
+    using typename base::const_iterator;
+    using typename base::const_pointer;
+    using typename base::const_reference;
+    using typename base::iterator;
+    using typename base::pointer;
+    using typename base::reference;
+    using typename base::size_type;
+    using typename base::value_type;
+    using element_type = T; // std::array doesn't have element_type
     using index_type = E;
     static constexpr size_t SIZE = SIZE_;
 
@@ -61,10 +74,11 @@ public:
     // Note: findIndexOf() would write "x == ptr" but this uses "std::addressof(deref(x)) == ptr" instead.
     // Also: "deref(x)" can throw, and std::addressof() ignores overloaded "operator&".
     template<typename U>
+        requires(requires(const T &x) {
+            { std::addressof(deref(x)) } -> std::same_as<U *>;
+        })
     NODISCARD std::optional<E> findIndexOfPointer(U *const pointer) const
     {
-        static_assert(
-            std::is_same_v<U *, decltype(std::addressof(deref(std::declval<const T &>())))>);
         const auto beg = this->begin();
         const auto end = this->end();
         const auto it = std::find_if(beg, end, [pointer](auto &x) -> bool {
@@ -91,3 +105,28 @@ public:
     }
     NODISCARD bool operator!=(const EnumIndexedArray &other) const { return !operator==(other); }
 };
+
+namespace concepts {
+namespace detail {
+namespace cpp11 {
+template<typename T>
+struct IsEnumIndexedArray : std::false_type
+{};
+template<typename T, IsUnsignedEnum E, size_t size>
+struct IsEnumIndexedArray<EnumIndexedArray<T, E, size>> : std::true_type
+{};
+} // namespace cpp11
+namespace cpp17 {
+template<typename T>
+inline constexpr bool IsEnumIndexedArray_v = cpp11::IsEnumIndexedArray<T>::value;
+}
+} // namespace detail
+template<typename T>
+concept IsEnumIndexedArray = detail::cpp17::IsEnumIndexedArray_v<T>;
+} // namespace concepts
+
+namespace concepts {
+template<typename T>
+concept IsEnumIndexedArrayOfStrings
+    = IsEnumIndexedArray<T> and std::convertible_to<typename T::value_type, std::string_view>;
+} // namespace concepts

--- a/src/global/Flags.h
+++ b/src/global/Flags.h
@@ -22,7 +22,7 @@ struct NODISCARD CountOf
 {};
 #define DEFINE_ENUM_COUNT(_E, _N) \
     template<> \
-    struct NODISCARD ::enums::CountOf<_E> \
+    struct NODISCARD enums::CountOf<_E> \
     { \
         static inline constexpr size_t value = (_N); \
     };

--- a/src/global/Flags.h
+++ b/src/global/Flags.h
@@ -4,6 +4,7 @@
 // Author: Nils Schimmelmann <nschimme@gmail.com> (Jahara)
 
 #include "bits.h"
+#include "concepts.h"
 #include "utils.h"
 
 #include <cassert>
@@ -16,59 +17,63 @@
 
 namespace enums {
 
-// REVISIT: add CountOf_v ?
-template<typename E>
+template<concepts::IsEnum E>
 struct NODISCARD CountOf
 {};
-#define DEFINE_ENUM_COUNT(E, N) \
-    namespace enums { \
+#define DEFINE_ENUM_COUNT(_E, _N) \
     template<> \
-    struct NODISCARD CountOf<E> \
+    struct NODISCARD ::enums::CountOf<_E> \
     { \
-        static_assert(std::is_enum_v<E>); \
-        static constexpr const size_t value = N; \
-    }; \
-    }
+        static inline constexpr size_t value = (_N); \
+    };
+
+// This concept can be satisfied by using the DEFINE_ENUM_COUNT() macro in the global namespace.
+template<typename E>
+concept HasCountOf = concepts::IsEnum<E> and
+    requires()
+{
+    CountOf<E>::value;
+};
+
+template<HasCountOf E>
+inline constexpr size_t CountOf_v = CountOf<E>::value;
 
 template<typename CRTP,
-         typename Flag_,
-         typename UnderlyingType_,
-         size_t NUM_FLAGS_ = CountOf<Flag_>::value>
+         concepts::IsEnum Flag_,
+         concepts::IsIntegralNumeric BitmaskType_,
+         size_t NUM_FLAGS_ = CountOf_v<Flag_>>
+    requires(std::is_unsigned_v<BitmaskType_> and NUM_FLAGS_ != 0
+             and NUM_FLAGS_ <= std::numeric_limits<BitmaskType_>::digits)
 class NODISCARD Flags
 {
 public:
     using Flag = Flag_;
-    using underlying_type = UnderlyingType_;
-    static_assert(std::is_enum_v<Flag>);
-    static_assert(std::is_integral_v<underlying_type>);
-    static_assert(!std::numeric_limits<underlying_type>::is_signed);
-    static constexpr const size_t NUM_FLAGS = NUM_FLAGS_;
-    static_assert(NUM_FLAGS != 0u);
-    static_assert(NUM_FLAGS <= std::numeric_limits<underlying_type>::digits);
+    using bitmask_type = BitmaskType_;
+    static constexpr size_t NUM_FLAGS = NUM_FLAGS_;
 
 private:
-    static constexpr const underlying_type MASK = static_cast<underlying_type>(
-        static_cast<underlying_type>(static_cast<underlying_type>(~underlying_type{0u})
-                                     >> (std::numeric_limits<underlying_type>::digits - NUM_FLAGS)));
-    underlying_type m_flags = 0u;
+    static constexpr bitmask_type MASK = static_cast<bitmask_type>(
+        static_cast<bitmask_type>(static_cast<bitmask_type>(~bitmask_type{0u})
+                                  >> (std::numeric_limits<bitmask_type>::digits - NUM_FLAGS)));
+    bitmask_type m_flags = 0u;
 
     template<typename T>
-    NODISCARD static inline constexpr underlying_type narrow(const T x) noexcept
+    NODISCARD static inline constexpr bitmask_type narrow(const T x) noexcept
     {
-        return static_cast<underlying_type>(x & MASK);
+        return static_cast<bitmask_type>(x & MASK);
     }
 
 public:
     /* implicit */ constexpr Flags() noexcept = default;
 
-    explicit constexpr Flags(const underlying_type flags) noexcept
+    explicit constexpr Flags(const bitmask_type flags) noexcept
         : m_flags{narrow(flags & MASK)}
     {}
 
     // This might be tempting to make implcit, but it's not worth it because it doesn't enable the
     // `Flags binop(Flag, Flag)` helper operators (see below).
     explicit constexpr Flags(const Flag flag) noexcept
-        : Flags{narrow(underlying_type{1u} << static_cast<int>(flag))}
+        : Flags{narrow(bitmask_type{1u} << static_cast<int>(flag))}
     {}
 
 private:
@@ -79,12 +84,10 @@ private:
     }
 
 public:
-    NODISCARD explicit constexpr operator underlying_type() const noexcept { return m_flags; }
+    NODISCARD explicit constexpr operator bitmask_type() const noexcept { return m_flags; }
     NODISCARD constexpr uint32_t asUint32() const noexcept
+        requires(sizeof(bitmask_type) <= sizeof(uint32_t))
     {
-        // Note: static_assert here isn't checked unless you call this function.
-        static_assert(sizeof(underlying_type) <= sizeof(uint32_t),
-                      "asUint32() is disabled because the underlying type is larger than 32-bits");
         return m_flags;
     }
 
@@ -203,10 +206,9 @@ public:
     NODISCARD inline size_t size() const { return count(); }
 
 private:
-    static void remove_lowest_bit(underlying_type &flags)
+    static void remove_lowest_bit(bitmask_type &flags)
     {
-        using U = underlying_type;
-        static_assert(std::is_unsigned_v<U>);
+        using U = bitmask_type;
         assert(flags != 0u);
         flags = static_cast<U>(flags & static_cast<U>(flags - U{1}));
     }
@@ -276,7 +278,7 @@ public:
     struct ALLOW_DISCARD Iterator final
     {
     private:
-        underlying_type m_bits = 0;
+        bitmask_type m_bits = 0;
         uint8_t m_pos = 0;
 
     public:
@@ -307,9 +309,39 @@ public:
 public:
     NODISCARD Iterator begin() const { return Iterator{*this, 0}; }
     NODISCARD Iterator end() const { return Iterator{*this, size()}; }
+
+    NODISCARD auto front() const
+    {
+        if (empty()) {
+            throw std::runtime_error("empty");
+        }
+        return *begin();
+    }
 };
 
 } // namespace enums
+
+namespace concepts {
+// Doesn't have to be based on enums::Flags<>
+template<typename T>
+concept IsEnumFlags_container
+    = IsUnsignedEnum<std::remove_cvref_t<decltype(std::declval<const T &>().front())>>;
+// Expects enums::Flags<>
+template<typename T>
+concept IsEnumFlags = IsEnumFlags_container<T> and IsUnsignedEnum<typename T::Flag>
+                      and IsUnsignedIntegralNumeric<typename T::bitmask_type>;
+
+} // namespace concepts
+
+#define DEFINE_FLAGS_BITOP_OR(_Flags) \
+    NODISCARD inline constexpr MM_TYPE_IDENTITY( \
+        _Flags) operator|(const typename MM_TYPE_IDENTITY(_Flags)::Flag lhs, \
+                          const typename MM_TYPE_IDENTITY(_Flags)::Flag rhs) noexcept \
+    { \
+        static_assert(concepts::IsEnumFlags<_Flags>); \
+        using F = MM_TYPE_IDENTITY(_Flags); \
+        return F{lhs} | rhs; \
+    }
 
 namespace test {
 extern void testFlags();

--- a/src/global/MakeQPointer.h
+++ b/src/global/MakeQPointer.h
@@ -12,8 +12,8 @@
 
 namespace mmqt {
 template<typename T, typename... Args>
-NODISCARD auto makeQPointer(Args &&...args)
-    -> std::enable_if_t<std::is_base_of_v<QObject, T>, QPointer<T>>
+    requires(std::is_base_of_v<QObject, T>)
+NODISCARD QPointer<T> makeQPointer(Args &&...args)
 {
     auto ptr = std::make_unique<T>(std::forward<Args>(args)...);
     if (ptr->QObject::parent() == nullptr) {
@@ -24,9 +24,9 @@ NODISCARD auto makeQPointer(Args &&...args)
 }
 
 template<typename T, typename... Args>
+    requires(std::is_base_of_v<QObject, T>)
 NODISCARD QScopedPointer<T> makeQScopedPointer(Args &&...args)
 {
-    static_assert(std::is_base_of_v<QObject, T>);
     auto ptr = std::make_unique<T>(std::forward<Args>(args)...);
     return QScopedPointer<T>{ptr.release()};
 }

--- a/src/global/TaggedInt.h
+++ b/src/global/TaggedInt.h
@@ -2,19 +2,22 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (C) 2021 The MMapper Authors
 
+#include "concepts.h"
 #include "macros.h"
 
 #include <limits>
 #include <stdexcept>
 #include <type_traits>
 
-template<typename Crtp_, typename Tag_, typename Wrapped_, Wrapped_ DefaultValue_ = Wrapped_{}>
+template<typename Crtp_,
+         typename Tag_,
+         concepts::IsIntegralNumeric Wrapped_,
+         Wrapped_ DefaultValue_ = Wrapped_{}>
 struct NODISCARD TaggedInt
 {
 public:
     using TagType = Tag_;
     using WrappedType = Wrapped_;
-    static_assert(std::is_integral_v<WrappedType>);
 
 public:
     static constexpr const WrappedType DEFAULT_VALUE = DefaultValue_;
@@ -79,15 +82,17 @@ template<typename...>
 struct NODISCARD underlying_helper;
 
 template<typename T>
+    requires(not concepts::IsEnum<T>)
 struct NODISCARD underlying_helper<T>
 {
     using type = T;
 };
 
 template<typename T>
-struct NODISCARD underlying_helper<T, std::enable_if_t<std::is_enum_v<T>>>
+    requires(concepts::IsEnum<T>)
+struct NODISCARD underlying_helper<T>
 {
-    using type = typename std::underlying_type_t<T>;
+    using type = std::underlying_type_t<T>;
 };
 
 template<typename Crtp_, typename Tag_, typename Type_>

--- a/src/global/TextBuffer.cpp
+++ b/src/global/TextBuffer.cpp
@@ -118,7 +118,7 @@ void TextBuffer::appendJustified(const QStringView input_line, const int maxLen)
     }
 
     // note: Generic lambda is actually a template function.
-    const auto appender = [this](auto &&arg) { this->append(std::forward<decltype(arg)>(arg)); };
+    const auto appender = [this]<typename Arg>(Arg &&arg) { this->append(std::forward<Arg>(arg)); };
 
     Prefix prefix;
     line = prefix.init(line, maxLen, appender);

--- a/src/global/View.cpp
+++ b/src/global/View.cpp
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+#include "View.h"
+
+#include "../map/CommandId.h"
+#include "../map/mmapper2room.h"
+#include "EnumIndexedArray.h"
+
+namespace {
+using namespace concepts;
+
+static_assert(IsView<View<int>>);
+
+enum class AbcEnum : uint8_t { A, B, C };
+constexpr size_t NUM_ABCS = 3;
+
+template<typename T>
+using AbcArray = EnumIndexedArray<T, AbcEnum, NUM_ABCS>;
+
+static_assert(!IsEnumIndexedArray<std::array<int, NUM_ABCS>>);
+static_assert(!IsEnumIndexedArray<std::vector<int>>);
+static_assert(IsEnumIndexedArray<AbcArray<int>>);
+static_assert(IsEnumIndexedArray<AbcArray<std::string>>);
+static_assert(IsEnumIndexedArray<EnumIndexedArray<int, AbcEnum, NUM_ABCS>>);
+
+} // namespace

--- a/src/global/View.h
+++ b/src/global/View.h
@@ -2,65 +2,74 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (C) 2026 The MMapper Authors
 
+#include "Array.h"
+#include "concepts.h"
 #include "macros.h"
 
-#include <array>
+#include <span>
 #include <stdexcept>
-#include <vector>
+#include <type_traits>
+
+#include <immer/detail/type_traits.hpp>
 
 template<typename T>
-struct NODISCARD View
+    requires(not std::is_array_v<T> and not std::is_reference_v<T>)
+struct NODISCARD View : public std::span<const T>
 {
-private:
-    const T *m_ptr = nullptr;
-    size_t m_size = 0;
-
 public:
-    using reference = const T &;
-    using pointer = const T *;
-    using size_type = size_t;
+    using base = std::span<const T>;
+    using base::base;
 
-public:
-    View() = default;
+    using typename base::const_pointer;
+    using typename base::element_type;
+    using typename base::pointer;
+    using typename base::reference;
+    using typename base::size_type;
+    using typename base::value_type;
 
-    explicit View(const T *const ptr, const size_t size)
-        : m_ptr{ptr}
-        , m_size{size}
+    using iterator = decltype(std::declval<base &>().begin());
+    using const_iterator = decltype(std::declval<const base &>().begin());
+
+#if !defined(__cpp_lib_span) or __cpp_lib_span < 202311L
+    NODISCARD constexpr reference at(const size_type pos) const
     {
-        if (ptr == nullptr && size != 0) {
-            throw std::invalid_argument("ptr");
-        }
-    }
-
-    IMPLICIT View(const std::vector<T> &v)
-        : View{v.data(), v.size()}
-    {}
-
-    template<size_t N>
-    IMPLICIT View(const std::array<T, N> &v)
-        : View{v.data(), v.size()}
-    {}
-
-public:
-    NODISCARD auto begin() const { return data(); }
-    NODISCARD auto end() const { return begin() + size(); }
-    NODISCARD bool empty() const { return size() == 0; }
-    NODISCARD pointer data() const { return m_ptr; }
-    NODISCARD size_type size() const { return m_size; }
-
-public:
-    NODISCARD reference at(const size_type pos) const
-    {
-        if (!(pos < size())) {
+        const base &self = *this;
+        if (!(pos < self.size())) {
             throw std::out_of_range("pos");
         }
-        return m_ptr[pos];
+        return self[pos];
     }
-    NODISCARD reference operator[](const size_type pos) const { return at(pos); }
+#endif
+    // This purposely hides the base class operator[] in order to require bounds checking.
+    NODISCARD constexpr reference operator[](const size_type pos) const { return at(pos); }
 };
 
-template<typename T>
-View(const std::vector<T> &) -> View<T>;
+template<concepts::IsMmapperArray A>
+View(A) -> View<typename A::value_type>;
 
-template<typename T, size_t N>
-View(const std::array<T, N> &) -> View<T>;
+namespace concepts {
+
+namespace detail {
+namespace cpp11 {
+template<typename T>
+struct IsView : std::false_type
+{};
+template<typename T>
+struct IsView<View<T>> : std::true_type
+{};
+} // namespace cpp11
+namespace cpp17 {
+template<typename T>
+constexpr bool IsView_v = cpp11::IsView<T>::value;
+}
+} // namespace detail
+
+template<typename T>
+concept IsView = detail::cpp17::IsView_v<T>;
+
+template<typename T>
+concept IsStringViewGetter = requires(const T &x) {
+    { x() } -> std::same_as<std::string_view>;
+};
+
+} // namespace concepts

--- a/src/global/concepts.cpp
+++ b/src/global/concepts.cpp
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+#include "concepts.h"
+
+#include <cstdint>
+
+namespace concepts {
+static_assert(!IsNumeric<bool>);
+static_assert(IsBoolean<bool>);
+
+static_assert(!IsNumeric<char>);
+static_assert(IsCharacter<char>);
+static_assert(IsCharacter<char32_t>);
+
+static_assert(IsNumeric<signed char>);
+static_assert(IsNumeric<int>);
+static_assert(IsNumeric<uint32_t>);
+} // namespace concepts

--- a/src/global/concepts.h
+++ b/src/global/concepts.h
@@ -1,0 +1,121 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+#include <concepts>
+#include <string_view>
+
+#define MM_TYPE_IDENTITY(_x) std::type_identity_t<_x>
+
+namespace concepts {
+
+template<typename T>
+concept IsTriviallyCopyable = std::is_trivially_copyable_v<T>;
+
+namespace detail {
+
+namespace cpp11 {
+
+template<typename T>
+struct CharacterType : std::false_type
+{};
+template<typename T>
+struct ArithmeticIntegral : std::false_type
+{};
+
+#define XFOREACH_CHAR_TYPES(X) \
+    X(char) \
+    X(char8_t) \
+    X(char16_t) \
+    X(char32_t)
+
+#define X_DEFINE(_type) \
+    template<> \
+    struct CharacterType<_type> : std::true_type \
+    {};
+XFOREACH_CHAR_TYPES(X_DEFINE)
+#undef X_DEFINE
+
+#define XFOREACH_ARITH_INT_TYPES(X) \
+    X(signed char) \
+    X(signed short int) \
+    X(signed int) \
+    X(signed long int) \
+    X(signed long long) \
+    X(unsigned char) \
+    X(unsigned short int) \
+    X(unsigned int) \
+    X(unsigned long int) \
+    X(unsigned long long)
+
+#define X_DEFINE(_type) \
+    template<> \
+    struct ArithmeticIntegral<_type> : std::true_type \
+    {};
+XFOREACH_ARITH_INT_TYPES(X_DEFINE)
+#undef X_DEFINE
+} // namespace cpp11
+
+// X_v<T> and X_t<T> templates as shortcuts for X<T>::value and X<T>::type.
+namespace cpp17 {
+template<typename T>
+inline constexpr bool IsCharacterType_v = cpp11::CharacterType<T>::value;
+template<typename T>
+inline constexpr bool IsIntegralNumeric_v = cpp11::ArithmeticIntegral<T>::value;
+} // namespace cpp17
+
+} // namespace detail
+
+template<typename T>
+concept IsBoolean = std::is_same_v<bool, T>;
+
+template<typename T>
+concept IsCharacter = detail::cpp17::IsCharacterType_v<T>;
+
+// caution: this differs from std::integral because we purposely exclude boolean and character types.
+template<typename T>
+concept IsIntegralNumeric = detail::cpp17::IsIntegralNumeric_v<T>;
+
+template<typename T>
+concept IsUnsignedIntegralNumeric = IsIntegralNumeric<T> and std::is_unsigned_v<T>;
+
+template<typename T>
+concept IsSignedIntegralNumeric = IsIntegralNumeric<T> and std::is_signed_v<T>;
+
+template<typename T>
+concept IsEnum = std::is_enum_v<T>;
+
+template<typename T>
+concept IsUnsignedEnum = IsEnum<T> and IsUnsignedIntegralNumeric<std::underlying_type_t<T>>;
+
+template<typename T>
+concept IsSignedEnum = IsEnum<T> and IsSignedIntegralNumeric<std::underlying_type_t<T>>;
+
+template<typename T>
+concept IsEnumRef = IsEnum<std::remove_reference_t<T>>;
+
+template<typename T>
+concept IsEnumOrEnumRef = IsEnum<T> or IsEnumRef<T>;
+
+template<typename T>
+concept IsFloatingPoint = std::floating_point<T>;
+
+template<typename T>
+concept IsNumeric = IsIntegralNumeric<T> or IsFloatingPoint<T>;
+
+template<typename T>
+concept IsPointer = std::is_pointer_v<T>;
+
+template<typename T>
+concept IsValue = std::is_same_v<T, std::decay_t<T>>;
+
+template<typename T>
+concept IsLValueRef = std::is_lvalue_reference_v<T>;
+
+template<typename T>
+concept IsConstLValueRef = IsLValueRef<T> and std::is_const_v<std::remove_reference_t<T>>;
+
+template<typename T>
+concept IsValueOrConstLValueRef = IsValue<T> or IsConstLValueRef<T>;
+
+} // namespace concepts

--- a/src/global/emojis.cpp
+++ b/src/global/emojis.cpp
@@ -171,36 +171,18 @@ public:
     class NODISCARD HexPrefixTree final
     {
     private:
-#if defined(__cpp_lib_generic_unordered_lookup) && __cpp_lib_generic_unordered_lookup
-        static_assert(false, "Not tested; this may need to be fixed.");
-        using HashBase = std::hash<std::u32string_view>;
-        struct NODISCARD Hash final : public HashBase
-        {
-            auto operator()(const std::u32string &s) const { return HashBase::operator()(s); }
-        };
-        struct NODISCARD Pred final
-        {
-            using T1 = const std::u32string &;
-            using T2 = const std::u32string_view;
-            bool operator()(T1 a, T1 b) const { return a == b; }
-            bool operator()(T1 a, T2 b) const { return a == b; }
-            bool operator()(T2 a, T1 b) const { return a == b; }
-            // bool operator()(T2 a, T2 b) const { return a == b; }
-        };
-        using Map = std::unordered_map<std::u32string, std::optional<std::u32string>, Hash, Pred>;
-#else
+        // REVISIT: consider using std::unordered_map
         struct NODISCARD Comp final
         {
             using is_transparent = void;
             using T1 = const std::u32string &;
             using T2 = const std::u32string_view;
-            bool operator()(T1 a, T1 b) const { return a < b; }
-            bool operator()(T1 a, T2 b) const { return a < b; }
-            bool operator()(T2 a, T1 b) const { return a < b; }
+            NODISCARD bool operator()(T1 a, T1 b) const { return a < b; }
+            NODISCARD bool operator()(T1 a, T2 b) const { return a < b; }
+            NODISCARD bool operator()(T2 a, T1 b) const { return a < b; }
             // bool operator()(T2 a, T2 b) const { return a < b; }
         };
         using Map = std::map<std::u32string, std::optional<std::u32string>, Comp>;
-#endif
 
         Map m_map;
 
@@ -604,7 +586,7 @@ NODISCARD QString mmqt::encodeEmojiShortCodes(const QString &s)
 
             // REVISIT: should this include "U+" or not?
             char hex[32];
-            snprintf(hex, sizeof(hex), "[:U+%X:]", c);
+            snprintf(hex, sizeof(hex), "[:U+%X:]", static_cast<unsigned int>(c));
             for (const char ascii : std::string_view{hex}) {
                 m_output += static_cast<char32_t>(static_cast<uint8_t>(ascii));
             }

--- a/src/global/enums.h
+++ b/src/global/enums.h
@@ -4,73 +4,133 @@
 // Author: Nils Schimmelmann <nschimme@gmail.com> (Jahara)
 
 #include "Array.h"
+#include "Flags.h"
+#include "View.h"
+#include "concepts.h"
 
+#include <cassert>
 #include <cstddef>
-#include <stdexcept>
+
+namespace concepts {
+template<typename E>
+concept with_UNDEFINED = requires(E x) { x = E::UNDEFINED; };
+template<typename E>
+concept without_UNDEFINED = not with_UNDEFINED<E>;
+
+template<typename E>
+concept IsEnum_with_UNDEFINED = IsUnsignedEnum<E> and with_UNDEFINED<E>;
+template<typename E>
+concept IsEnum_without_UNDEFINED = IsUnsignedEnum<E> and without_UNDEFINED<E>;
+} // namespace concepts
 
 namespace enums {
 
-template<typename T, const size_t N>
-NODISCARD inline MMapper::Array<T, N> genEnumValues()
+template<concepts::IsEnum E>
+constexpr auto to_underlying(const E e) noexcept
 {
-    MMapper::Array<T, N> result;
+#if !defined(__cpp_lib_to_underlying) or __cpp_lib_to_underlying < 202102L
+    return static_cast<std::underlying_type_t<E>>(e);
+#else
+    return std::to_underlying(e); // c++23
+#endif
+}
+
+template<concepts::IsUnsignedEnum E, const size_t N = CountOf_v<E>>
+    requires(N > 0)
+NODISCARD constexpr auto genEnumValues() -> MMapper::Array<E, N>
+{
+    MMapper::Array<E, N> result;
     for (size_t i = 0u; i < N; ++i) {
-        result[i] = static_cast<T>(i);
+        result[i] = static_cast<E>(i);
     }
     return result;
 }
 
-template<typename E, typename It>
-struct NODISCARD counting_iterator
+template<concepts::IsUnsignedEnum E, const size_t N = CountOf_v<E>>
+    requires(N > (concepts::IsEnum_without_UNDEFINED<E> ? 0 : 1))
+NODISCARD auto genEnumValues_without_UNDEFINED() -> View<E>
 {
-    It begin_;
-    It it_;
-    It end_;
-
-    void operator++(int) = delete;
-    ALLOW_DISCARD counting_iterator &operator++()
-    {
-        if (it_ >= end_) {
-            throw std::runtime_error("overflow");
+    static auto values = std::invoke([]() constexpr {
+        if constexpr (concepts::IsEnum_without_UNDEFINED<E>) {
+            return genEnumValues<E, N>();
+        } else {
+            constexpr size_t UNDEF = to_underlying(E::UNDEFINED);
+            constexpr size_t SIZE = (UNDEF < N) ? (N - 1) : N;
+            MMapper::Array<E, SIZE> tmp;
+            size_t o = 0;
+            for (size_t i = 0u; i < N; ++i) {
+                const auto e = static_cast<E>(i);
+                if (e != E::UNDEFINED) {
+                    tmp[o++] = e;
+                }
+            }
+            assert(o == SIZE);
+            return tmp;
         }
-        ++it_;
-        return *this;
-    }
-
-    NODISCARD bool operator==(const counting_iterator &rhs) const
-    {
-        if (begin_ != rhs.begin_ || end_ != rhs.end_) {
-            throw std::runtime_error("invalid comparison");
-        }
-        return it_ == rhs.it_;
-    }
-    NODISCARD bool operator!=(const counting_iterator &rhs) const { return !operator==(rhs); }
-
-    NODISCARD E operator*()
-    {
-        if (it_ >= end_) {
-            throw std::runtime_error("overflow");
-        }
-
-        return static_cast<E>(it_ - begin_);
-    }
-};
-
-template<typename E, typename It>
-struct NODISCARD counting_range
-{
-    using iterator = counting_iterator<E, It>;
-    It beg_;
-    It end_;
-    NODISCARD auto begin() { return iterator{beg_, beg_, end_}; }
-    NODISCARD auto end() { return iterator{beg_, end_, end_}; }
-};
-
-template<typename E, typename T>
-NODISCARD static inline auto makeCountingIterator(T &&container)
-{
-    auto beg = std::begin(container);
-    return counting_range<E, decltype(beg)>{beg, std::end(container)};
+    });
+    static constinit auto view = View<E>{values};
+    return view;
 }
-
 } // namespace enums
+
+#define DECL_ENUM_GETTER2(_E, _N, _name) \
+    NODISCARD inline auto _name() -> View<_E> \
+    { \
+        using E = MM_TYPE_IDENTITY(_E); \
+        static_assert(concepts::IsEnum<E>); \
+        static constexpr size_t N = (_N); \
+        static_assert(N == ::enums::CountOf_v<E>); \
+        return ::enums::genEnumValues_without_UNDEFINED<E>(); \
+    }
+
+// for use only with flags-like enums; consider using Flags<E> instead
+#define ENUM_ALLOW_BIT_AND(_E, _maybe_friend) \
+    NODISCARD _maybe_friend inline constexpr MM_TYPE_IDENTITY( \
+        _E) operator&(const MM_TYPE_IDENTITY(_E) lhs, const MM_TYPE_IDENTITY(_E) rhs) noexcept \
+    { \
+        static_assert(concepts::IsUnsignedEnum<_E>); \
+        return static_cast<_E>(enums::to_underlying(lhs) & enums::to_underlying(rhs)); \
+    } \
+    ALLOW_DISCARD _maybe_friend inline constexpr MM_TYPE_IDENTITY(_E) & \
+    operator&=(MM_TYPE_IDENTITY(_E) & lhs, const MM_TYPE_IDENTITY(_E) rhs) noexcept \
+    { \
+        return lhs = (lhs & rhs); \
+    }
+
+// for use only with flags-like enums; consider using enums::Flags instead
+#define ENUM_ALLOW_BIT_OR(_E, _maybe_friend) \
+    NODISCARD _maybe_friend inline constexpr MM_TYPE_IDENTITY( \
+        _E) operator|(const MM_TYPE_IDENTITY(_E) lhs, const MM_TYPE_IDENTITY(_E) rhs) noexcept \
+    { \
+        static_assert(concepts::IsUnsignedEnum<_E>); \
+        return static_cast<_E>(enums::to_underlying(lhs) | enums::to_underlying(rhs)); \
+    } \
+    ALLOW_DISCARD _maybe_friend inline constexpr MM_TYPE_IDENTITY(_E) & \
+    operator|=(MM_TYPE_IDENTITY(_E) & lhs, const MM_TYPE_IDENTITY(_E) rhs) noexcept \
+    { \
+        return lhs = (lhs | rhs); \
+    }
+
+// for use only with flags-like enums; consider using enums::Flags instead
+#define ENUM_ALLOW_BIT_COMPL(_E, _Bits, _maybe_friend) \
+    NODISCARD _maybe_friend inline constexpr _E operator~(const MM_TYPE_IDENTITY(_E) x) noexcept \
+    { \
+        static_assert(concepts::IsUnsignedEnum<_E>); \
+        constexpr size_t N = (_Bits); \
+        using U = std::underlying_type_t<_E>; \
+        static_assert(N > 0); \
+        static_assert(N <= std::numeric_limits<U>::digits); \
+        constexpr U mask = (U{1} << N) - U{1}; \
+        static_assert(((mask + 1) & mask) == U{0}); \
+        return static_cast<_E>(~enums::to_underlying(x) & mask); \
+    }
+
+// for use only with flags-like enums; consider using enums::Flags instead
+#define ENUM_ALLOWS_BIT_OPS_WITH_WIDTH(_E, _N) \
+    ENUM_ALLOW_BIT_AND(_E, ) \
+    ENUM_ALLOW_BIT_OR(_E, ) ENUM_ALLOW_BIT_COMPL(_E, (_N), )
+
+// for use only with flags-like enums; consider using enums::Flags instead
+#define FRIEND_ENUM_ALLOWS_BIT_OPS_WITH_WIDTH(_E, _N) \
+    ENUM_ALLOW_BIT_AND(_E, friend) \
+    ENUM_ALLOW_BIT_OR(_E, friend) ENUM_ALLOW_BIT_COMPL(_E, (_N), friend)

--- a/src/global/enums.h
+++ b/src/global/enums.h
@@ -68,7 +68,7 @@ NODISCARD auto genEnumValues_without_UNDEFINED() -> View<E>
             return tmp;
         }
     });
-    static constinit auto view = View<E>{values};
+    static const auto view = View<E>{values};
     return view;
 }
 } // namespace enums

--- a/src/global/float_cast.h
+++ b/src/global/float_cast.h
@@ -28,33 +28,29 @@ NODISCARD constexpr bool isSameIntValue(const A a, const B b) noexcept
     return a == b;
 }
 
-// This only exists because c++17 std::isnan() is not constexpr;
-// using "f != f" feels like a hack.
 template<typename FloatType>
 NODISCARD constexpr bool isNan(const FloatType f) noexcept
 {
-#if __cplusplus >= 202000L
+#if defined(__cpp_lib_constexpr_cmath) && __cpp_lib_constexpr_cmath >= 202202L
     return std::isnan(f);
+#elif defined(__clang__) || defined(__GNUC__)
+    return __builtin_isnan(f);
 #else
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wfloat-equal"
-#endif
-    return f != f; // NOLINT (this is only true for NaNs)
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+    // std::isnan() is not constexpr in all C++20 implementations (e.g. MSVC 2022)
+    return f != f;
 #endif
 }
 
-// this only exists because c++17 std::isfinite() is not constexpr
 template<typename FloatType>
 NODISCARD constexpr bool isFinite(const FloatType f) noexcept
 {
-#if __cplusplus >= 202000L
+#if defined(__cpp_lib_constexpr_cmath) && __cpp_lib_constexpr_cmath >= 202202L
     return std::isfinite(f);
+#elif defined(__clang__) || defined(__GNUC__)
+    return __builtin_isfinite(f);
 #else
-    constexpr auto inf = std::numeric_limits<FloatType>::infinity();
+    // std::isfinite() is not constexpr in all C++20 implementations (e.g. MSVC 2022)
+    const auto inf = std::numeric_limits<FloatType>::infinity();
     return !isNan(f) && -inf < f && f < inf;
 #endif
 }

--- a/src/global/hash.h
+++ b/src/global/hash.h
@@ -7,13 +7,10 @@
 #include <cstdint>
 #include <cstring>
 #include <string_view>
-#include <type_traits>
 
-template<typename T>
-MAYBE_UNUSED NODISCARD static auto numeric_hash(const T val) noexcept
-    -> std::enable_if_t<std::is_arithmetic_v<T>, size_t>
+MAYBE_UNUSED NODISCARD static size_t numeric_hash(const std::integral auto val) noexcept
 {
-    static constexpr const size_t size = sizeof(val);
+    static constexpr size_t size = sizeof(val);
     char buf[size];
     std::memcpy(buf, &val, size);
     return std::hash<std::string_view>()({buf, size});

--- a/src/global/mm_source_location.h
+++ b/src/global/mm_source_location.h
@@ -4,28 +4,10 @@
 
 #include "macros.h"
 
-#include <cstdint>
-
-#if __cplusplus >= 202000L \
-    && __has_builtin(__builtin_source_location) // && __cpp_lib_source_location >= 201907L
 #include <source_location>
+
 namespace mm {
 using source_location = std::source_location;
-}
-#define MM_SOURCE_LOCATION() (std::source_location::current())
-#else
-namespace mm {
-// TODO: replace this with C++20's std::source_location
-struct NODISCARD source_location final
-{
-    const char *m_file_name = "";
-    const char *m_function_name = "";
-    std::uint_least32_t m_line = 0;
-
-    NODISCARD const char *file_name() const { return this->m_file_name; }
-    NODISCARD const char *function_name() const { return this->m_function_name; }
-    NODISCARD std::uint_least32_t line() const { return this->m_line; }
-};
 } // namespace mm
-#define MM_SOURCE_LOCATION() (mm::source_location{__FILE__, __FUNCTION__, __LINE__})
-#endif
+
+#define MM_SOURCE_LOCATION() (std::source_location::current())

--- a/src/global/random.h
+++ b/src/global/random.h
@@ -26,7 +26,7 @@ public:
 NODISCARD extern size_t getRandom(size_t max);
 
 template<typename T>
-NODISCARD decltype(auto) chooseRandomElement(T &container)
+NODISCARD decltype(auto) chooseRandomElement(T &&container)
 {
     if (container.empty()) {
         throw std::invalid_argument("container");

--- a/src/global/unquote.cpp
+++ b/src/global/unquote.cpp
@@ -35,7 +35,7 @@ struct NODISCARD UnquoteException final : public std::runtime_error
 };
 UnquoteException::~UnquoteException() = default;
 
-enum class NODISCARD TokenEnum { BeginString, EndString };
+enum class NODISCARD TokenEnum : uint8_t { BeginString, EndString };
 
 NODISCARD static std::optional<uint32_t> try_decode_oct(char c) noexcept
 {
@@ -266,32 +266,38 @@ NODISCARD static std::vector<std::string> unquote_unsafe(const std::string_view 
     std::optional<size_t> current_pos;
     std::optional<size_t> stringNumber;
 
-    foreach_char([&result, &stringNumber, &current_pos](auto &&x) {
-        using T = std::decay_t<decltype(x)>;
-        if constexpr (std::is_same_v<T, char>) {
-            const size_t pos = current_pos.value()++;
-            std::string &s = result[stringNumber.value()];
-            assert(pos < s.length());
-            s[pos] = static_cast<char>(x);
-        } else if constexpr (std::is_same_v<T, TokenEnum>) {
-            switch (x) {
-            case TokenEnum::BeginString:
-                assert(!current_pos.has_value());
-                current_pos.emplace(0);
-                if (!stringNumber.has_value()) {
-                    stringNumber = 0;
-                }
-                break;
-            case TokenEnum::EndString:
-                assert(result[stringNumber.value()].size() == current_pos.value());
-                current_pos.reset();
-                ++stringNumber.value();
-                break;
-            }
-        } else {
-            throw std::runtime_error("internal error");
-        }
-    });
+    foreach_char([&result, &stringNumber, &current_pos]<typename T>
+                     requires(std::same_as<char, std::remove_cvref_t<T>>
+                              or std::same_as<TokenEnum, std::remove_cvref_t<T>>)
+                 (T &&x) -> void {
+                     if constexpr (std::is_same_v<char, std::remove_cvref_t<T>>) {
+                         const size_t pos = current_pos.value()++;
+                         std::string &s = result[stringNumber.value()];
+                         assert(pos < s.length());
+                         s[pos] = static_cast<char>(x);
+                     } else if constexpr (std::is_same_v<TokenEnum, std::remove_cvref_t<T>>) {
+                         switch (x) {
+                         case TokenEnum::BeginString:
+                             assert(!current_pos.has_value());
+                             current_pos.emplace(0);
+                             if (!stringNumber.has_value()) {
+                                 stringNumber = 0;
+                             }
+                             break;
+                         case TokenEnum::EndString:
+                             assert(result[stringNumber.value()].size() == current_pos.value());
+                             current_pos.reset();
+                             ++stringNumber.value();
+                             break;
+                         default:
+                             std::abort();
+                         }
+                     } else {
+                         // this cannot happen
+                         static_assert(std::is_void_v<T>);
+                         throw std::runtime_error("internal error");
+                     }
+                 });
 
     assert(stringNumber.value_or(0) == result.size());
     return result;

--- a/src/global/utils.h
+++ b/src/global/utils.h
@@ -4,6 +4,7 @@
 // Author: Nils Schimmelmann <nschimme@gmail.com> (Jahara)
 
 #include "NullPointerException.h"
+#include "concepts.h"
 #include "macros.h"
 
 #include <algorithm>
@@ -25,12 +26,9 @@ namespace utils {
 
 // This mainly exists to avoid float-equal warnings,
 // but it also checks that the floating point types are the same.
-template<typename A, typename B>
-NODISCARD constexpr bool isSameFloat(const A a, const B b) noexcept
+template<concepts::IsFloatingPoint A>
+NODISCARD constexpr bool isSameFloat(const A a, const std::same_as<A> auto b) noexcept
 {
-    static_assert(std::is_floating_point_v<A>);
-    static_assert(std::is_floating_point_v<B>);
-    static_assert(std::is_same_v<std::decay_t<A>, std::decay_t<B>>);
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wfloat-equal"
@@ -45,9 +43,9 @@ namespace details {
 template<typename T>
 NODISCARD constexpr bool isBitMask()
 {
-    if constexpr (std::is_integral_v<T> && std::is_unsigned_v<T>) {
+    if constexpr (concepts::IsUnsignedIntegralNumeric<T>) {
         return true;
-    } else if constexpr (std::is_enum_v<T>) {
+    } else if constexpr (concepts::IsEnum<T>) {
         return isBitMask<std::underlying_type_t<T>>();
     } else {
         return false;
@@ -59,10 +57,10 @@ template<typename T>
 NODISCARD constexpr bool isPowerOfTwo(const T x) noexcept
 {
     static_assert(details::isBitMask<T>());
-    if constexpr (std::is_enum_v<T>) {
+    if constexpr (concepts::IsEnum<T>) {
         using U = std::underlying_type_t<T>;
         return isPowerOfTwo<U>(static_cast<U>(x));
-    } else if constexpr (std::is_integral_v<T> && std::is_unsigned_v<T>) {
+    } else if constexpr (concepts::IsUnsignedIntegralNumeric<T>) {
         return x != 0u && (x & (x - 1u)) == 0u;
     } else {
         throw std::invalid_argument("x");
@@ -75,10 +73,9 @@ NODISCARD constexpr bool isPowerOfTwo(const T x) noexcept
  * If the next power of two would overflow T, it is clamped to the largest
  * representable power of two.
  */
-template<typename T>
+template<concepts::IsUnsignedIntegralNumeric T>
 NODISCARD constexpr T nextPowerOfTwo(T x) noexcept
 {
-    static_assert(std::is_integral_v<T> && std::is_unsigned_v<T>);
     if (x <= 1) {
         return 1;
     }
@@ -109,10 +106,9 @@ NODISCARD constexpr T nextPowerOfTwo(T x) noexcept
  * For x=0 or 1, returns 1.
  * If x is beyond the largest representable power of two, that value is returned.
  */
-template<typename T>
+template<concepts::IsUnsignedIntegralNumeric T>
 NODISCARD constexpr T nearestPowerOfTwo(T x) noexcept
 {
-    static_assert(std::is_integral_v<T> && std::is_unsigned_v<T>);
     if (x <= 1) {
         return 1;
     }
@@ -129,15 +125,17 @@ NODISCARD constexpr T nearestPowerOfTwo(T x) noexcept
 }
 
 template<typename T>
+    requires(concepts::IsUnsignedEnum<T> or concepts::IsUnsignedIntegralNumeric<T>)
 NODISCARD constexpr bool isAtLeastTwoBits(const T x) noexcept
 {
     static_assert(details::isBitMask<T>());
-    if constexpr (std::is_enum_v<T>) {
+    if constexpr (concepts::IsUnsignedEnum<T>) {
         using U = std::underlying_type_t<T>;
         return isAtLeastTwoBits<U>(static_cast<U>(x));
-    } else if constexpr (std::is_integral_v<T> && std::is_unsigned_v<T>) {
+    } else if constexpr (concepts::IsUnsignedIntegralNumeric<T>) {
         return x != 0u && (x & (x - 1u)) != 0u;
     } else {
+        static_assert(std::is_void_v<T>);
         throw std::invalid_argument("x");
     }
 }
@@ -170,18 +168,21 @@ NODISCARD bool isSet(const T src, const T bit)
 namespace details {
 namespace cpp11 {
 template<size_t N, typename T>
-struct IsValidCircularSize
-    : std::bool_constant<(N > 1 and std::is_unsigned_v<T>
-                          and (N <= std::numeric_limits<T>::max()
-                               or (sizeof(T) < sizeof(size_t)
-                                   and N == static_cast<size_t>(std::numeric_limits<T>::max()) + 1)))>
-      //
-      {};
+struct IsValidCircularSize : std::false_type
+{};
 
 template<>
 struct IsValidCircularSize<2, bool> : std::true_type
 {};
 
+template<size_t N, concepts::IsUnsignedIntegralNumeric T>
+struct IsValidCircularSize<N, T>
+    : std::bool_constant<(N > 1
+                          and (N <= std::numeric_limits<T>::max()
+                               or (sizeof(T) < sizeof(size_t)
+                                   and N == static_cast<size_t>(std::numeric_limits<T>::max()) + 1)))>
+      //
+      {};
 } // namespace cpp11
 
 namespace cpp17 {
@@ -191,35 +192,37 @@ inline constexpr bool IsValidCircularSize_v = cpp11::IsValidCircularSize<N, T>::
 } // namespace cpp17
 } // namespace details
 
-template<size_t N, typename T>
+template<size_t N, concepts::IsUnsignedIntegralNumeric T>
+    requires(details::cpp17::IsValidCircularSize_v<N, T>)
 NODISCARD constexpr T circular_increment(const T x)
 {
-    if constexpr (std::is_unsigned_v<T> && details::cpp17::IsValidCircularSize_v<N, T>) {
-        return static_cast<T>((x + 1) % N);
-    } else if constexpr (std::is_same_v<T, bool> && N == 2) {
-        return !x;
-    } else {
-        static_assert(std::is_same_v<T, void>);
-        std::abort();
-    }
+    return static_cast<T>((x + 1) % N);
 }
-template<size_t N, typename T>
+template<size_t N, concepts::IsUnsignedIntegralNumeric T>
+    requires(details::cpp17::IsValidCircularSize_v<N, T>)
 NODISCARD constexpr T circular_decrement(const T x)
 {
-    if constexpr (std::is_unsigned_v<T> && details::cpp17::IsValidCircularSize_v<N, T>) {
-        return static_cast<T>((x + N - 1) % N);
-    } else if constexpr (std::is_same_v<T, bool> && N == 2) {
-        return !x;
-    } else {
-        static_assert(std::is_same_v<T, void>);
-        std::abort();
-    }
+    return static_cast<T>((x + N - 1) % N);
+}
+
+template<size_t N, concepts::IsBoolean T>
+    requires(N == 2)
+NODISCARD constexpr T circular_increment(const T x)
+{
+    return !x;
+}
+template<size_t N, concepts::IsBoolean T>
+    requires(N == 2)
+NODISCARD constexpr T circular_decrement(const T x)
+{
+    return !x;
 }
 
 } // namespace utils
 
 template<typename T>
-NODISCARD constexpr bool isClamped(T x, T lo, T hi)
+    requires(concepts::IsNumeric<T> or concepts::IsCharacter<T>)
+NODISCARD constexpr bool isClamped(const T x, const T lo, const T hi)
 {
     return x >= lo && x <= hi;
 }
@@ -229,20 +232,35 @@ NODISCARD int round_ftoi(float f);
 } // namespace utils
 
 template<typename Base, typename Derived>
+    requires(std::is_base_of_v<Base, Derived>)
 NODISCARD std::unique_ptr<Base> static_upcast(std::unique_ptr<Derived> &&ptr)
 {
-    static_assert(std::is_base_of_v<Base, Derived>);
     return std::unique_ptr<Base>(ptr.release());
 }
 
 template<typename T>
-NODISCARD inline T &deref(T *const ptr)
+NODISCARD inline auto &deref(T *const ptr)
 {
     if (ptr == nullptr) {
         throw NullPointerException();
     }
     return *ptr;
 }
+
+template<typename T>
+    requires(not std::is_reference_v<T>)
+NODISCARD inline auto &deref(T &ptr)
+{
+    if (ptr == nullptr) {
+        throw NullPointerException();
+    }
+    return *ptr;
+}
+
+template<typename T>
+    requires(not std::is_reference_v<T>)
+NODISCARD inline T deref(T &&ptr) = delete;
+
 template<typename T>
 NODISCARD inline T deref(std::optional<T> &&ptr)
 {
@@ -260,39 +278,6 @@ NODISCARD inline const T &deref(const std::optional<T> &ptr)
 {
     // note: this can throw bad_optional_access
     return ptr.value();
-}
-
-// Technically we could make this return move or copy of the pointed-to value,
-// but that's probably not what the caller expects.
-template<typename T>
-inline T deref(std::shared_ptr<T> &&ptr) = delete;
-template<typename T>
-NODISCARD inline T &deref(const std::shared_ptr<T> &ptr)
-{
-    if (ptr == nullptr) {
-        throw NullPointerException();
-    }
-    return *ptr;
-}
-// Technically we could make this return move or copy of the pointed-to value,
-// but that's probably not what the caller expects.
-template<typename T>
-inline T deref(std::unique_ptr<T> &&ptr) = delete;
-template<typename T>
-NODISCARD inline T &deref(const std::unique_ptr<T> &ptr)
-{
-    if (ptr == nullptr) {
-        throw NullPointerException();
-    }
-    return *ptr;
-}
-template<typename T>
-NODISCARD inline T &deref(const QPointer<T> &ptr)
-{
-    if (ptr == nullptr) {
-        throw NullPointerException();
-    }
-    return *ptr;
 }
 
 ///  Can throw NullPointerException or std::bad_cast
@@ -460,16 +445,7 @@ ALLOW_DISCARD static inline size_t erase_if(Container &container, Callback &&cal
 template<typename T, typename Predicate>
 NODISCARD bool listRemoveIf(std::list<T> &list, Predicate &&should_remove)
 {
-    // c++20 version of remove_if() returns # of elements removed, but c++17 doesn't.
-    bool removed = false;
-    list.remove_if([&removed, &should_remove](const T &element) -> bool {
-        if (should_remove(element)) {
-            removed = true;
-            return true;
-        }
-        return false;
-    });
-    return removed;
+    return std::erase_if(list, std::forward<Predicate>(should_remove)) > 0;
 }
 
 template<typename Container, typename Callback>
@@ -498,9 +474,8 @@ NODISCARD static inline auto find_min_computed(const Container &container, Callb
     }
 }
 
-// This can be removed and replaced with std::remove_cvref_t<T> in c++20.
 template<typename T>
-using remove_cvref_t = std::remove_cv_t<std::remove_reference_t<T>>;
+using remove_cvref_t = std::remove_cvref_t<T>;
 
 template<typename T, typename... Ts>
 struct are_distinct : std::conjunction<std::negation<std::is_same<T, Ts>>..., are_distinct<Ts...>>

--- a/src/group/enums.cpp
+++ b/src/group/enums.cpp
@@ -5,38 +5,19 @@
 #include "enums.h"
 
 #include "../global/enums.h"
-#include "mmapper2character.h"
+#include "../global/tests.h"
 
-#include <array>
-#include <vector>
-
-#define DEFINE_GETTER(E, N, name) \
-    const MMapper::Array<E, N> &name() \
-    { \
-        static const auto things = ::enums::genEnumValues<E, N>(); \
-        return things; \
+namespace test {
+void test_group_enums()
+{
+    for (auto x : DEFINED_CHARACTER_POSITIONS) {
+        assert(x != CharacterPositionEnum::UNDEFINED);
     }
-#define DEFINE_GETTER_DEFINED(E, N, name) \
-    const std::vector<E> &name() \
-    { \
-        static const auto things = std::invoke([]() { \
-            static_assert(std::is_enum_v<E>); \
-            std::vector<E> result; \
-            for (const E x : ::enums::genEnumValues<E, N>()) { \
-                if (x != E::UNDEFINED) { \
-                    result.emplace_back(x); \
-                } \
-            } \
-            return result; \
-        }); \
-        return things; \
+    for (auto x : DEFINED_CHARACTER_TYPES) {
+        assert(x != CharacterTypeEnum::UNDEFINED);
     }
-
-namespace enums {
-DEFINE_GETTER_DEFINED(CharacterPositionEnum, NUM_CHARACTER_POSITIONS, getAllCharacterPositions)
-DEFINE_GETTER_DEFINED(CharacterTypeEnum, NUM_CHARACTER_TYPES, getAllCharacterTypes)
-DEFINE_GETTER(CharacterAffectEnum, NUM_CHARACTER_AFFECTS, getAllCharacterAffects)
-} // namespace enums
-
-#undef DEFINE_GETTER
-#undef DEFINE_GETTER_DEFINED
+    TEST_ASSERT(DEFINED_CHARACTER_POSITIONS.size() == NUM_CHARACTER_POSITIONS - 1);
+    TEST_ASSERT(DEFINED_CHARACTER_TYPES.size() == NUM_CHARACTER_TYPES - 1);
+    TEST_ASSERT(ALL_CHARACTER_AFFECTS.size() == NUM_CHARACTER_AFFECTS);
+}
+} // namespace test

--- a/src/group/enums.h
+++ b/src/group/enums.h
@@ -3,25 +3,19 @@
 // Copyright (C) 2019 The MMapper Authors
 // Author: Nils Schimmelmann <nschimme@gmail.com> (Jahara)
 
-#include "../global/Array.h"
+#include "../global/enums.h"
 #include "mmapper2character.h"
 
-#include <vector>
-
-#define DECL_GETTER(E, N, name) const MMapper::Array<E, N> &name();
-#define DECL_GETTER_DEFINED(E, N, name) const std::vector<E> &name();
-
 namespace enums {
-DECL_GETTER_DEFINED(CharacterPositionEnum, NUM_CHARACTER_POSITIONS, getAllCharacterPositions)
-DECL_GETTER_DEFINED(CharacterTypeEnum, NUM_CHARACTER_TYPES, getAllCharacterTypes)
-DECL_GETTER(CharacterAffectEnum, NUM_CHARACTER_AFFECTS, getAllCharacterAffects)
+DECL_ENUM_GETTER2(CharacterPositionEnum, NUM_CHARACTER_POSITIONS, getDefinedCharacterPositions)
+DECL_ENUM_GETTER2(CharacterTypeEnum, NUM_CHARACTER_TYPES, getDefinedCharacterTypes)
+DECL_ENUM_GETTER2(CharacterAffectEnum, NUM_CHARACTER_AFFECTS, getAllCharacterAffects)
 } // namespace enums
 
-#undef DECL_GETTER
-#undef DECL_GETTER_DEFINED
-
 #define ALL_CHARACTER_AFFECTS ::enums::getAllCharacterAffects()
-
-/* NOTE: These are actually used; but they're hidden in macros as DEFINED_CHARACTER_##X##_TYPES */
 #define DEFINED_CHARACTER_POSITIONS ::enums::getDefinedCharacterPositions()
 #define DEFINED_CHARACTER_TYPES ::enums::getDefinedCharacterTypes()
+
+namespace test {
+void test_group_enums();
+}

--- a/src/group/mmapper2character.h
+++ b/src/group/mmapper2character.h
@@ -91,7 +91,7 @@ Q_DECLARE_METATYPE(CharacterTypeEnum)
     /* define character affects above in display priority order */
 
 // TODO: States for CASTING DISEASED
-enum class NODISCARD CharacterAffectEnum {
+enum class NODISCARD CharacterAffectEnum : uint8_t {
 #define X_DECL_CHARACTER_AFFECT(UPPER_CASE, lower_case, CamelCase, friendly) UPPER_CASE,
     XFOREACH_CHARACTER_AFFECT(X_DECL_CHARACTER_AFFECT)
 #undef X_DECL_CHARACTER_AFFECT
@@ -114,9 +114,4 @@ public:
     XFOREACH_CHARACTER_AFFECT(X_DEFINE_ACCESSORS)
 #undef X_DEFINE_ACCESSORS
 };
-
-NODISCARD inline constexpr const CharacterAffectFlags operator|(CharacterAffectEnum lhs,
-                                                                CharacterAffectEnum rhs) noexcept
-{
-    return CharacterAffectFlags{lhs} | CharacterAffectFlags{rhs};
-}
+DEFINE_FLAGS_BITOP_OR(CharacterAffectFlags)

--- a/src/map/ConnectedRoomFlags.h
+++ b/src/map/ConnectedRoomFlags.h
@@ -3,6 +3,7 @@
 // Copyright (C) 2019 The MMapper Authors
 // Author: Nils Schimmelmann <nschimme@gmail.com> (Jahara)
 
+#include "../global/enums.h"
 #include "../global/utils.h"
 #include "ExitDirection.h"
 
@@ -13,19 +14,6 @@ enum class NODISCARD DirectSunlightEnum : uint32_t {
     SAW_DIRECT_SUN = 1,
     SAW_NO_DIRECT_SUN = 2,
 };
-
-NODISCARD constexpr inline auto toUint(const DirectSunlightEnum val) noexcept
-{
-    using U = uint32_t;
-    static_assert(std::is_same_v<U, std::underlying_type_t<DirectSunlightEnum>>);
-    return static_cast<U>(val);
-}
-
-NODISCARD inline constexpr DirectSunlightEnum operator&(const DirectSunlightEnum lhs,
-                                                        const DirectSunlightEnum rhs)
-{
-    return static_cast<DirectSunlightEnum>(toUint(lhs) & toUint(rhs));
-}
 
 static constexpr const auto SAW_ANY_DIRECT_SUNLIGHT = 0b10101010101u;
 static constexpr const auto CONNECTED_ROOM_FLAGS_VALID = 1u << 14;
@@ -39,6 +27,7 @@ static_assert(CONNECTED_ROOM_FLAGS_VALID > SAW_ANY_DIRECT_SUNLIGHT);
 class NODISCARD ConnectedRoomFlagsType final
 {
 private:
+    static_assert(std::is_same_v<uint32_t, std::underlying_type_t<DirectSunlightEnum>>);
     uint32_t m_flags = 0;
 
 public:
@@ -72,8 +61,9 @@ public:
     void reset() { *this = ConnectedRoomFlagsType(); }
 
 private:
-    static constexpr const auto MASK = static_cast<std::underlying_type_t<DirectSunlightEnum>>(
-        toUint(DirectSunlightEnum::SAW_DIRECT_SUN) | toUint(DirectSunlightEnum::SAW_NO_DIRECT_SUN));
+    static constexpr const auto MASK = enums::to_underlying(DirectSunlightEnum::SAW_DIRECT_SUN)
+                                       | enums::to_underlying(DirectSunlightEnum::SAW_NO_DIRECT_SUN);
+    static_assert(MASK == 3u);
 
     NODISCARD static int getShift(const ExitDirEnum dir) { return static_cast<int>(dir) * 2; }
 
@@ -89,7 +79,7 @@ public:
     {
         const auto shift = getShift(dir);
         m_flags &= ~(MASK << shift);
-        m_flags |= (toUint(light) & MASK) << shift;
+        m_flags |= (enums::to_underlying(light) & MASK) << shift;
     }
 
     NODISCARD bool hasNoDirectSunlight(const ExitDirEnum dir) const

--- a/src/map/Crtp.h
+++ b/src/map/Crtp.h
@@ -10,9 +10,6 @@
 template<typename CRTP>
 struct NODISCARD ExitFieldsGetters
 {
-protected:
-    ExitFieldsGetters() = default;
-
 private:
     NODISCARD const auto &crtp_get_fields() const
     {
@@ -77,9 +74,6 @@ public:
 template<typename CRTP>
 struct NODISCARD ExitFieldsSetters
 {
-protected:
-    ExitFieldsSetters() = default;
-
 private:
     NODISCARD auto &crtp_get_fields() { return static_cast<CRTP &>(*this).getExitFields(); }
 
@@ -120,9 +114,6 @@ public:
 template<typename CRTP>
 struct NODISCARD RoomFieldsGetters
 {
-protected:
-    RoomFieldsGetters() = default;
-
 private:
     NODISCARD const auto &crtp_get_fields() const
     {
@@ -139,9 +130,6 @@ public:
 template<typename CRTP>
 struct NODISCARD RoomFieldsSetters
 {
-protected:
-    RoomFieldsSetters() = default;
-
 private:
     NODISCARD auto &crtp_get_fields() { return static_cast<CRTP &>(*this).getRoomFields(); }
 
@@ -175,9 +163,6 @@ public:
 template<typename CRTP>
 struct NODISCARD RoomExitFieldsGetters
 {
-protected:
-    RoomExitFieldsGetters() = default;
-
 private:
     // Expect a const reference or a copy (necessary for fat-pointer proxy objects).
     NODISCARD decltype(auto) crtp_get_exit(const ExitDirEnum dir) const
@@ -203,9 +188,6 @@ public:
 template<typename CRTP>
 struct NODISCARD RoomExitFieldsSetters
 {
-protected:
-    RoomExitFieldsSetters() = default;
-
 private:
     NODISCARD auto &crtp_get_exit(const ExitDirEnum dir)
     {

--- a/src/map/Diff.h
+++ b/src/map/Diff.h
@@ -183,19 +183,17 @@ private:
         printQuoted(s.getStdStringViewUtf8());
     }
 
-    template<typename E>
-    auto printEnum(const E x) -> std::enable_if_t<std::is_enum_v<E>>
+    template<concepts::IsEnum E>
+    void printEnum(const E x)
     {
         m_os << to_string_view(x);
     }
 
-    template<typename Flags>
+    template<concepts::IsEnumFlags Flags>
     void printFlags(const Flags flags)
     {
         // assumes it's templated based on Flags in Flags.h
         using Flag = typename decltype(flags)::Flag;
-        static_assert(std::is_enum_v<Flag>);
-
         bool first = true;
         // m_os << "[";
         for (const Flag flag : flags) {

--- a/src/map/DoorFlags.h
+++ b/src/map/DoorFlags.h
@@ -48,11 +48,7 @@ public:
     // REVISIT: this name is different from the rest
     NODISCARD bool needsKey() const { return isNeedKey(); }
 };
-
-NODISCARD inline constexpr const DoorFlags operator|(DoorFlagEnum lhs, DoorFlagEnum rhs) noexcept
-{
-    return DoorFlags{lhs} | DoorFlags{rhs};
-}
+DEFINE_FLAGS_BITOP_OR(DoorFlags)
 
 NODISCARD extern std::string_view to_string_view(DoorFlagEnum flag);
 NODISCARD extern std::string_view getName(DoorFlagEnum flag);

--- a/src/map/ExitDirection.cpp
+++ b/src/map/ExitDirection.cpp
@@ -12,20 +12,26 @@
 #include "coordinate.h"
 
 namespace enums {
-const MMapper::Array<ExitDirEnum, NUM_EXITS_NESW> &getAllExitsNESW()
+View<ExitDirEnum> getAllExitsNESW()
 {
-    static const auto g_all_exits = genEnumValues<ExitDirEnum, NUM_EXITS_NESW>();
-    return g_all_exits;
+    static constexpr auto g_all_exits = genEnumValues<ExitDirEnum, NUM_EXITS_NESW>();
+    static constexpr auto view = View{g_all_exits};
+    static_assert(view.size() == NUM_EXITS_NESW);
+    return view;
 }
-const MMapper::Array<ExitDirEnum, NUM_EXITS_NESWUD> &getAllExitsNESWUD()
+View<ExitDirEnum> getAllExitsNESWUD()
 {
-    static const auto g_all_exits = genEnumValues<ExitDirEnum, NUM_EXITS_NESWUD>();
-    return g_all_exits;
+    static constexpr auto g_all_exits = genEnumValues<ExitDirEnum, NUM_EXITS_NESWUD>();
+    static constexpr auto view = View{g_all_exits};
+    static_assert(view.size() == NUM_EXITS_NESWUD);
+    return view;
 }
-const MMapper::Array<ExitDirEnum, NUM_EXITS> &getAllExits7()
+View<ExitDirEnum> getAllExits7()
 {
-    static const auto g_all_exits = genEnumValues<ExitDirEnum, NUM_EXITS>();
-    return g_all_exits;
+    static constexpr auto g_all_exits = genEnumValues<ExitDirEnum, NUM_EXITS>();
+    static constexpr auto view = View{g_all_exits};
+    static_assert(view.size() == NUM_EXITS);
+    return view;
 }
 
 } // namespace enums

--- a/src/map/ExitDirection.cpp
+++ b/src/map/ExitDirection.cpp
@@ -15,22 +15,19 @@ namespace enums {
 View<ExitDirEnum> getAllExitsNESW()
 {
     static constexpr auto g_all_exits = genEnumValues<ExitDirEnum, NUM_EXITS_NESW>();
-    static constexpr auto view = View{g_all_exits};
-    static_assert(view.size() == NUM_EXITS_NESW);
+    static const auto view = View{g_all_exits};
     return view;
 }
 View<ExitDirEnum> getAllExitsNESWUD()
 {
     static constexpr auto g_all_exits = genEnumValues<ExitDirEnum, NUM_EXITS_NESWUD>();
-    static constexpr auto view = View{g_all_exits};
-    static_assert(view.size() == NUM_EXITS_NESWUD);
+    static const auto view = View{g_all_exits};
     return view;
 }
 View<ExitDirEnum> getAllExits7()
 {
     static constexpr auto g_all_exits = genEnumValues<ExitDirEnum, NUM_EXITS>();
-    static constexpr auto view = View{g_all_exits};
-    static_assert(view.size() == NUM_EXITS);
+    static const auto view = View{g_all_exits};
     return view;
 }
 

--- a/src/map/ExitDirection.h
+++ b/src/map/ExitDirection.h
@@ -3,7 +3,7 @@
 // Copyright (C) 2019 The MMapper Authors
 // Author: Nils Schimmelmann <nschimme@gmail.com> (Jahara)
 
-#include "../global/Array.h"
+#include "../global/View.h"
 #include "ExitFlags.h"
 
 #include <cstdint>
@@ -27,13 +27,13 @@ static constexpr uint32_t NUM_EXITS = 7u;
 static constexpr uint32_t NUM_EXITS_INCLUDING_NONE = 8u;
 
 namespace enums {
-NODISCARD const MMapper::Array<ExitDirEnum, NUM_EXITS_NESW> &getAllExitsNESW();
-NODISCARD const MMapper::Array<ExitDirEnum, NUM_EXITS_NESWUD> &getAllExitsNESWUD();
-NODISCARD const MMapper::Array<ExitDirEnum, NUM_EXITS> &getAllExits7();
+NODISCARD View<ExitDirEnum> getAllExitsNESW();
+NODISCARD View<ExitDirEnum> getAllExitsNESWUD();
+NODISCARD View<ExitDirEnum> getAllExits7();
 
-#define ALL_EXITS_NESW enums::getAllExitsNESW()
-#define ALL_EXITS_NESWUD enums::getAllExitsNESWUD()
-#define ALL_EXITS7 enums::getAllExits7()
+#define ALL_EXITS_NESW ::enums::getAllExitsNESW()
+#define ALL_EXITS_NESWUD ::enums::getAllExitsNESWUD()
+#define ALL_EXITS7 ::enums::getAllExits7()
 
 } // namespace enums
 

--- a/src/map/ExitFlags.h
+++ b/src/map/ExitFlags.h
@@ -47,10 +47,7 @@ public:
 #undef X_DEFINE_ACCESSORS
 };
 
-NODISCARD inline constexpr const ExitFlags operator|(ExitFlagEnum lhs, ExitFlagEnum rhs) noexcept
-{
-    return ExitFlags{lhs} | ExitFlags{rhs};
-}
+DEFINE_FLAGS_BITOP_OR(ExitFlags)
 
 NODISCARD extern std::string_view to_string_view(ExitFlagEnum flag);
 NODISCARD extern std::string_view getName(ExitFlagEnum flag);

--- a/src/map/Map.cpp
+++ b/src/map/Map.cpp
@@ -697,7 +697,7 @@ static void print_coordinate(AnsiOstream &os, const RawAnsi &ansi, const Coordin
     os << ")";
 }
 
-void Map::statRoom(AnsiOstream &os, RoomId id) const
+void Map::statRoom(AnsiOstream &os, const RoomId id) const
 {
     const auto &room = getRoomHandle(id);
     const auto &pos = room.getPosition();
@@ -707,18 +707,17 @@ void Map::statRoom(AnsiOstream &os, RoomId id) const
     const auto ansi_yellow = getRawAnsi(AnsiColor16Enum::yellow);
     const auto ansi_red = getRawAnsi(AnsiColor16Enum::red);
 
-    auto kv = [&ansi_green, &os](std::string_view k, std::string_view v) {
+    auto kv = [&ansi_green, &os](const std::string_view k, const std::string_view v) {
         os << k << ": ";
         os.writeWithColor(ansi_green, v);
     };
 
-    auto print_flags = [&ansi_green, &os](const auto flags) {
+    auto print_flags = [&ansi_green, &os]<concepts::IsEnumFlags Flags>(const Flags flags) {
         if (flags.empty()) {
             os << " (none)";
         } else {
             // assumes it's templated based on Flags in Flags.h
-            using Flag = typename decltype(flags)::Flag;
-            static_assert(std::is_enum_v<Flag>);
+            using Flag = typename Flags::Flag;
             for (const Flag flag : flags) {
                 os << " ";
                 os.writeWithColor(ansi_green, to_string_view(flag));

--- a/src/map/ParseTree.cpp
+++ b/src/map/ParseTree.cpp
@@ -142,9 +142,8 @@ void ParseTree::printStats(ProgressCounter & /*pc*/, AnsiOstream &os) const
     static constexpr RawAnsi green = getRawAnsi(AnsiColor16Enum::green);
     static constexpr RawAnsi yellow = getRawAnsi(AnsiColor16Enum::yellow);
 
-    auto C = [](auto x) {
-        static_assert(std::is_integral_v<decltype(x)>);
-        return ColoredValue{green, x};
+    auto C = []<concepts::IsIntegralNumeric T>(const T x) -> ColoredValue<T> {
+        return ColoredValue<T>{green, x};
     };
 
     {

--- a/src/map/ParseTree.h
+++ b/src/map/ParseTree.h
@@ -51,14 +51,15 @@ struct std::hash<NameDesc>
     }
 };
 
-enum class NODISCARD ParseKeyEnum { Name, Desc };
+enum class NODISCARD ParseKeyEnum : uint8_t { Name, Desc };
 struct NODISCARD ParseKeyFlags final : public enums::Flags<ParseKeyFlags, ParseKeyEnum, uint8_t, 2>
 {
     using Flags::Flags;
 };
+DEFINE_FLAGS_BITOP_OR(ParseKeyFlags)
 
 static constexpr const ParseKeyFlags ALL_PARSE_KEY_FLAGS = ~ParseKeyFlags{};
-static_assert(ALL_PARSE_KEY_FLAGS == (ParseKeyFlags{ParseKeyEnum::Name} | ParseKeyEnum::Desc));
+static_assert(ALL_PARSE_KEY_FLAGS == (ParseKeyEnum::Name | ParseKeyEnum::Desc));
 
 struct NODISCARD ParseTreeInitializer final
 {

--- a/src/map/PromptFlags.h
+++ b/src/map/PromptFlags.h
@@ -20,8 +20,8 @@
     X(HEAVY_FOG)
 
 #define X_DECL(X) X,
-enum class NODISCARD PromptWeatherEnum { XFOREACH_PROMPT_WEATHER_ENUM(X_DECL) };
-enum class NODISCARD PromptFogEnum { XFOREACH_PROMPT_FOG_ENUM(X_DECL) };
+enum class NODISCARD PromptWeatherEnum : uint8_t { XFOREACH_PROMPT_WEATHER_ENUM(X_DECL) };
+enum class NODISCARD PromptFogEnum : uint8_t { XFOREACH_PROMPT_FOG_ENUM(X_DECL) };
 #undef X_DECL
 
 #define X_ADD(X) +1

--- a/src/map/RawExit.cpp
+++ b/src/map/RawExit.cpp
@@ -7,12 +7,6 @@
 
 namespace detail {
 
-/*
-template<typename T>
-struct is_const_ref : std::bool_constant<!std::is_const_v<std::remove_reference_t<T>>>
-{};
-*/
-
 template<typename Exit_>
 struct NODISCARD InvariantsHelper final
 {
@@ -53,8 +47,10 @@ struct NODISCARD InvariantsHelper final
     }
 
     // Note: This function will cause a ton of compiler errors if you try to call it
-    // with a const ref Exit type, but we can't use std::enable_if_t here.
+    // with a const ref Exit type. The requires() clause should help give a reasonable
+    // error message.
     void enforce()
+        requires(not std::is_const_v<std::remove_reference_t<Exit_>>)
     {
         if (hasActualExitFlag != shouldHaveExitFlag) {
             if (shouldHaveExitFlag) {

--- a/src/map/RawRooms.h
+++ b/src/map/RawRooms.h
@@ -63,11 +63,11 @@ public:
 
 public:
 #define X_DECL_ACCESSORS(_Type, _Name, _Init) \
-    NODISCARD const _Type &getRoom##_Name(const RoomId id) const \
+    NODISCARD const MM_TYPE_IDENTITY(_Type) & getRoom##_Name(const RoomId id) const \
     { \
         return getRawRoomRef(id).fields._Name; \
     } \
-    void setRoom##_Name(const RoomId id, _Type x) \
+    void setRoom##_Name(const RoomId id, MM_TYPE_IDENTITY(_Type) x) \
     { \
         if (getRoom##_Name(id) != x) { \
             updateRawRoomRef(id, [&x](auto &tmp) { tmp.fields._Name = std::move(x); }); \
@@ -81,14 +81,15 @@ public:
 
 public:
 #define X_DEFINE_ACCESSOR(_Type, _Name, _Init) \
-    void setExit##_Type(const RoomId id, const ExitDirEnum dir, _Type x) \
+    void setExit##_Type(const RoomId id, const ExitDirEnum dir, MM_TYPE_IDENTITY(_Type) x) \
     { \
         if (getExit##_Type(id, dir) != x) { \
             updateRawRoomRef(id, \
                              [dir, &x](auto &r) { r.getExit(dir).fields._Name = std::move(x); }); \
         } \
     } \
-    NODISCARD const _Type &getExit##_Type(const RoomId id, const ExitDirEnum dir) const \
+    NODISCARD const MM_TYPE_IDENTITY(_Type) \
+        & getExit##_Type(const RoomId id, const ExitDirEnum dir) const \
     { \
         return getRawRoomRef(id).getExit(dir).fields._Name; \
     }

--- a/src/map/RoomFieldVariant.h
+++ b/src/map/RoomFieldVariant.h
@@ -110,3 +110,19 @@ public:
     }
     NODISCARD bool operator!=(const RoomFieldVariant &other) const { return !operator==(other); }
 };
+
+namespace concepts {
+template<typename Flags>
+concept ConvertsToRoomFieldVariant = (IsEnum<Flags> or IsEnumFlags_container<Flags>)
+                                     and requires(Flags flags) {
+                                             static_cast<RoomFieldVariant>(flags);
+                                         };
+
+template<typename Converter, typename Flags>
+concept ConverterConvertsToRoomFieldVariant = IsEnumFlags_container<Flags>
+                                              and requires(Flags flags, Converter &&convert) {
+                                                      {
+                                                          convert(flags.front())
+                                                      } -> ConvertsToRoomFieldVariant;
+                                                  };
+} // namespace concepts

--- a/src/map/TinyRoomIdSet.cpp
+++ b/src/map/TinyRoomIdSet.cpp
@@ -9,10 +9,9 @@
 #include <array>
 #include <set>
 
-template<typename T,
-         typename U,
-         typename = std::enable_if_t<!std::is_same_v<std::decay_t<T>, std::decay_t<U>>>>
-static T convertTo(const U &input)
+template<typename T, typename U>
+    requires(not std::is_same_v<std::decay_t<T>, std::decay_t<U>>)
+NODISCARD static T convertTo(const U &input)
 {
     T copy;
     for (const auto &x : input) {

--- a/src/map/World.cpp
+++ b/src/map/World.cpp
@@ -1669,40 +1669,21 @@ void World::apply(ProgressCounter & /*pc*/, const room_change_types::MergeRelati
 }
 
 namespace detail {
-template<typename T, typename... /*Args*/>
-class can_insert
-{
-    template<typename C, typename = decltype(std::declval<C &>() |= std::declval<const C &>())>
-    static std::true_type test(int);
-    template<typename C>
-    static std::false_type test(...);
-
-public:
-    static constexpr bool value = decltype(test<T>(0))::value;
-};
-template<typename T, typename... /*Args*/>
-class can_remove
-{
-    template<typename C, typename = decltype(std::declval<C &>() &= ~std::declval<const C &>())>
-    static std::true_type test(int);
-    template<typename C>
-    static std::false_type test(...);
-
-public:
-    static constexpr bool value = decltype(test<T>(0))::value;
-};
+template<typename T>
+concept can_insert = requires(T &x, const T &y) { x |= y; };
 
 template<typename T>
-struct NODISCARD IsEnum final : std::bool_constant<std::is_enum_v<T>>
-{};
-static_assert(!IsEnum<RoomName>::value);
-static_assert(IsEnum<RoomTerrainEnum>::value);
-static_assert(!IsEnum<RoomMobFlags>::value);
+concept can_remove = requires(T &x, const T &y) { x &= ~y; };
+
+static_assert(!concepts::IsEnum<RoomName>);
+static_assert(concepts::IsEnum<RoomTerrainEnum>);
+static_assert(!concepts::IsEnum<RoomMobFlags>);
+static_assert(concepts::IsEnumFlags<RoomMobFlags>);
 
 template<typename T, typename...>
 struct NODISCARD BasicSetUnsetHelper
 {
-    static inline constexpr bool isEnum = IsEnum<T>::value;
+    static inline constexpr bool isEnum = concepts::IsEnum<T>;
     static void sanitize(T &x)
     {
         if constexpr (isEnum) {
@@ -1721,7 +1702,7 @@ struct NODISCARD BasicSetUnsetHelper
     {
         // insert() is really only supported for flags
         assert(false);
-        if constexpr (can_insert<T>::value) {
+        if constexpr (can_insert<T>) {
             x |= change;
             sanitize(x);
         } else {
@@ -1732,7 +1713,7 @@ struct NODISCARD BasicSetUnsetHelper
     {
         // remove() is really only supported for flags
         assert(false);
-        if constexpr (can_remove<T>::value) {
+        if constexpr (can_remove<T>) {
             x &= ~change;
             sanitize(x);
         } else {
@@ -1794,13 +1775,13 @@ static_assert(!IsTaggedString<RoomMobFlags>::value);
 
 template<typename T>
 struct NODISCARD SetUnsetHelper final
-    : std::conditional_t<IsTaggedString<T>::value || IsEnum<T>::value,
+    : std::conditional_t<IsTaggedString<T>::value || concepts::IsEnum<T>,
                          BasicSetUnsetHelper<T>,
                          FlagSetUnsetHelper<T>>
 {
-    static constexpr const bool isTagged = IsTaggedString<T>::value;
-    static constexpr const bool isEnum = IsEnum<T>::value;
-    static constexpr const bool isBasic = isTagged || isEnum;
+    static inline constexpr bool isTagged = IsTaggedString<T>::value;
+    static inline constexpr bool isEnum = concepts::IsEnum<T>;
+    static inline constexpr bool isBasic = isTagged || isEnum;
 };
 
 static_assert(SetUnsetHelper<RoomName>::isBasic);
@@ -2107,9 +2088,8 @@ void World::printStats(ProgressCounter &pc, AnsiOstream &os) const
     {
         static constexpr auto green = getRawAnsi(AnsiColor16Enum::green);
 
-        static auto C = [](auto x) {
-            static_assert(std::is_integral_v<decltype(x)>);
-            return ColoredValue{green, x};
+        static auto C = []<std::integral T>(const T x) -> ColoredValue<T> {
+            return ColoredValue<T>{green, x};
         };
 
         struct NODISCARD Stats final

--- a/src/map/enums.cpp
+++ b/src/map/enums.cpp
@@ -13,51 +13,11 @@
 #include <array>
 #include <vector>
 
-#define X_DEFINE_GETTER(E, N, name) \
-    const MMapper::Array<E, N> &name() \
-    { \
-        static const auto things = ::enums::genEnumValues<E, N>(); \
-        return things; \
-    }
-#define X_DEFINE_GETTER_DEFINED(E, N, name) \
-    const std::vector<E> &name() \
-    { \
-        static_assert(std::is_enum_v<E>); \
-        static const auto things = std::invoke([]() { \
-            std::vector<E> result; \
-            for (const E x : ::enums::genEnumValues<E, N>()) { \
-                if (x != E::UNDEFINED) { \
-                    result.emplace_back(x); \
-                } \
-            } \
-            return result; \
-        }); \
-        return things; \
-    }
-
-namespace enums {
-X_DEFINE_GETTER_DEFINED(RoomLightEnum, NUM_LIGHT_TYPES, getDefinedRoomLightTypes)
-X_DEFINE_GETTER_DEFINED(RoomSundeathEnum, NUM_SUNDEATH_TYPES, getDefinedRoomSundeathTypes)
-X_DEFINE_GETTER_DEFINED(RoomPortableEnum, NUM_PORTABLE_TYPES, getDefinedRoomPortbleTypes)
-X_DEFINE_GETTER_DEFINED(RoomRidableEnum, NUM_RIDABLE_TYPES, getDefinedRoomRidableTypes)
-X_DEFINE_GETTER_DEFINED(RoomAlignEnum, NUM_ALIGN_TYPES, getDefinedRoomAlignTypes)
-X_DEFINE_GETTER(RoomTerrainEnum, NUM_ROOM_TERRAIN_TYPES, getAllTerrainTypes)
-X_DEFINE_GETTER(RoomMobFlagEnum, NUM_ROOM_MOB_FLAGS, getAllMobFlags)
-X_DEFINE_GETTER(RoomLoadFlagEnum, NUM_ROOM_LOAD_FLAGS, getAllLoadFlags)
-X_DEFINE_GETTER(DoorFlagEnum, NUM_DOOR_FLAGS, getAllDoorFlags)
-X_DEFINE_GETTER(ExitFlagEnum, NUM_EXIT_FLAGS, getAllExitFlags)
-X_DEFINE_GETTER(InfomarkClassEnum, NUM_INFOMARK_CLASSES, getAllInfomarkClasses)
-X_DEFINE_GETTER(InfomarkTypeEnum, NUM_INFOMARK_TYPES, getAllInfomarkTypes)
-} // namespace enums
-
-#undef X_DEFINE_GETTER
-#undef X_DEFINE_GETTER_DEFINED
-
 namespace { // anonymous
 template<typename Enum>
+    requires(concepts::IsUnsignedEnum<Enum> and concepts::IsEnum_with_UNDEFINED<Enum>)
 void basicRoomEnumTest()
 {
-    static_assert(std::is_enum_v<Enum>);
     static_assert(std::is_same_v<std::underlying_type_t<Enum>, uint8_t>);
 
     constexpr auto badAlignValue = static_cast<Enum>(255);
@@ -67,14 +27,13 @@ void basicRoomEnumTest()
     static_assert(enums::sanitizeEnum(badAlignValue) == Enum::UNDEFINED);
 }
 
-template<typename Flags>
+template<concepts::IsEnumFlags Flags>
 void basicFlagsTest()
 {
     using Enum = typename Flags::Flag;
-    using U = typename Flags::underlying_type;
-    static_assert(std::is_enum_v<Enum>);
-    static_assert(std::is_unsigned_v<U>);
-    static_assert(std::is_unsigned_v<std::underlying_type_t<Enum>>);
+    using U = typename Flags::bitmask_type;
+    static_assert(concepts::IsUnsignedEnum<Enum>);
+    static_assert(concepts::IsUnsignedIntegralNumeric<U>);
 
     constexpr auto flags = static_cast<Flags>(enums::getValidMask<Flags>());
     static_assert(enums::sanitizeFlags<Flags>(flags) == flags);

--- a/src/map/enums.h
+++ b/src/map/enums.h
@@ -4,6 +4,7 @@
 // Author: Nils Schimmelmann <nschimme@gmail.com> (Jahara)
 
 #include "../global/Array.h"
+#include "../global/enums.h"
 #include "DoorFlags.h"
 #include "ExitFlags.h"
 #include "infomark.h"
@@ -11,26 +12,20 @@
 
 #include <vector>
 
-#define X_DECL_GETTER(E, N, name) NODISCARD const MMapper::Array<E, N> &name();
-#define X_DECL_GETTER_DEFINED(E, N, name) NODISCARD const std::vector<E> &name();
-
 namespace enums {
-X_DECL_GETTER_DEFINED(RoomLightEnum, NUM_LIGHT_TYPES, getDefinedRoomLightTypes)
-X_DECL_GETTER_DEFINED(RoomSundeathEnum, NUM_SUNDEATH_TYPES, getDefinedRoomSundeathTypes)
-X_DECL_GETTER_DEFINED(RoomPortableEnum, NUM_PORTABLE_TYPES, getDefinedRoomPortbleTypes)
-X_DECL_GETTER_DEFINED(RoomRidableEnum, NUM_RIDABLE_TYPES, getDefinedRoomRidableTypes)
-X_DECL_GETTER_DEFINED(RoomAlignEnum, NUM_ALIGN_TYPES, getDefinedRoomAlignTypes)
-X_DECL_GETTER(RoomTerrainEnum, NUM_ROOM_TERRAIN_TYPES, getAllTerrainTypes)
-X_DECL_GETTER(RoomMobFlagEnum, NUM_ROOM_MOB_FLAGS, getAllMobFlags)
-X_DECL_GETTER(RoomLoadFlagEnum, NUM_ROOM_LOAD_FLAGS, getAllLoadFlags)
-X_DECL_GETTER(DoorFlagEnum, NUM_DOOR_FLAGS, getAllDoorFlags)
-X_DECL_GETTER(ExitFlagEnum, NUM_EXIT_FLAGS, getAllExitFlags)
-X_DECL_GETTER(InfomarkClassEnum, NUM_INFOMARK_CLASSES, getAllInfomarkClasses)
-X_DECL_GETTER(InfomarkTypeEnum, NUM_INFOMARK_TYPES, getAllInfomarkTypes)
+DECL_ENUM_GETTER2(RoomLightEnum, NUM_LIGHT_TYPES, getDefinedRoomLightTypes)
+DECL_ENUM_GETTER2(RoomSundeathEnum, NUM_SUNDEATH_TYPES, getDefinedRoomSundeathTypes)
+DECL_ENUM_GETTER2(RoomPortableEnum, NUM_PORTABLE_TYPES, getDefinedRoomPortbleTypes)
+DECL_ENUM_GETTER2(RoomRidableEnum, NUM_RIDABLE_TYPES, getDefinedRoomRidableTypes)
+DECL_ENUM_GETTER2(RoomAlignEnum, NUM_ALIGN_TYPES, getDefinedRoomAlignTypes)
+DECL_ENUM_GETTER2(RoomTerrainEnum, NUM_ROOM_TERRAIN_TYPES, getAllTerrainTypes)
+DECL_ENUM_GETTER2(RoomMobFlagEnum, NUM_ROOM_MOB_FLAGS, getAllMobFlags)
+DECL_ENUM_GETTER2(RoomLoadFlagEnum, NUM_ROOM_LOAD_FLAGS, getAllLoadFlags)
+DECL_ENUM_GETTER2(DoorFlagEnum, NUM_DOOR_FLAGS, getAllDoorFlags)
+DECL_ENUM_GETTER2(ExitFlagEnum, NUM_EXIT_FLAGS, getAllExitFlags)
+DECL_ENUM_GETTER2(InfomarkClassEnum, NUM_INFOMARK_CLASSES, getAllInfomarkClasses)
+DECL_ENUM_GETTER2(InfomarkTypeEnum, NUM_INFOMARK_TYPES, getAllInfomarkTypes)
 } // namespace enums
-
-#undef X_DECL_GETTER
-#undef X_DECL_GETTER_DEFINED
 
 #define ALL_TERRAIN_TYPES ::enums::getAllTerrainTypes()
 #define ALL_DOOR_FLAGS ::enums::getAllDoorFlags()
@@ -176,45 +171,25 @@ constexpr bool isValidEnumValue(const RoomTerrainEnum value)
 #undef X_CASE
 }
 
-template<typename E>
-NODISCARD constexpr E getInvalidValue();
-template<>
-constexpr RoomAlignEnum getInvalidValue()
+template<concepts::IsEnum E>
+NODISCARD constexpr E getInvalidValue()
 {
-    return RoomAlignEnum::UNDEFINED;
-}
-template<>
-constexpr RoomLightEnum getInvalidValue()
-{
-    return RoomLightEnum::UNDEFINED;
-}
-template<>
-constexpr RoomPortableEnum getInvalidValue()
-{
-    return RoomPortableEnum::UNDEFINED;
-}
-template<>
-constexpr RoomRidableEnum getInvalidValue()
-{
-    return RoomRidableEnum::UNDEFINED;
-}
-template<>
-constexpr RoomSundeathEnum getInvalidValue()
-{
-    return RoomSundeathEnum::UNDEFINED;
-}
-template<>
-constexpr RoomTerrainEnum getInvalidValue()
-{
-    return RoomTerrainEnum::UNDEFINED;
+    if constexpr (concepts::IsEnum_with_UNDEFINED<E>) {
+        return E::UNDEFINED;
+    } else {
+        // Note: You have to specialise getInvalidValue<E>() to use it with an enum
+        // that doesn't have E::UNDEFINED.
+        static_assert(std::is_void_v<E>);
+        return E{};
+    }
 }
 
-template<typename Flags>
-constexpr auto getValidMask() -> typename Flags::underlying_type
+template<concepts::IsEnumFlags Flags>
+constexpr auto getValidMask() -> typename Flags::bitmask_type
 {
     static_assert(Flags::NUM_FLAGS <= 32);
     using Enum = typename Flags::Flag;
-    using U = typename Flags::underlying_type;
+    using U = typename Flags::bitmask_type;
     Flags tmp;
     for (U n = 0; n < Flags::NUM_FLAGS; ++n) {
         const auto e = static_cast<Enum>(n);
@@ -225,11 +200,10 @@ constexpr auto getValidMask() -> typename Flags::underlying_type
     return static_cast<U>(tmp);
 }
 
-template<typename Enum, typename Value>
+template<concepts::IsEnum Enum, typename Value>
+    requires(std::is_same_v<Value, std::underlying_type_t<Enum>>)
 NODISCARD constexpr Enum toEnum(const Value value)
 {
-    static_assert(std::is_enum_v<Enum>);
-    static_assert(std::is_same_v<Value, std::underlying_type_t<Enum>>);
     const auto result = static_cast<Enum>(value);
     if (!isValidEnumValue(result)) {
         return getInvalidValue<Enum>();
@@ -237,16 +211,12 @@ NODISCARD constexpr Enum toEnum(const Value value)
     return result;
 }
 
-template<typename Flags, typename Value>
+template<concepts::IsEnumFlags Flags, typename Value>
+    requires(std::is_same_v<Value, typename Flags::bitmask_type>)
 NODISCARD constexpr Flags bitmaskToFlags(const Value value)
 {
     // we assume this is an enums::Flags
-    using U = typename Flags::underlying_type;
-    static_assert(std::is_same_v<Value, U>);
-
-    using Enum = typename Flags::Flag;
-    static_assert(std::is_enum_v<Enum>);
-
+    using U = typename Flags::bitmask_type;
     static_assert(std::is_unsigned_v<Value> && sizeof(value) <= sizeof(uint32_t));
     static_assert(Flags::NUM_FLAGS > 0 && Flags::NUM_FLAGS <= 32);
 
@@ -259,19 +229,17 @@ NODISCARD constexpr Flags bitmaskToFlags(const Value value)
     return Flags{static_cast<U>(value & valid_mask)};
 }
 
-template<typename Enum>
+template<concepts::IsUnsignedEnum Enum>
 NODISCARD constexpr Enum sanitizeEnum(const Enum value)
 {
-    using U = std::underlying_type_t<Enum>;
-    static_assert(std::is_unsigned_v<U>);
-    return toEnum<Enum>(static_cast<U>(value));
+    return toEnum<Enum>(enums::to_underlying(value));
 }
 
-template<typename Flags>
+template<concepts::IsEnumFlags Flags>
 NODISCARD constexpr Flags sanitizeFlags(const Flags flags)
 {
-    using U = typename Flags::underlying_type;
-    static_assert(std::is_unsigned_v<U>);
+    // note: Flags::underlying_type is distinct from the underlying type of the enum.
+    using U = typename Flags::bitmask_type;
     return bitmaskToFlags<Flags>(static_cast<U>(flags));
 }
 

--- a/src/map/infomark.h
+++ b/src/map/infomark.h
@@ -46,6 +46,8 @@ static constexpr const size_t NUM_INFOMARK_TYPES = XFOREACH_INFOMARK_TYPE(X_COUN
 #undef X_COUNT
 static_assert(NUM_INFOMARK_TYPES == 3);
 
+DEFINE_ENUM_COUNT(InfomarkTypeEnum, NUM_INFOMARK_TYPES)
+
 #define XFOREACH_INFOMARK_CLASS(X) \
     X(GENERIC) \
     X(HERB) \
@@ -64,6 +66,8 @@ enum class NODISCARD InfomarkClassEnum : uint8_t { XFOREACH_INFOMARK_CLASS(X_DEC
 static constexpr const size_t NUM_INFOMARK_CLASSES = XFOREACH_INFOMARK_CLASS(X_COUNT);
 #undef X_COUNT
 static_assert(NUM_INFOMARK_CLASSES == 10);
+
+DEFINE_ENUM_COUNT(InfomarkClassEnum, NUM_INFOMARK_CLASSES);
 
 struct NODISCARD RawInfomark final
 {

--- a/src/map/mmapper2room.h
+++ b/src/map/mmapper2room.h
@@ -228,7 +228,7 @@ enum class ModifyTypeEnum { AssignClear, InsertRemove };
     X(RESERVED, InsertRemove)
 
 #define X_DECL(_name, _type) _name,
-enum class NODISCARD RoomFieldEnum { XFOREACH_ROOM_FIELD_ENUM(X_DECL) };
+enum class NODISCARD RoomFieldEnum : uint8_t { XFOREACH_ROOM_FIELD_ENUM(X_DECL) };
 #undef X_DECL
 
 #define X_ADD(_name, _type) +1
@@ -244,11 +244,7 @@ class NODISCARD RoomFieldFlags final : public enums::Flags<RoomFieldFlags, RoomF
     using Flags::Flags;
 };
 
-NODISCARD inline constexpr RoomFieldFlags operator|(const RoomFieldEnum lhs,
-                                                    const RoomFieldEnum rhs) noexcept
-{
-    return RoomFieldFlags{lhs} | RoomFieldFlags{rhs};
-}
+DEFINE_FLAGS_BITOP_OR(RoomFieldFlags)
 
 template<>
 struct std::hash<RoomName>

--- a/src/mapdata/roomfilter.h
+++ b/src/mapdata/roomfilter.h
@@ -56,10 +56,9 @@ private:
     }
 
 private:
-    template<typename E>
+    template<concepts::IsEnum E>
     NODISCARD bool matchesParserCommand(const E type) const
     {
-        static_assert(std::is_enum_v<E>);
         const auto s = getParserCommandName(type).getCommand();
         assert(s != nullptr);
         return s != nullptr && this->matches(s);
@@ -75,7 +74,7 @@ private:
 
 private:
     /// Note: Assumes enum E has value E::UNDEFINED.
-    template<typename E>
+    template<concepts::IsEnum_with_UNDEFINED E>
     NODISCARD bool matchesDefined(const E type) const
     {
         return (type != E::UNDEFINED) && this->matchesParserCommand(type);

--- a/src/mapstorage/XmlMapStorage.cpp
+++ b/src/mapstorage/XmlMapStorage.cpp
@@ -85,20 +85,18 @@ public:
     }
 
     // parse string containing the name of an enum.
-    template<typename ENUM>
+    template<concepts::IsEnum ENUM>
     NODISCARD std::optional<ENUM> toEnum(const QStringView str) const
     {
-        static_assert(std::is_enum_v<ENUM>, "template type ENUM must be an enumeration");
         if (const auto opt = stringToEnum(enumToType(static_cast<ENUM>(0)), str); opt.has_value()) {
             return static_cast<ENUM>(opt.value());
         }
         return std::nullopt;
     }
 
-    template<typename ENUM>
+    template<concepts::IsEnum ENUM>
     NODISCARD QString toString(const ENUM val) const
     {
-        static_assert(std::is_enum_v<ENUM>, "template type ENUM must be an enumeration");
         if constexpr (std::is_same_v<ENUM, TypeEnum>) {
 #define X_CASE(x) \
     case TypeEnum::x: \
@@ -630,11 +628,9 @@ void XmlMapStorage::loadMarker(QXmlStreamReader &stream) const
 }
 
 // load current element, which is expected to contain ONLY the name of an enum value
-template<typename ENUM>
+template<concepts::IsEnum ENUM>
 ENUM XmlMapStorage::loadEnum(QXmlStreamReader &stream)
 {
-    static_assert(std::is_enum_v<ENUM>, "template type ENUM must be an enumeration");
-
     // copy name in case it's somehow modified by loadStringView()
     const auto name = stream.name();
     const QStringView text = loadStringView(stream);

--- a/src/mapstorage/XmlMapStorage.h
+++ b/src/mapstorage/XmlMapStorage.h
@@ -83,7 +83,7 @@ private:
         TERRAIN /* */ = 1 << 10,
     };
 
-    template<typename ENUM>
+    template<concepts::IsEnum ENUM>
     NODISCARD static ENUM loadEnum(QXmlStreamReader &stream);
     NODISCARD static QString loadString(QXmlStreamReader &stream);
     NODISCARD static QStringView loadStringView(QXmlStreamReader &stream);

--- a/src/media/DescriptionWidget.h
+++ b/src/media/DescriptionWidget.h
@@ -2,6 +2,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (C) 2025 The MMapper Authors
 
+#if 1
+// https://qt-project.atlassian.net/browse/QTBUG-31496
+#include <QtCore/qglobal.h>
+#endif
+
 #include "../map/RoomHandle.h"
 
 #include <QCache>

--- a/src/mpi/remoteeditprocess.h
+++ b/src/mpi/remoteeditprocess.h
@@ -3,6 +3,11 @@
 // Copyright (C) 2019 The MMapper Authors
 // Author: Nils Schimmelmann <nschimme@gmail.com> (Jahara)
 
+#if 1
+// https://qt-project.atlassian.net/browse/QTBUG-31496
+#include <QtCore/qglobal.h>
+#endif
+
 #include "../global/macros.h"
 #include "remoteeditsession.h"
 

--- a/src/mpi/remoteeditsession.h
+++ b/src/mpi/remoteeditsession.h
@@ -3,6 +3,11 @@
 // Copyright (C) 2019 The MMapper Authors
 // Author: Nils Schimmelmann <nschimme@gmail.com> (Jahara)
 
+#if 1
+// https://qt-project.atlassian.net/browse/QTBUG-31496
+#include <QtCore/qglobal.h>
+#endif
+
 #include "../global/TaggedInt.h"
 #include "../global/TaggedString.h"
 #include "../global/macros.h"

--- a/src/mpi/remoteeditwidget.cpp
+++ b/src/mpi/remoteeditwidget.cpp
@@ -467,11 +467,9 @@ enum class NODISCARD CallbackResultEnum { KEEP_GOING, STOP };
 /// -or-
 /// CallbackResultEnum callback(const QTextCursor&);
 template<typename Callback>
+    requires(std::is_invocable_r_v<CallbackResultEnum, Callback, const QTextCursor &>)
 static void foreach_partly_selected_block_until(QTextCursor cur, Callback &&callback)
 {
-    static_assert(
-        std::is_same_v<CallbackResultEnum, decltype(callback(std::declval<const QTextCursor &>()))>);
-
     auto beg = LineRange::beg(cur);
     auto end = LineRange::end(cur);
     for (auto it = beg; !it.isNull() && it < end;) {
@@ -487,10 +485,9 @@ static void foreach_partly_selected_block_until(QTextCursor cur, Callback &&call
 }
 
 template<typename Callback>
+    requires(std::is_invocable_r_v<bool, Callback, const QTextCursor &>)
 bool exists_partly_selected_block(QTextCursor cur, Callback &&callback)
 {
-    static_assert(std::is_same_v<bool, decltype(callback(std::declval<const QTextCursor &>()))>);
-
     bool result = false;
     foreach_partly_selected_block_until(cur,
                                         [&result, &callback](QTextCursor it) -> CallbackResultEnum {

--- a/src/opengl/FontFormatFlags.h
+++ b/src/opengl/FontFormatFlags.h
@@ -21,7 +21,7 @@ enum class NODISCARD FontFormatFlagEnum {
     //
 };
 
-DEFINE_ENUM_COUNT(FontFormatFlagEnum, 5);
+DEFINE_ENUM_COUNT(FontFormatFlagEnum, 5)
 
 struct NODISCARD FontFormatFlags final
     : public enums::Flags<FontFormatFlags, FontFormatFlagEnum, uint8_t>

--- a/src/opengl/legacy/Shaders.cpp
+++ b/src/opengl/legacy/Shaders.cpp
@@ -90,11 +90,10 @@ void ShaderPrograms::resetAll()
 
 // essentially a private member of ShaderPrograms
 template<typename T>
+    requires(std::is_base_of_v<AbstractShaderProgram, T>)
 NODISCARD static std::shared_ptr<T> loadSimpleShaderProgram(Functions &functions,
                                                             const std::string &dir)
 {
-    static_assert(std::is_base_of_v<AbstractShaderProgram, T>);
-
     const auto getSource = [&dir](const std::string &name) -> ShaderUtils::Source {
         return ::readWholeShader(dir, name);
     };

--- a/src/opengl/legacy/VBO.h
+++ b/src/opengl/legacy/VBO.h
@@ -19,8 +19,8 @@ private:
     WeakFunctions m_weakFunctions;
     GLuint m_vbo = INVALID_VBOID;
     GLenum m_boundTarget = GL_ARRAY_BUFFER;
-    bool m_bound = false;
-    bool m_bound_buffer_base = false;
+    bool m_bound : 1 = false;
+    bool m_bound_buffer_base : 1 = false;
 
 public:
     VBO() = default;
@@ -124,12 +124,11 @@ public:
         }
     }
 
-    template<typename T>
+    template<concepts::IsTriviallyCopyable T>
     NODISCARD GLsizei setVbo(const GLenum target,
                              const View<T> batch,
                              const BufferUsageEnum usage = BufferUsageEnum::DYNAMIC_DRAW)
     {
-        static_assert(std::is_trivially_copyable_v<T>);
         const auto numElements = static_cast<GLsizei>(batch.size());
         const auto elementSize = static_cast<GLsizei>(sizeof(T));
         const auto numBytes = numElements * elementSize;
@@ -143,12 +142,11 @@ public:
         }
     }
 
-    template<typename T>
+    template<concepts::IsTriviallyCopyable T>
     void setVbo(const GLenum target,
                 const T &data,
                 const BufferUsageEnum usage = BufferUsageEnum::DYNAMIC_DRAW)
     {
-        static_assert(std::is_trivially_copyable_v<T>);
         MAYBE_UNUSED auto vbo_binder = bind(target);
         if (const auto shared = m_weakFunctions.lock(); shared == nullptr) {
             MMLOG_WARNING() << "Failed to set VBO " << m_vbo;
@@ -157,12 +155,11 @@ public:
         }
     }
 
-    template<typename T>
+    template<concepts::IsTriviallyCopyable T>
     NODISCARD auto setVbo(const DrawModeEnum mode,
                           const View<T> batch,
                           const BufferUsageEnum usage = BufferUsageEnum::DYNAMIC_DRAW)
     {
-        static_assert(std::is_trivially_copyable_v<T>);
         using Pair = std::pair<DrawModeEnum, GLsizei>;
         if (const auto shared = m_weakFunctions.lock(); shared == nullptr) {
             MMLOG_WARNING() << "Failed to set VBO " << m_vbo;

--- a/src/parser/AbstractParser-Commands.cpp
+++ b/src/parser/AbstractParser-Commands.cpp
@@ -6,10 +6,12 @@
 
 #include "../global/CaseUtils.h"
 #include "../global/Consts.h"
+#include "../global/EnumIndexedArray.h"
 #include "../global/LineUtils.h"
 #include "../global/StringView.h"
 #include "../global/TextUtils.h"
 #include "../global/View.h"
+#include "../global/concepts.h"
 #include "../global/progresscounter.h"
 #include "../map/CommandId.h"
 #include "../map/DoorFlags.h"
@@ -35,11 +37,8 @@
 #include <stdexcept>
 #include <string>
 #include <utility>
-#include <vector>
 
-#include <QtCore>
-
-namespace { // anonymous
+namespace {
 
 struct NODISCARD SendToUserHelper final
 {
@@ -66,7 +65,7 @@ public:
     NODISCARD AnsiOstream &getAnsiOstream() { return m_aos; }
 };
 
-template<typename Container>
+template<concepts::IsEnumIndexedArrayOfStrings Container>
 NODISCARD auto find_abbrev(const Container &container,
                            const StringView input,
                            const size_t required_len)
@@ -83,7 +82,7 @@ NODISCARD auto find_abbrev(const Container &container,
     return std::nullopt;
 };
 
-template<typename Container>
+template<concepts::IsEnumIndexedArrayOfStrings Container>
 void concat_comma_and_or(AnsiOstream &aos,
                          const Container &container,
                          // color each word int he container
@@ -140,7 +139,10 @@ constexpr EnumIndexedArray<std::string_view, PromptWeatherEnum, NUM_PROMPT_WEATH
 #undef X_CASE
     };
 
-template<typename Container, typename Getter, typename Setter>
+template<concepts::IsEnumIndexedArrayOfStrings Container,
+         concepts::IsStringViewGetter Getter,
+         typename Setter>
+    requires(std::is_invocable_r_v<void, Setter, typename Container::index_type>)
 void trySetEnumValue(AbstractParser &parser,
                      StringView view,
                      const std::string_view what,

--- a/src/parser/AbstractParser-Room.cpp
+++ b/src/parser/AbstractParser-Room.cpp
@@ -139,10 +139,11 @@ NODISCARD static std::optional<RoomFieldVariant> evalRoomField(const std::string
     static const auto map = std::invoke([]() -> ParserRoomFieldMap {
         ParserRoomFieldMap result;
 
-        auto add_all = [&result](const auto &flags, auto &&convert) {
+        auto add_all = [&result]<concepts::IsEnumFlags_container Flags, typename Converter>
+            requires(concepts::ConverterConvertsToRoomFieldVariant<Converter, Flags>)
+        (const Flags &flags, Converter &&convert) {
             // assumes it's an array or vector of enum flags.
-            using Flag = std::decay_t<decltype(*flags.begin())>;
-            static_assert(std::is_enum_v<Flag>);
+            using Flag = std::decay_t<decltype(flags.front())>;
             for (const Flag flag : flags) {
                 const auto abb = getParserCommandName(flag);
                 if (!abb) {
@@ -158,7 +159,9 @@ NODISCARD static std::optional<RoomFieldVariant> evalRoomField(const std::string
                 }
             }
         };
-        auto identity = [](auto flag) { return flag; };
+        auto identity = []<concepts::IsEnum Flag>
+            requires(concepts::ConvertsToRoomFieldVariant<Flag>)
+        (Flag flag) { return flag; };
 
         // REVISIT: separate these into their own args, and don't try to group them.
         // (Hint: That would allow you set each category as "UNDEFINED.")

--- a/src/parser/DoorAction.cpp
+++ b/src/parser/DoorAction.cpp
@@ -3,17 +3,3 @@
 // Author: Nils Schimmelmann <nschimme@gmail.com> (Jahara)
 
 #include "DoorAction.h"
-
-#include "../global/enums.h"
-
-#include <array>
-
-namespace enums {
-
-const MMapper::Array<DoorActionEnum, NUM_DOOR_ACTION_TYPES> &getAllDoorActionTypes()
-{
-    static const auto g_door_actions = genEnumValues<DoorActionEnum, NUM_DOOR_ACTION_TYPES>();
-    return g_door_actions;
-}
-
-} // namespace enums

--- a/src/parser/DoorAction.h
+++ b/src/parser/DoorAction.h
@@ -4,10 +4,11 @@
 // Author: Nils Schimmelmann <nschimme@gmail.com> (Jahara)
 
 #include "../global/Array.h"
+#include "../global/enums.h"
 
 #include <cstddef>
 
-enum class NODISCARD DoorActionEnum {
+enum class NODISCARD DoorActionEnum : uint8_t {
     OPEN,
     CLOSE,
     LOCK,
@@ -24,8 +25,9 @@ enum class NODISCARD DoorActionEnum {
 /* does not include NONE */
 static constexpr const size_t NUM_DOOR_ACTION_TYPES = 10;
 
+DEFINE_ENUM_COUNT(DoorActionEnum, NUM_DOOR_ACTION_TYPES)
+
 namespace enums {
 #define ALL_DOOR_ACTION_TYPES ::enums::getAllDoorActionTypes()
-NODISCARD const MMapper::Array<DoorActionEnum, NUM_DOOR_ACTION_TYPES> &getAllDoorActionTypes();
-
+DECL_ENUM_GETTER2(DoorActionEnum, NUM_DOOR_ACTION_TYPES, getAllDoorActionTypes)
 } // namespace enums

--- a/src/parser/LineFlags.h
+++ b/src/parser/LineFlags.h
@@ -4,6 +4,7 @@
 // Author: Nils Schimmelmann <nschimme@gmail.com> (Jahara)
 
 #include "../global/Flags.h"
+#include "../global/enums.h"
 
 #include <cstdint>
 
@@ -44,20 +45,3 @@ public:
     XFOREACH_LINE_FLAG(X_DEFINE_ACCESSORS)
 #undef X_DEFINE_ACCESSORS
 };
-
-NODISCARD constexpr inline auto toUint(const LineFlagEnum val) noexcept
-{
-    using U = uint32_t;
-    static_assert(std::is_same_v<U, std::underlying_type_t<LineFlagEnum>>);
-    return static_cast<U>(val);
-}
-
-NODISCARD inline constexpr LineFlagEnum operator|(const LineFlagEnum lhs, const LineFlagEnum rhs)
-{
-    return static_cast<LineFlagEnum>(toUint(lhs) | toUint(rhs));
-}
-
-NODISCARD inline constexpr LineFlagEnum operator&(const LineFlagEnum lhs, const LineFlagEnum rhs)
-{
-    return static_cast<LineFlagEnum>(toUint(lhs) & toUint(rhs));
-}

--- a/src/preferences/AdvancedGraphics.cpp
+++ b/src/preferences/AdvancedGraphics.cpp
@@ -173,11 +173,9 @@ AdvancedGraphicsGroupBox::AdvancedGraphicsGroupBox(QGroupBox &groupBox)
 {
     auto *vertical = new QVBoxLayout(m_groupBox);
 
-    auto makeSsb = [this, vertical](const QString &name, auto &fp, bool is3DOnly = true) {
-        using FP = std::decay_t<decltype(fp)>;
-        static_assert(std::is_same_v<FP, FixedPoint<FP::digits>>,
-                      "makeSsb expects a FixedPoint<digits> argument");
-
+    auto makeSsb = [this, vertical]<typename FP>
+        requires(std::is_same_v<FP, FixedPoint<FP::digits>>)
+    (const QString &name, FP &fp, bool is3DOnly = true) {
         addLine(*vertical);
         auto ssb = std::make_unique<SliderSpinboxButtonImpl<FP::digits>>(*this, *vertical, name, fp);
         if (is3DOnly) {

--- a/src/proxy/GmcpModule.h
+++ b/src/proxy/GmcpModule.h
@@ -25,17 +25,18 @@
     X(ROOM, Room, "room", "Room") \
     /* define gmcp module types above */
 
-enum class NODISCARD GmcpModuleTypeEnum {
-    UNKNOWN = -1,
+enum class NODISCARD GmcpModuleTypeEnum : uint8_t {
 #define X_DECL_GMCP_MODULE_TYPE(UPPER_CASE, CamelCase, normalized, friendly) UPPER_CASE,
     XFOREACH_GMCP_MODULE_TYPE(X_DECL_GMCP_MODULE_TYPE)
 #undef X_DECL_GMCP_MODULE_TYPE
+        UNKNOWN
 };
 
 #define X_COUNT(...) +1
 static constexpr const size_t NUM_GMCP_MODULES = XFOREACH_GMCP_MODULE_TYPE(X_COUNT);
 #undef X_COUNT
 static_assert(NUM_GMCP_MODULES == 7);
+static_assert(NUM_GMCP_MODULES == enums::to_underlying(GmcpModuleTypeEnum::UNKNOWN));
 DEFINE_ENUM_COUNT(GmcpModuleTypeEnum, NUM_GMCP_MODULES)
 
 namespace tags {

--- a/src/syntax/TreeParser.cpp
+++ b/src/syntax/TreeParser.cpp
@@ -17,6 +17,31 @@
 #include <tuple>
 #include <vector>
 
+namespace {
+auto ignore_sv(std::string_view) {}
+// TODO: Each code point's "width" can be 1 or 2 spaces on the terminal.
+// This should eventually work like  wcswidth() and wcwidth(),
+// but for now it'll just report the number of codepoints.
+// (This "mostly works" as long as the input is from the ASCII or Latin-1 subset of UTF-8.)
+auto utf8_width(const std::string_view sv) -> size_t
+{
+    if (isAscii(sv)) {
+        return sv.length();
+    }
+    size_t len = 0;
+    charset::foreach_codepoint_utf8(sv, [&len](char32_t) { ++len; });
+    return len;
+}
+auto utf8_width_ansiAware(const std::string_view sv) -> size_t
+{
+    size_t len = 0;
+    foreachAnsi(sv, &ignore_sv, &ignore_sv, [&len](const std::string_view nonAnsi) {
+        len += utf8_width(nonAnsi);
+    });
+    return len;
+}
+} // namespace
+
 namespace syntax {
 
 TreeParser::TreeParser(SharedConstSublist syntaxRoot, User &user)
@@ -202,31 +227,9 @@ void HelpFrame::flush()
             }
         }
 
-        auto str = ss.str();
+        const auto str = ss.str();
         os.writeWithEmbeddedAnsi(str);
-
-        // TODO: convert QString ansi stuff to std::string_view instead of QStringView
-        static const auto getLengthAnsiAware = [](const std::string_view sv) -> size_t {
-            size_t len = 0;
-            bool inEsc = false;
-            for (char c : sv) {
-                if (c == C_ESC) {
-                    inEsc = true;
-                } else if (inEsc) {
-                    if (c == 'm') {
-                        inEsc = false;
-                    } else {
-                        assert(std::isdigit(c) || c == C_OPEN_BRACKET || c == C_SEMICOLON
-                               || c == C_COLON);
-                    }
-                } else {
-                    ++len;
-                }
-            }
-            return len;
-        };
-
-        size_t pos = getLengthAnsiAware(str);
+        size_t pos = utf8_width_ansiAware(str);
 
         if (m_accept) {
             if (!m_helps.empty()) {
@@ -271,8 +274,7 @@ void HelpFrame::flush()
 HelpFrame HelpFrame::makeChild()
 {
     flush();
-    HelpFrame child = *this; // copy ctor
-    return child; // c++17 spec says NRVO elides the move constructor here, but g++ 7.4 uses move ctor.
+    return HelpFrame{*this}; // note: copy-ctor
 }
 
 class NODISCARD TreeParser::HelpCommon final

--- a/src/syntax/Value.cpp
+++ b/src/syntax/Value.cpp
@@ -137,6 +137,26 @@ Vector::Base::const_iterator Vector::end() const
     return m_vector->end();
 }
 
+bool Vector::empty() const
+{
+    return m_vector->empty();
+}
+
+size_t Vector::size() const
+{
+    return m_vector->size();
+}
+
+const Value &Vector::at(const size_t pos) const
+{
+    return m_vector->at(pos);
+}
+
+const Value &Vector::operator[](const size_t pos) const
+{
+    return at(pos);
+}
+
 Vector getAnyVectorReversed(const Pair *const matched)
 {
     size_t len = 0;

--- a/src/syntax/Value.h
+++ b/src/syntax/Value.h
@@ -30,7 +30,7 @@ public:
     explicit Vector(Base &&x);
 
 public:
-    Vector();
+    explicit Vector();
     DEFAULT_RULE_OF_5(Vector);
 
 public:
@@ -38,11 +38,11 @@ public:
     NODISCARD Base::const_iterator end() const;
 
 public:
-    NODISCARD bool empty() const { return m_vector->empty(); }
-    NODISCARD size_t size() const { return m_vector->size(); }
+    NODISCARD bool empty() const;
+    NODISCARD size_t size() const;
     // NOTE: at() throws if out of range.
-    const Value &at(size_t pos) const { return m_vector->at(pos); }
-    const Value &operator[](size_t pos) const { return at(pos); }
+    NODISCARD const Value &at(size_t pos) const;
+    NODISCARD const Value &operator[](size_t pos) const;
 
 public:
     friend std::ostream &operator<<(std::ostream &os, const Vector &v);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,7 +35,7 @@ add_library(mm_test STATIC
     ../src/proxy/GmcpMessage.h
 )
 set_target_properties(mm_test PROPERTIES
-    CXX_STANDARD 17
+    CXX_STANDARD 20
     CXX_STANDARD_REQUIRED ON
     CXX_EXTENSIONS OFF
     COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -67,7 +67,7 @@ target_link_libraries(TestClock
         coverage_config)
 set_target_properties(
   TestClock PROPERTIES
-  CXX_STANDARD 17
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -92,7 +92,7 @@ target_link_libraries(TestExpandoraCommon
         coverage_config)
 set_target_properties(
   TestExpandoraCommon PROPERTIES
-  CXX_STANDARD 17
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -114,7 +114,7 @@ target_link_libraries(TestParser
         coverage_config)
 set_target_properties(
   TestParser PROPERTIES
-  CXX_STANDARD 17
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -136,7 +136,7 @@ add_dependencies(TestProxy mm_test mm_global)
 target_link_libraries(TestProxy mm_test mm_global Qt6::Test coverage_config)
 set_target_properties(
   TestProxy PROPERTIES
-  CXX_STANDARD 17
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -163,7 +163,7 @@ target_link_libraries(TestMainWindow
         coverage_config)
 set_target_properties(
   TestMainWindow PROPERTIES
-  CXX_STANDARD 17
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -182,14 +182,40 @@ target_link_libraries(TestGlobal
         coverage_config)
 set_target_properties(
   TestGlobal PROPERTIES
-  CXX_STANDARD 17
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   COMPILE_FLAGS "${WARNING_FLAGS}"
 )
 add_test(NAME TestGlobal COMMAND TestGlobal)
 
-# Global
+# Group
+set(TestGroup_SRCS
+        ../src/group/enums.cpp
+        ../src/group/enums.h
+        TestGroup.cpp
+)
+add_executable(TestGroup ${TestGroup_SRCS})
+add_dependencies(TestGroup mm_test mm_global mm_map)
+target_link_libraries(TestGroup
+        mm_map
+        mm_test
+        mm_global
+        Qt6::Gui
+        Qt6::Network
+        Qt6::Test
+        Qt6::Widgets
+        coverage_config)
+set_target_properties(
+        TestGroup PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+        COMPILE_FLAGS "${WARNING_FLAGS}"
+)
+add_test(NAME TestGroup COMMAND TestGroup)
+
+# Map
 set(TestMap_SRCS
         TestMap.cpp
 )
@@ -206,7 +232,7 @@ target_link_libraries(TestMap
         coverage_config)
 set_target_properties(
         TestMap PROPERTIES
-        CXX_STANDARD 17
+        CXX_STANDARD 20
         CXX_STANDARD_REQUIRED ON
         CXX_EXTENSIONS OFF
         COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -228,7 +254,7 @@ add_dependencies(TestAdventure mm_test mm_global)
 target_link_libraries(TestAdventure mm_test mm_global Qt6::Widgets Qt6::Network Qt6::Test coverage_config)
 set_target_properties(
         TestAdventure PROPERTIES
-        CXX_STANDARD 17
+        CXX_STANDARD 20
         CXX_STANDARD_REQUIRED ON
         CXX_EXTENSIONS OFF
         COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -248,7 +274,7 @@ add_dependencies(TestTimer mm_global)
 target_link_libraries(TestTimer mm_global Qt6::Test coverage_config)
 set_target_properties(
         TestTimer PROPERTIES
-        CXX_STANDARD 17
+        CXX_STANDARD 20
         CXX_STANDARD_REQUIRED ON
         CXX_EXTENSIONS OFF
         COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -266,7 +292,7 @@ add_dependencies(TestRoomMob mm_global)
 target_link_libraries(TestRoomMob mm_global Qt6::Test Qt6::Gui Qt6::Widgets coverage_config)
 set_target_properties(
         TestRoomMob PROPERTIES
-        CXX_STANDARD 17
+        CXX_STANDARD 20
         CXX_STANDARD_REQUIRED ON
         CXX_EXTENSIONS OFF
         COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -287,7 +313,7 @@ add_dependencies(TestRoomMobs mm_global)
 target_link_libraries(TestRoomMobs mm_global Qt6::Test Qt6::Gui Qt6::Widgets coverage_config)
 set_target_properties(
         TestRoomMobs PROPERTIES
-        CXX_STANDARD 17
+        CXX_STANDARD 20
         CXX_STANDARD_REQUIRED ON
         CXX_EXTENSIONS OFF
         COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -309,7 +335,7 @@ add_dependencies(TestRoomManager mm_test mm_global)
 target_link_libraries(TestRoomManager mm_test mm_global Qt6::Test Qt6::Gui Qt6::Widgets coverage_config)
 set_target_properties(
         TestRoomManager PROPERTIES
-        CXX_STANDARD 17
+        CXX_STANDARD 20
         CXX_STANDARD_REQUIRED ON
         CXX_EXTENSIONS OFF
         COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -329,7 +355,7 @@ add_dependencies(TestHotkeyManager mm_test mm_global mm_map)
 target_link_libraries(TestHotkeyManager mm_map mm_test mm_global Qt6::Test Qt6::Network coverage_config)
 set_target_properties(
         TestHotkeyManager PROPERTIES
-        CXX_STANDARD 17
+        CXX_STANDARD 20
         CXX_STANDARD_REQUIRED ON
         CXX_EXTENSIONS OFF
         COMPILE_FLAGS "${WARNING_FLAGS}"

--- a/tests/TestGlobal.cpp
+++ b/tests/TestGlobal.cpp
@@ -8,6 +8,7 @@
 #include "../src/global/CaseUtils.h"
 #include "../src/global/CharUtils.h"
 #include "../src/global/Diff.h"
+#include "../src/global/EnumIndexedArray.h"
 #include "../src/global/Flags.h"
 #include "../src/global/HideQDebug.h"
 #include "../src/global/IndexedVectorWithDefault.h"
@@ -190,17 +191,17 @@ void TestGlobal::flagsTest()
 
 void TestGlobal::hideQDebugTest()
 {
-    static constexpr auto onlyDebug = []() {
+    static constexpr auto onlyDebug = std::invoke([]() constexpr -> mmqt::HideQDebugOptions {
         mmqt::HideQDebugOptions tmp;
         tmp.hideInfo = false;
         return tmp;
-    }();
+    });
 
-    static constexpr auto onlyInfo = []() {
+    static constexpr auto onlyInfo = std::invoke([]() constexpr -> mmqt::HideQDebugOptions {
         mmqt::HideQDebugOptions tmp;
         tmp.hideDebug = false;
         return tmp;
-    }();
+    });
 
     const QString expected = "1{DIW}\n2{DW}\n3{DIW}\n4{IW}\n5{DIW}\n"
                              "---\n"

--- a/tests/TestGroup.cpp
+++ b/tests/TestGroup.cpp
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+#include "TestGroup.h"
+
+#include "../src/group/enums.h"
+
+#include <QDebug>
+#include <QtTest/QtTest>
+
+TestGroup::TestGroup() = default;
+TestGroup::~TestGroup() = default;
+
+void TestGroup::enumsTest()
+{
+    test::test_group_enums();
+}
+
+QTEST_MAIN(TestGroup)

--- a/tests/TestGroup.h
+++ b/tests/TestGroup.h
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+#pragma once
+
+#include "../src/global/macros.h"
+
+#include <QObject>
+
+class NODISCARD_QOBJECT TestGroup final : public QObject
+{
+    Q_OBJECT
+
+public:
+    TestGroup();
+    ~TestGroup() final;
+
+private Q_SLOTS:
+    static void enumsTest();
+};

--- a/tests/testadventure.cpp
+++ b/tests/testadventure.cpp
@@ -178,6 +178,8 @@ void testParser(T &parser, const std::vector<TestLine> &testLines)
 }
 
 template<auto parseFn>
+    requires(
+        std::is_invocable_r_v<LineParserResult, decltype(parseFn), const QString &, const QString &>)
 struct NODISCARD OneLineMemoryParser final
 {
 private:
@@ -186,11 +188,7 @@ private:
 public:
     NODISCARD LineParserResult parse(const QString &line)
     {
-        using Callback = decltype(parseFn);
-        static_assert(
-            std::is_invocable_r_v<LineParserResult, Callback, const QString &, const QString &>);
         auto result = parseFn(m_prev, line);
-        static_assert(std::is_same_v<decltype(result), LineParserResult>);
         m_prev = line;
         return result;
     }

--- a/tests/testclock.cpp
+++ b/tests/testclock.cpp
@@ -6,11 +6,47 @@
 #include "../src/clock/mumeclock.h"
 #include "../src/configuration/configuration.h"
 #include "../src/global/HideQDebug.h"
+#include "../src/global/enums.h"
 #include "../src/observer/gameobserver.h"
 #include "../src/proxy/GmcpMessage.h"
 
 #include <QDebug>
 #include <QtTest/QtTest>
+
+namespace test_concepts {
+template<typename E>
+concept IsEnum_Int8 = concepts::IsEnum<E> and std::is_same_v<int8_t, std::underlying_type_t<E>>;
+
+template<typename E>
+concept IsEnum_Int8_with_Invalid = IsEnum_Int8<E> and enums::to_underlying(E::Invalid) == -1;
+
+template<typename E>
+concept IsMonthEnum = IsEnum_Int8_with_Invalid<E>
+                      and (std::is_same_v<E, MumeClock::WestronMonthNamesEnum>
+                           or std::is_same_v<E, MumeClock::SindarinMonthNamesEnum>);
+
+template<typename E>
+concept IsWeekdayEnum = IsEnum_Int8_with_Invalid<E>
+                        and (std::is_same_v<E, MumeClock::WestronWeekDayNamesEnum>
+                             or std::is_same_v<E, MumeClock::SindarinWeekDayNamesEnum>);
+} // namespace test_concepts
+
+namespace {
+template<test_concepts::IsMonthEnum E>
+void test_month(const QString &name, const E e)
+{
+    const auto x = enums::to_underlying(e);
+    Q_ASSERT(x >= 0);
+    QCOMPARE(MumeClock::getMumeMonth(name), x);
+}
+template<test_concepts::IsWeekdayEnum E>
+void test_weekday(const QString &name, const E e)
+{
+    const auto x = enums::to_underlying(e);
+    Q_ASSERT(x >= 0);
+    QCOMPARE(MumeClock::getMumeWeekday(name), x);
+}
+} // namespace
 
 TestClock::TestClock()
 {
@@ -120,42 +156,29 @@ void TestClock::parseMumeTimeTest()
 void TestClock::getMumeMonthTest()
 {
     {
-        using E = MumeClock::WestronMonthNamesEnum;
-        static_assert(std::is_same_v<int8_t, std::underlying_type_t<E>>);
-
-#define X_CASE(x) \
-    static_assert(static_cast<int8_t>(E::x) >= 0); \
-    QCOMPARE(MumeClock::getMumeMonth(#x), static_cast<int8_t>(E::x));
+        using enum MumeClock::WestronMonthNamesEnum;
+#define X_CASE(x) test_month(#x, (x));
         XFOREACH_WestronMonthNamesEnum(X_CASE)
 #undef X_CASE
     }
 
     {
-        using E = MumeClock::SindarinMonthNamesEnum;
-        static_assert(std::is_same_v<int8_t, std::underlying_type_t<E>>);
-#define X_CASE(x) \
-    static_assert(static_cast<int8_t>(E::x) >= 0); \
-    QCOMPARE(MumeClock::getMumeMonth(#x), static_cast<int8_t>(E::x));
+        using enum MumeClock::SindarinMonthNamesEnum;
+#define X_CASE(x) test_month(#x, (x));
         XFOREACH_SindarinMonthNamesEnum(X_CASE)
 #undef X_CASE
     }
 
     {
-        using E = MumeClock::WestronWeekDayNamesEnum;
-        static_assert(std::is_same_v<int8_t, std::underlying_type_t<E>>);
-#define X_CASE(x) \
-    static_assert(static_cast<int8_t>(E::x) >= 0); \
-    QCOMPARE(MumeClock::getMumeWeekday(#x), static_cast<int8_t>(E::x));
+        using enum MumeClock::WestronWeekDayNamesEnum;
+#define X_CASE(x) test_weekday(#x, (x));
         XFOREACH_WestronWeekDayNamesEnum(X_CASE)
 #undef X_CASE
     }
 
     {
-        using E = MumeClock::SindarinWeekDayNamesEnum;
-        static_assert(std::is_same_v<int8_t, std::underlying_type_t<E>>);
-#define X_CASE(x) \
-    static_assert(static_cast<int8_t>(E::x) >= 0); \
-    QCOMPARE(MumeClock::getMumeWeekday(#x), static_cast<int8_t>(E::x));
+        using enum MumeClock::SindarinWeekDayNamesEnum;
+#define X_CASE(x) test_weekday(#x, (x));
         XFOREACH_SindarinWeekDayNamesEnum(X_CASE)
 #undef X_CASE
     }

--- a/tests/testexpandoracommon.cpp
+++ b/tests/testexpandoracommon.cpp
@@ -109,14 +109,14 @@ void TestExpandoraCommon::roomCompareTest_data()
         builder.setTerrainType(terrain);
         builder.setLightType(lit);
         auto &eList = builder.exits;
-        eList[ExitDirEnum::NORTH].setExitFlags(
-            ExitFlags{ExitFlagEnum::DOOR | ExitFlagEnum::EXIT | ExitFlagEnum::ROAD});
+        eList[ExitDirEnum::NORTH].setExitFlags(ExitFlagEnum::DOOR | ExitFlagEnum::EXIT
+                                               | ExitFlagEnum::ROAD);
         eList[ExitDirEnum::SOUTH].setExitFlags(ExitFlags{ExitFlagEnum::EXIT});
-        eList[ExitDirEnum::EAST].setExitFlags(ExitFlags{ExitFlagEnum::CLIMB | ExitFlagEnum::EXIT});
-        eList[ExitDirEnum::WEST].setExitFlags(ExitFlags{ExitFlagEnum::DOOR | ExitFlagEnum::EXIT});
+        eList[ExitDirEnum::EAST].setExitFlags(ExitFlagEnum::CLIMB | ExitFlagEnum::EXIT);
+        eList[ExitDirEnum::WEST].setExitFlags(ExitFlagEnum::DOOR | ExitFlagEnum::EXIT);
         eList[ExitDirEnum::WEST].setDoorFlags(DoorFlags{DoorFlagEnum::HIDDEN});
-        eList[ExitDirEnum::DOWN].setExitFlags(
-            ExitFlags{ExitFlagEnum::CLIMB | ExitFlagEnum::DOOR | ExitFlagEnum::EXIT});
+        eList[ExitDirEnum::DOWN].setExitFlags(ExitFlagEnum::CLIMB | ExitFlagEnum::DOOR
+                                              | ExitFlagEnum::EXIT);
 
         // NOTE: We have to add an outgoing exit here because the map now automatically
         // sets or clears the EXIT flag based on the presence of outgoing exits.
@@ -220,8 +220,8 @@ void TestExpandoraCommon::roomCompareTest_data()
     {
         const auto &room = perfect_room;
         auto exits = perfect_exits;
-        exits[ExitDirEnum::DOWN].setExitFlags(
-            ExitFlags{ExitFlagEnum::DOOR | ExitFlagEnum::EXIT}); // Remove climb down
+        exits[ExitDirEnum::DOWN].setExitFlags(ExitFlagEnum::DOOR
+                                              | ExitFlagEnum::EXIT); // Remove climb down
         const auto event = createParseEvent(CommandEnum::NORTH,
                                             name,
                                             desc,
@@ -236,8 +236,8 @@ void TestExpandoraCommon::roomCompareTest_data()
     {
         const auto &room = perfect_room;
         auto exits = perfect_exits;
-        exits[ExitDirEnum::NORTH].setExitFlags(
-            ExitFlags{ExitFlagEnum::DOOR | ExitFlagEnum::EXIT}); // Remove road north
+        exits[ExitDirEnum::NORTH].setExitFlags(ExitFlagEnum::DOOR
+                                               | ExitFlagEnum::EXIT); // Remove road north
         ConnectedRoomFlagsType connectedFlags;
         connectedFlags.setDirectSunlight(ExitDirEnum::NORTH, DirectSunlightEnum::SAW_DIRECT_SUN);
         connectedFlags.setDirectSunlight(ExitDirEnum::EAST, DirectSunlightEnum::SAW_DIRECT_SUN);
@@ -319,8 +319,8 @@ void TestExpandoraCommon::roomCompareTest_data()
             r.setExitFlags(ExitDirEnum::EAST, ExitFlags{ExitFlagEnum::EXIT});
         });
         auto exits = perfect_exits;
-        exits[ExitDirEnum::EAST].setExitFlags(
-            ExitFlags{ExitFlagEnum::ROAD | ExitFlagEnum::EXIT}); // Event has road e
+        exits[ExitDirEnum::EAST].setExitFlags(ExitFlagEnum::ROAD
+                                              | ExitFlagEnum::EXIT); // Event has road e
         const auto &east = room.getExit(ExitDirEnum::EAST);
         QVERIFY(east.exitIsExit());
         QVERIFY(!east.exitIsRoad()); // Room has no road e

--- a/tests/testexpandoracommon.h
+++ b/tests/testexpandoracommon.h
@@ -2,6 +2,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (C) 2019 The MMapper Authors
 
+#if 1
+// https://qt-project.atlassian.net/browse/QTBUG-31496
+#include <QtCore/qglobal.h>
+#endif
+
 #include "../src/map/RoomHandle.h"
 #include "../src/map/parseevent.h"
 #include "../src/map/room.h"


### PR DESCRIPTION
## Summary by Sourcery

Migrate the codebase and build configuration from C++17 to C++20 while introducing shared concepts and enum/flag utilities, modernizing helpers and containers around them, and updating tests and documentation to align with the new language standard.

New Features:
- Introduce reusable enum utilities and concepts for working with underlying values, counts, and flag bit operations.
- Add generic View and EnumIndexedArray helpers plus associated concepts for safer span-like and enum-indexed access.

Bug Fixes:
- Ensure various deref overloads and bitmask utilities are constrained correctly to prevent invalid usage and runtime errors.
- Fix emoji hex encoding and UTF-8 handling edge cases, including 7-bit detection and numeric conversions.

Enhancements:
- Refactor enums, flags, and utility code to use C++20 concepts, spans, and modern constexpr facilities across the codebase.
- Simplify and strengthen generic helpers (casting, iteration, hashing, random selection, etc.) with tighter type constraints and clearer semantics.
- Replace ad‑hoc enum bitwise operators and counting logic with centralized macros and type-safe Flags support.
- Improve text and ANSI handling with UTF‑8 width calculation, safer foreachAnsi callbacks, and richer Value/Vector accessors.
- Clean up CRTP helpers, room/stat reporting, and map/parse utilities to better leverage new concepts and flag abstractions.

Build:
- Raise project and test targets to C++20, adjust compiler flags for Clang/MSVC, and bump macOS deployment target.
- Extend build sources with new global concepts, View, and EnumIndexedArray implementation files.

Documentation:
- Update build documentation to require a C++20-compatible compiler instead of C++17.

Tests:
- Add new TestGroup target and group enum tests, and expand existing tests to cover new enum utilities, concepts usage, and clock/month/week mappings.

Chores:
- Remove legacy C++17 workarounds (manual source_location, remove_cvref_t, generic enum access patterns) now superseded by C++20/23 library features.