### PR TITLE
fix GMCP error caused by forwarding External.Discord.Get to MUME

### DIFF
--- a/src/proxy/GmcpMessage.h
+++ b/src/proxy/GmcpMessage.h
@@ -31,10 +31,7 @@ class ParseEvent;
     X(EVENT_MOVED, EventMoved, "event.moved", "Event.Moved") \
     X(EVENT_MOON, EventMoon, "event.moon", "Event.Moon") \
     X(EVENT_SUN, EventSun, "event.sun", "Event.Sun") \
-    X(EXTERNAL_DISCORD_GET, \
-      ExternalDiscordGet, \
-      "external.discord.get", \
-      "External.Discord.Get") \
+    X(EXTERNAL_DISCORD_GET, ExternalDiscordGet, "external.discord.get", "External.Discord.Get") \
     X(EXTERNAL_DISCORD_HELLO, \
       ExternalDiscordHello, \
       "external.discord.hello", \

--- a/src/proxy/GmcpMessage.h
+++ b/src/proxy/GmcpMessage.h
@@ -31,6 +31,10 @@ class ParseEvent;
     X(EVENT_MOVED, EventMoved, "event.moved", "Event.Moved") \
     X(EVENT_MOON, EventMoon, "event.moon", "Event.Moon") \
     X(EVENT_SUN, EventSun, "event.sun", "Event.Sun") \
+    X(EXTERNAL_DISCORD_GET, \
+      ExternalDiscordGet, \
+      "external.discord.get", \
+      "External.Discord.Get") \
     X(EXTERNAL_DISCORD_HELLO, \
       ExternalDiscordHello, \
       "external.discord.hello", \
@@ -66,7 +70,7 @@ enum class NODISCARD GmcpMessageTypeEnum {
 #define X_COUNT(...) +1
 static constexpr const size_t NUM_GMCP_MESSAGES = XFOREACH_GMCP_MESSAGE_TYPE(X_COUNT);
 #undef X_COUNT
-static_assert(NUM_GMCP_MESSAGES == 30);
+static_assert(NUM_GMCP_MESSAGES == 31);
 DEFINE_ENUM_COUNT(GmcpMessageTypeEnum, NUM_GMCP_MESSAGES)
 
 namespace tags {

--- a/src/proxy/UserTelnet.cpp
+++ b/src/proxy/UserTelnet.cpp
@@ -164,6 +164,11 @@ void UserTelnet::virt_receiveGmcpMessage(const GmcpMessage &msg)
         return;
     }
 
+    // Eat External.Discord.Get as MUME does not support it and would return a MUME.Client.Error
+    if (msg.isExternalDiscordGet()) {
+        return;
+    }
+
     const bool requiresRewrite = msg.getJson()
                                  && (msg.isCoreSupportsAdd() || msg.isCoreSupportsSet()
                                      || msg.isCoreSupportsRemove())

--- a/tests/TestProxy.cpp
+++ b/tests/TestProxy.cpp
@@ -34,6 +34,12 @@ void TestProxy::gmcpMessageDeserializeTest()
     GmcpMessage gmcp3 = GmcpMessage::fromRawBytes(R"(External.Discord.Hello)");
     QCOMPARE(gmcp3.getName().toQByteArray(), QByteArray("External.Discord.Hello"));
     QVERIFY(!gmcp3.getJson());
+    QVERIFY(gmcp3.isExternalDiscordHello());
+
+    GmcpMessage gmcp4 = GmcpMessage::fromRawBytes(R"(External.Discord.Get)");
+    QCOMPARE(gmcp4.getName().toQByteArray(), QByteArray("External.Discord.Get"));
+    QVERIFY(!gmcp4.getJson());
+    QVERIFY(gmcp4.isExternalDiscordGet());
 }
 
 void TestProxy::gmcpMessageSerializeTest()


### PR DESCRIPTION
Handle External.Discord.Get messages locally to avoid MUME GMCP errors.

Bug Fixes:
- Prevent unsupported External.Discord.Get messages from being forwarded to MUME and triggering GMCP protocol errors.

Enhancements:
- Register External.Discord.Get as a recognized GMCP message type.

Tests:
- Add coverage for deserializing and identifying External.Discord.Get messages.

## Summary by Sourcery

Prevent External.Discord.Get messages from reaching MUME and causing GMCP errors.

Bug Fixes:
- Handle External.Discord.Get messages locally instead of forwarding them to MUME, preventing GMCP protocol errors.

Enhancements:
- Recognize External.Discord.Get as a supported GMCP message type.

Tests:
- Add coverage for deserializing and identifying External.Discord.Get messages.